### PR TITLE
Fix Go module path and improve installer repo detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ sudo mv atv-installer /usr/local/bin/   # macOS/Linux
 go install github.com/All-The-Vibes/ATV-StarterKit@latest
 ```
 
+This installs into your Go bin directory (`GOBIN`, or `%USERPROFILE%\\go\\bin` on Windows by default). Because the CLI entrypoint lives at the repo root, the installed executable is named after the package path, not `atv-installer`.
+
 ## ⚡ Quick Start
 
 ### One-Click Mode (Default)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,16 +1,19 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/github/atv-installer/pkg/detect"
-	"github.com/github/atv-installer/pkg/output"
-	"github.com/github/atv-installer/pkg/scaffold"
-	"github.com/github/atv-installer/pkg/tui"
+	"github.com/All-The-Vibes/ATV-StarterKit/pkg/detect"
+	"github.com/All-The-Vibes/ATV-StarterKit/pkg/output"
+	"github.com/All-The-Vibes/ATV-StarterKit/pkg/scaffold"
+	"github.com/All-The-Vibes/ATV-StarterKit/pkg/tui"
 	"github.com/spf13/cobra"
 )
+
+const installerModulePath = "module github.com/All-The-Vibes/ATV-StarterKit"
 
 var guided bool
 
@@ -65,12 +68,25 @@ func runInit(cmd *cobra.Command, args []string) error {
 	printer.PrintResults(results)
 	printer.PrintNextSteps(env.Stack)
 
-	// Update plan checkboxes if running in-repo
-	planPath := filepath.Join(targetDir, "docs", "plans")
-	if _, err := os.Stat(planPath); err == nil {
-		// Plan directory exists — this is the atv-installer repo itself
+	// Update plan checkboxes only when running inside the installer repository.
+	if isInstallerRepo(targetDir) {
 		printer.Info("Plan directory detected. Update plan checkboxes manually.")
 	}
 
 	return nil
+}
+
+func isInstallerRepo(dir string) bool {
+	goModPath := filepath.Join(dir, "go.mod")
+	goMod, err := os.ReadFile(goModPath)
+	if err != nil {
+		return false
+	}
+
+	templatesPath := filepath.Join(dir, "pkg", "scaffold", "templates")
+	if info, err := os.Stat(templatesPath); err != nil || !info.IsDir() {
+		return false
+	}
+
+	return bytes.Contains(goMod, []byte(installerModulePath))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/github/atv-installer
+module github.com/All-The-Vibes/ATV-StarterKit
 
 go 1.26.1
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/github/atv-installer/cmd"
+import "github.com/All-The-Vibes/ATV-StarterKit/cmd"
 
 func main() {
 	cmd.Execute()

--- a/pkg/output/printer.go
+++ b/pkg/output/printer.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/github/atv-installer/pkg/detect"
-	"github.com/github/atv-installer/pkg/scaffold"
+	"github.com/All-The-Vibes/ATV-StarterKit/pkg/detect"
+	"github.com/All-The-Vibes/ATV-StarterKit/pkg/scaffold"
 )
 
 //go:embed banner.txt

--- a/pkg/scaffold/catalog.go
+++ b/pkg/scaffold/catalog.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/github/atv-installer/pkg/detect"
+	"github.com/All-The-Vibes/ATV-StarterKit/pkg/detect"
 )
 
 //go:embed all:templates

--- a/pkg/tui/wizard.go
+++ b/pkg/tui/wizard.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/huh"
-	"github.com/github/atv-installer/pkg/detect"
+	"github.com/All-The-Vibes/ATV-StarterKit/pkg/detect"
 )
 
 // WizardResult holds the user's selections from the guided wizard.


### PR DESCRIPTION


This pull request updates the project to use the new module path `github.com/All-The-Vibes/ATV-StarterKit` instead of the old `github.com/github/atv-installer`, and refines detection logic for when the CLI is running inside its own repository. It also clarifies installation instructions in the documentation.

**Module path and import updates:**

* Changed the Go module path in `go.mod` and updated all internal imports to use `github.com/All-The-Vibes/ATV-StarterKit` instead of the previous `github.com/github/atv-installer`.

**Repository detection improvements:**

* Refactored the logic in `cmd/init.go` to more robustly detect when the CLI is running inside its own repository by checking for both the module path and the presence of the templates directory. Extracted this logic into a new `isInstallerRepo` helper function.

**Documentation update:**

* Clarified in `README.md` that the installed executable is named after the package path, not `atv-installer`, due to the project structure.