### PR TITLE
fix: skip npm publish if version already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,5 +55,18 @@ jobs:
             echo "Version unchanged, skipping 'npm version'"
           fi
 
+      - name: Check if version already published
+        id: check-npm
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          PKG_NAME=$(node -p "require('./npm/package.json').name")
+          if npm view "${PKG_NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "✅ ${PKG_NAME}@${VERSION} already exists on npm — skipping publish."
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
+        if: steps.check-npm.outputs.already_published != 'true'
         run: cd npm && npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,11 +60,22 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           PKG_NAME=$(node -p "require('./npm/package.json').name")
-          if npm view "${PKG_NAME}@${VERSION}" version >/dev/null 2>&1; then
+
+          set +e
+          NPM_VIEW_OUTPUT=$(npm view "${PKG_NAME}@${VERSION}" version 2>&1)
+          NPM_VIEW_STATUS=$?
+          set -e
+
+          if [ "$NPM_VIEW_STATUS" -eq 0 ]; then
             echo "already_published=true" >> "$GITHUB_OUTPUT"
             echo "✅ ${PKG_NAME}@${VERSION} already exists on npm — skipping publish."
-          else
+          elif printf '%s\n' "$NPM_VIEW_OUTPUT" | grep -Eq 'E404|ETARGET'; then
             echo "already_published=false" >> "$GITHUB_OUTPUT"
+            echo "ℹ️ ${PKG_NAME}@${VERSION} was not found on npm — proceeding with publish."
+          else
+            echo "❌ Failed to determine whether ${PKG_NAME}@${VERSION} exists on npm." >&2
+            printf '%s\n' "$NPM_VIEW_OUTPUT" >&2
+            exit 1
           fi
 
       - name: Publish to npm


### PR DESCRIPTION
Adds a guard step to the Release workflow that checks npm before publishing. If the version is already published, the step exits cleanly instead of failing with a 403.

Fixes the failing v2.1.2 and v2.1.3 Release runs.