### PR TITLE
fix: harden Windows postinstall extraction with tar.exe + .NET fallbacks

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -151,12 +151,31 @@ function extractTarGz(archivePath, destDir) {
 
 /**
  * Extract a .zip archive to a destination directory.
+ *
+ * On Windows, prefer tar.exe (ships with Windows 10+ and handles .zip via
+ * libarchive). Fall back to PowerShell Expand-Archive, which can fail to
+ * autoload Microsoft.PowerShell.Archive in some environments. Final fallback:
+ * System.IO.Compression.ZipFile via powershell.
  */
 function extractZip(archivePath, destDir) {
-  // Use PowerShell on Windows for zip extraction
   if (os.platform() === "win32") {
+    try {
+      execSync(`tar -xf "${archivePath}" -C "${destDir}"`, { stdio: "pipe" });
+      return;
+    } catch (_) {
+      // continue to next strategy
+    }
+    try {
+      execSync(
+        `powershell -NoProfile -Command "Expand-Archive -Path '${archivePath}' -DestinationPath '${destDir}' -Force"`,
+        { stdio: "pipe" }
+      );
+      return;
+    } catch (_) {
+      // continue to next strategy
+    }
     execSync(
-      `powershell -Command "Expand-Archive -Path '${archivePath}' -DestinationPath '${destDir}' -Force"`,
+      `powershell -NoProfile -Command "Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('${archivePath}', '${destDir}')"`,
       { stdio: "pipe" }
     );
   } else {


### PR DESCRIPTION
## Summary

Hardens the Windows postinstall `extractZip` path in `npm/install.js` so global `npm i -g atv-installer` reliably extracts the release zip across Windows environments.

## Changes

- Try `tar.exe` first (ships with Windows 10+, uses libarchive, handles `.zip`).
- Fall back to `powershell -NoProfile Expand-Archive` (added `-NoProfile` to avoid user profile errors that can break module autoload).
- Final fallback to `System.IO.Compression.ZipFile.ExtractToDirectory` via PowerShell `Add-Type`, which works even when `Microsoft.PowerShell.Archive` fails to load.

## Why

Some Windows setups (locked-down profiles, old PS module cache, AV interference) cause `Expand-Archive` to fail during `npm i -g`, leaving the binary uninstalled. The layered fallbacks make the install resilient.

## Test plan

- `npm i -g atv-installer` on a clean Windows 10/11 box.
- Verified `atv --version` after install.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
