### PR TITLE
feat(skills): port /land and /takeoff to Copilot skills

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,11 @@ This project uses the ATV (Agentic Tool & Workflow) Starter Kit.
 - `/ce-compound` — Document solutions for future reference
 - `/lfg` — Full autonomous pipeline (plan → work → review)
 
+## Session Bookends
+
+- `/takeoff` — Prioritized backlog briefing to start a session
+- `/land` — Commit → push → PR → handoff to finish a session (never merges)
+
 ## Documentation Structure
 
 - `docs/plans/` — Implementation plans (living documents with checkboxes)

--- a/.github/skills/land/SKILL.md
+++ b/.github/skills/land/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: land
+description: Close out a session by committing, pushing, and opening a PR — then handing off. Use when the user says "land", "/land", "land the plane", "land plane", "land it", "let's land", "land this", "bring it in", "wrap it up", "land the plan", "time to land", "ok land", "go ahead and land", or any variation that signals they want to finish, close out, ship, or wrap up the current session's work. Executes the full checklist without asking. Never merges the PR — landing ≠ merging.
+---
+
+# Land the Plane
+
+The session completion counterpart to `/takeoff`. Where `/takeoff` *starts* work by surfacing the backlog, `/land` *finishes* work by running the full commit → push → PR → handoff checklist.
+
+## Trigger
+
+Any variation of: `land`, `/land`, `land the plane`, `land it`, `let's land`, `land this`, `bring it in`, `wrap it up`, `land the plan`, `land plane`, `time to land`, `ok land`, `go ahead and land`.
+
+When the user's message contains "land" in the context of finishing/wrapping up work, invoke this protocol. When in doubt, invoke it.
+
+## Core principle
+
+"Landing" means **commit, push, and create a PR** — it does **not** mean merge. A PR is how humans review agent work; no PR means no review means no trust. **Never merge unless the user explicitly says "merge this PR".**
+
+Work is **not complete until `git push` succeeds**. If push fails, resolve and retry until it works. Do not stop at "ready to push when you are" — you must push.
+
+## Execution
+
+Run the checklist **in order, completely, without asking**. Each step is non-negotiable.
+
+### Step 1: File remaining work
+
+Review what was worked on this session. Capture anything that's unfinished, deferred, or follow-up so it doesn't vanish when the session closes.
+
+- If the repo has Backlog.md tooling (`backlog/` directory at repo root and the `backlog` CLI available), create tasks for unfinished/follow-up work:
+  ```bash
+  if command -v backlog >/dev/null 2>&1 && [ -d backlog ]; then
+    backlog task create "<title>" --description "<context>"
+  fi
+  ```
+- Otherwise, gather remaining work into a short handoff list and surface it at Step 9.
+
+Skip silently if nothing remains.
+
+### Step 2: Run quality gates (only if code changed this session)
+
+Detect the stack from the repo root and run the matching build + test/lint commands. For ATV-starterkit specifically, this means Go at the root plus an optional Node subproject under `npm/`.
+
+```bash
+# Go (repo root) — run when go.mod is present. Do NOT suppress failure.
+if [ -f go.mod ]; then
+  go build ./... && go vet ./...
+fi
+
+# Node subproject — run when npm/ files have changed (staged, unstaged, or untracked).
+# Quality gates run BEFORE commit, so we cannot rely on HEAD~1.
+if [ -f npm/package.json ]; then
+  if { git diff --name-only;
+       git diff --name-only --cached;
+       git ls-files --others --exclude-standard; } | grep -q '^npm/'; then
+    (cd npm && npm run build)
+  fi
+fi
+
+# Generic fallbacks (portable to other repos)
+# pnpm:    [ -f pnpm-workspace.yaml ] && pnpm build && pnpm lint
+# npm:     [ -f package.json ] && npm run build && npm run lint
+# Python:  [ -f pyproject.toml ] && pytest && ruff check .
+# Rust:    [ -f Cargo.toml ] && cargo build && cargo test
+```
+
+If any gate fails (non-zero exit), **halt the routine, fix the failure, and re-run from Step 2 before proceeding to Step 4**. Do not append `|| true` to swallow failures — a broken build does not ship, and a swallowed failure would falsely emit the success banner at Step 10.
+
+If no code changed (docs-only, config-only, planning-only sessions), skip quality gates and note that in the handoff.
+
+### Step 3: Update task status (if the repo has task tracking)
+
+- Mark completed tasks as `Done`.
+- Update in-progress tasks with short implementation notes so the next session has context.
+- If the repo uses `backlog_task_id` in plan frontmatter, ensure status reflects reality.
+
+### Step 4: Commit all changes
+
+Stage specific files — **never** `git add -A` or `git add .`. That risks pulling in `.env`, credentials, or large binaries.
+
+```bash
+git status                         # see what's outstanding
+git add <specific-files>           # stage deliberately
+git commit -m "<type>: <summary>"  # conventional commits (feat, fix, refactor, docs, test, chore, perf, ci)
+```
+
+If there are no changes, skip. Do not create empty commits.
+
+### Step 5: PUSH TO REMOTE (MANDATORY)
+
+Work is not complete until this step succeeds.
+
+```bash
+branch=$(git branch --show-current)
+# only rebase if this branch already tracks a remote — new branches have no upstream yet
+if git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
+  git pull --rebase origin "$branch"
+fi
+git push -u origin "$branch"
+git status                         # must show "up to date with origin"
+```
+
+If push fails (conflicts, hook rejection, branch protection), **resolve and retry** until it works. Do not hand off with unpushed commits.
+
+### Step 6: Create or update the PR
+
+A PR is the review artifact. Agent work without a PR has no trust surface.
+
+Check first whether a PR already exists on this branch, capturing the exit code so "no PR yet" is handled as normal workflow state rather than an error:
+
+```bash
+if PR_VIEW_OUTPUT=$(gh pr view --json url,title,state 2>&1); then
+  PR_VIEW_EXIT=0
+else
+  PR_VIEW_EXIT=$?
+fi
+printf '%s\n__GH_PR_VIEW_EXIT__=%s\n' "$PR_VIEW_OUTPUT" "$PR_VIEW_EXIT"
+```
+
+If no PR exists, create one. **For PR body construction, follow the conventions in [`git-commit-push-pr`](../git-commit-push-pr/SKILL.md)** — value-first, intent-forward, scaled to the complexity of the change. Do not re-implement that logic here.
+
+Resolve the default branch dynamically — it's not always `main`:
+
+```bash
+default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+if [ -z "$default_branch" ]; then
+  default_branch=$(git rev-parse --verify origin/main >/dev/null 2>&1 && echo "main" || echo "master")
+fi
+git log "origin/$default_branch..HEAD" --oneline
+git diff "origin/$default_branch...HEAD" --stat
+```
+
+Summarize the **full branch** diff (not just the latest commit) when authoring the body. Include a test plan checklist. Share the PR URL at handoff.
+
+**Never merge the PR** unless the user explicitly says "merge this PR". Landing ≠ merging.
+
+### Step 7: Clean up
+
+```bash
+git stash list                     # check for session-era stashes
+# drop only stashes from this session; leave older ones alone
+```
+
+**If working inside a git worktree:** leave the worktree in place while the PR is open. Remove it manually with `git worktree remove <path>` only after the PR is merged or abandoned. Do not attempt to tear down worktrees from this skill.
+
+### Step 8: Verify
+
+Confirm a clean state:
+
+```bash
+git status                                          # working tree clean (or only untracked)
+git log "origin/$(git branch --show-current)..HEAD" # must be empty — all pushed
+```
+
+If either check fails, loop back and fix. Do not hand off a dirty or unpushed tree.
+
+### Step 9: Hand off
+
+Provide a concise summary for the next session:
+
+- **Accomplished** — what shipped (with task IDs if applicable)
+- **Next up** — what's queued (with task IDs if applicable)
+- **Blockers / gotchas** — anything that tripped you up or is waiting on a decision
+- **Branch** — current branch name
+- **PR** — PR URL from Step 6
+
+Keep it scannable. The next session (human or agent) should be able to take off from this handoff without re-reading the whole transcript.
+
+### Step 10: Final banner
+
+After the handoff summary, emit a single final line:
+
+```
+🛬 PLANE LANDED — NICE WORK
+```
+
+This **must** be the last line of output — no content after it, no code fence, no trailing heading. The banner is a **completion** marker, not a "we tried" marker: emit it only when the routine completes successfully (including the clean-tree / nothing-to-commit path where Step 5 is skipped because there's nothing to push). If `git push` never succeeds, a quality gate fails and halts the routine, or the PR step errors out and cannot be resolved, do **not** emit the banner.
+
+## Critical rules
+
+These are non-negotiable when `/land` is invoked:
+
+- **NEVER stop before pushing.** Unpushed work is stranded work.
+- **NEVER say "ready to push when you are."** You push. That is the job.
+- **NEVER skip quality gates.** Broken code does not ship.
+- **NEVER merge the PR** unless the user explicitly says "merge this PR".
+- **NEVER use `git add -A` or `git add .`.** Stage specific files.
+- **NEVER bypass hooks** (`--no-verify`, `--no-gpg-sign`) unless the user explicitly asks. If a hook fails, investigate and fix the root cause.
+- If push fails, **resolve and retry** until it succeeds.
+- **Always end successful landing output with the `🛬 PLANE LANDED — NICE WORK` banner line.** Do not emit the banner on failure paths (push failed, quality gate halted the routine, PR step errored out with no resolution).
+
+## Project-specific considerations
+
+Some repos have local conventions layered on top of this protocol — read `.github/copilot-instructions.md` and `AGENTS.md` at the repo root for project-specific rules (e.g., branch protection, PR comment workflows, backlog linkage requirements). Project rules override these defaults where they conflict.

--- a/.github/skills/land/SKILL.md
+++ b/.github/skills/land/SKILL.md
@@ -42,13 +42,17 @@ Skip silently if nothing remains.
 Detect the stack from the repo root and run the matching build + test/lint commands. For ATV-starterkit specifically, this means Go at the root plus an optional Node subproject under `npm/`.
 
 ```bash
-# Go (repo root) — run when go.mod is present. Do NOT suppress failure.
+# Go (repo root) — run when go.mod is present AND Go files changed this session.
+# Quality gates run BEFORE commit, so we cannot rely on HEAD~1; check working tree.
 if [ -f go.mod ]; then
-  go build ./... && go vet ./...
+  if { git diff --name-only;
+       git diff --name-only --cached;
+       git ls-files --others --exclude-standard; } | grep -qE '\.go$|^go\.(mod|sum)$'; then
+    go build ./... && go vet ./...
+  fi
 fi
 
 # Node subproject — run when npm/ files have changed (staged, unstaged, or untracked).
-# Quality gates run BEFORE commit, so we cannot rely on HEAD~1.
 if [ -f npm/package.json ]; then
   if { git diff --name-only;
        git diff --name-only --cached;
@@ -92,6 +96,10 @@ Work is not complete until this step succeeds.
 
 ```bash
 branch=$(git branch --show-current)
+if [ -z "$branch" ]; then
+  echo "ERROR: detached HEAD — refusing to push. Check out a branch first." >&2
+  exit 1
+fi
 # only rebase if this branch already tracks a remote — new branches have no upstream yet
 if git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
   git pull --rebase origin "$branch"
@@ -149,7 +157,12 @@ Confirm a clean state:
 
 ```bash
 git status                                          # working tree clean (or only untracked)
-git log "origin/$(git branch --show-current)..HEAD" # must be empty — all pushed
+branch=$(git branch --show-current)
+if [ -n "$branch" ] && git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
+  git log "origin/$branch..HEAD"                    # must be empty — all pushed
+else
+  echo "WARNING: no upstream tracking ref for '$branch' — cannot verify pushed state"
+fi
 ```
 
 If either check fails, loop back and fix. Do not hand off a dirty or unpushed tree.
@@ -191,4 +204,4 @@ These are non-negotiable when `/land` is invoked:
 
 ## Project-specific considerations
 
-Some repos have local conventions layered on top of this protocol — read `.github/copilot-instructions.md` and `AGENTS.md` at the repo root for project-specific rules (e.g., branch protection, PR comment workflows, backlog linkage requirements). Project rules override these defaults where they conflict.
+Some repos have local conventions layered on top of this protocol — read `.github/copilot-instructions.md` (and any `AGENTS.md` or `CLAUDE.md` at the repo root, when present) for project-specific rules (e.g., branch protection, PR comment workflows, backlog linkage requirements). Project rules override these defaults where they conflict.

--- a/.github/skills/takeoff/SKILL.md
+++ b/.github/skills/takeoff/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: takeoff
+description: Start a session with a prioritized backlog briefing. Use when the user says "takeoff", "take off", "/takeoff", "starting a new session", "what should I work on", "kickoff", "what's next", or wants a prioritized view of the backlog at the start of work. Surfaces the top-priority actionable tasks as bullet groups with status, dependencies, and blockers pulled from Backlog.md when available, or falls back to active plans under `docs/plans/`.
+---
+
+# Take Off
+
+The session kickoff counterpart to `/land`. Where `/land` closes out work, `/takeoff` *starts* work by giving a crisp, prioritized picture of what to pick up.
+
+## Trigger
+
+Any variation of:
+- `/takeoff`, `takeoff`, `take off`, `let's take off`, `time to take off`, `ready to take off`
+- `what should I work on`, `what's next`, `kickoff`, `start a new session`, `show me the backlog`
+
+When in doubt and the user is at the *start* of work (not finishing), invoke this protocol.
+
+## What this skill produces
+
+A short, scannable briefing with four sections:
+
+1. **Top Priority** — the N highest-priority actionable tasks
+2. **Blocked / Dependent** — tasks that exist but cannot be started
+3. **In Progress** — tasks already underway (not to be double-claimed)
+4. **Recommendation** — one sentence: "Start with `X` because …"
+
+Keep it terse. The user wants to pick a task and go, not read a report.
+
+## Execution
+
+### Step 1: Verify backlog tooling is present
+
+Check that the current repo has a `backlog/` directory. If not, fall back to reading plan files in `docs/plans/` and summarizing those instead (Step 2b).
+
+```bash
+test -d backlog && echo "backlog present" || echo "no backlog — will fall back to docs/plans/"
+```
+
+### Step 2: Pull the backlog (preferred path)
+
+Shell out to the backlog CLI when it's available and `backlog/` exists:
+
+```bash
+backlog task list --plain --sort priority
+```
+
+Also pull sequence info to detect dependencies:
+
+```bash
+backlog sequence list --plain
+```
+
+Parse both. Extract: id, title, priority, status, assignee, dependencies, blocked-by.
+
+If the `backlog` CLI is absent but the `backlog/` directory is present, read the task markdown files directly and parse frontmatter for the same fields.
+
+### Step 2b: Fallback — read `docs/plans/`
+
+When no `backlog/` directory exists (the default in ATV-starterkit today), scan `docs/plans/` for plans with `status: active` in the YAML frontmatter:
+
+```bash
+for plan in docs/plans/*.md; do
+  [ -f "$plan" ] || continue
+  # Only consider plans whose frontmatter has `status: active`.
+  # awk pulls the first YAML block; grep checks for the active marker.
+  if awk '/^---$/{c++; next} c==1' "$plan" | grep -qE '^status:[[:space:]]*active$'; then
+    title=$(awk '/^---$/{c++; next} c==1' "$plan" | grep -E '^title:' | sed 's/^title:[[:space:]]*//; s/^"//; s/"$//')
+    echo "- $(basename "$plan") — ${title:-(untitled)}"
+  fi
+done
+```
+
+Skip plans with `status: done`, `status: archived`, or missing frontmatter. Mention explicitly in the output that this is a `docs/plans/` fallback because the repo has no `backlog/` directory. If the fallback also yields zero active plans, drop into the empty-list edge case (congratulate + suggest `/ce-ideate` or `/ce-plan`).
+
+### Step 3: Classify each task
+
+For every task returned, bucket it:
+
+| Bucket | Criteria |
+|---|---|
+| **Actionable** | status = "To Do", no unresolved dependencies, not assigned to someone else |
+| **Blocked** | status = "To Do" but has a `blocked_by` / unresolved dependency |
+| **In Progress** | status = "In Progress" or "Doing" |
+| **Done** | status = "Done" — skip, don't surface |
+
+If a task has a dependency, note *which* task blocks it by ID.
+
+### Step 4: Render as bulleted groups
+
+Sort actionable tasks by priority (HIGH → MEDIUM → LOW), then by ID. By default show the top 5 in the top-priority group. If the user passed `--top N`, honor that. If they passed `--mine`, filter to their assignee.
+
+**Format: flat bullet lists grouped by category, with an emoji header on each secondary group.** Tables wrap poorly in narrow terminals. A plain `- ID — Title` bullet reads cleanly at any width.
+
+Use `—` (em-dash) as the separator between ID and title. For tasks with dependencies, append `(blocked by X, Y)` or `(depends on X)` at the end of the line.
+
+Group headers use these emojis:
+- 🛫 Top-priority actionable group (the main recommendation pool)
+- 🔵 Epic subtasks, or clusters of related follow-ups
+- 🟢 In Progress
+- ⚪ LOW / Housekeeping
+- 🔴 Blocked / Dependent (only when all blockers are hard blockers)
+
+Emit the output directly as markdown in your final response — no code fences, no custom rendering scripts.
+
+**Shape:**
+
+```markdown
+## 🛫 Takeoff — <repo-name>
+
+### Top Priority (actionable)
+
+- AGENTSAPI-1 — Orchestrator admin-agents client + manifest types
+- AGENTSAPI-2 — Admin Agents list page + row actions (depends on AGENTSAPI-1)
+- NEBULA-42 — PR comment three-step enforcement hook
+
+🔵 DOCREVIEW epic subtasks (children of DOCREVIEW-1)
+
+- DOCREVIEW-1.1 — strip Recommendations strip from final chain message
+- DOCREVIEW-1.2 — generalize Review Document button via ChainConfig
+
+🟢 In Progress
+
+- AGENTSAPI-7 — something currently being worked on (@sam)
+
+⚪ LOW / Housekeeping
+
+- NEBULA-35 — Enforce backlog.md usage via MCP server and hooks
+
+### Recommendation
+Start with **AGENTSAPI-1**. It's the next unblocked HIGH-priority item and clears the path for 2 more.
+```
+
+**Formatting rules:**
+- One task per line. Do not wrap a task across multiple lines.
+- Group headers use H3 (`###`) for top-priority only; secondary groups use a bold-emoji line (e.g., `🔵 DOCREVIEW epic subtasks`), not an H-level heading.
+- Omit groups that have zero tasks. If In Progress is empty, skip the section.
+- Never emit a table. No pipes, no box-drawing characters.
+- **Escape any pipes inside task titles** with `\|` as a defensive measure. Do not truncate titles.
+
+### Step 5: Offer a next step
+
+End with a single question: "Want me to open the plan for `<ID>` and start `/ce-work` on it?" — do not auto-start. Takeoff is for orientation, not execution.
+
+### Step 6: Final banner
+
+After the recommendation question, emit a single final line:
+
+```
+✈️ TAKE OFF — NOW AT 30,000 FEET
+```
+
+This **must** be the last line of output — no content after it, no code fence, no trailing heading. It fires on every successful completion path, including the no-backlog fallback and the empty-task-list edge case. Do not emit the banner if the routine aborts before producing a briefing.
+
+## Formatting rules
+
+- **Bullets, not tables.** Tables break at narrow widths; bullets flow cleanly.
+- **Group with emoji headers.** 🛫 top-priority, 🔵 related clusters / epics, 🟢 in progress, ⚪ housekeeping, 🔴 hard-blocked.
+- **Never hide blockers.** Annotate dependencies inline with `(blocked by X)` — don't silently drop the task.
+- **Show dependency IDs explicitly.** `(blocked by AGENTSAPI-1)` is useful; `(has dependencies)` is not.
+- **Be honest about emptiness.** If there are zero actionable tasks, say so and suggest creating one or picking up in-progress work.
+- **Always end with the takeoff banner.** The final line of every successful invocation must be `✈️ TAKE OFF — NOW AT 30,000 FEET`.
+
+## Why this shape
+
+Takeoff's job is one concentrated briefing that answers *"what am I about to do and why"* in under 15 seconds of reading. Bullets + a one-line recommendation beat a paragraph because the user is scanning, not reading.
+
+Dependencies matter more than priority on their own — a HIGH task that's blocked is worse than a MEDIUM task that's ready. The recommendation should factor in unblocking power, not just raw priority.
+
+## Arguments
+
+- `--top N` — show N tasks in the top-priority group (default 5)
+- `--mine` — filter to tasks assigned to the current user (resolve via `git config user.email` or `git config user.name`)
+- `--all` — also include LOW priority actionable tasks
+- `--tag <tag>` — filter by a backlog tag/label
+
+If no arguments are given, use defaults.
+
+## Edge cases
+
+- **No `backlog/` directory** → fall back to `docs/plans/` summaries (Step 2b); tell the user.
+- **`backlog/` present but CLI missing** → parse task markdown files directly.
+- **`backlog` CLI returns non-zero** → report the error honestly, fall back to `docs/plans/`, still emit banner.
+- **Everything is blocked** → surface the root blockers and ask whether to create a task to unblock them.
+- **Task list is empty** → congratulate the user and suggest `/ce-ideate` or `/ce-plan` to generate new work.
+- **Tasks without priority set** → treat as MEDIUM.

--- a/.github/skills/takeoff/SKILL.md
+++ b/.github/skills/takeoff/SKILL.md
@@ -38,19 +38,16 @@ test -d backlog && echo "backlog present" || echo "no backlog — will fall back
 
 ### Step 2: Pull the backlog (preferred path)
 
-Shell out to the backlog CLI when it's available and `backlog/` exists:
+Shell out to the backlog CLI only when both the CLI and `backlog/` directory are present. Otherwise fall through to Step 2b:
 
 ```bash
-backlog task list --plain --sort priority
+if command -v backlog >/dev/null 2>&1 && [ -d backlog ]; then
+  backlog task list --plain --sort priority
+  backlog sequence list --plain
+fi
 ```
 
-Also pull sequence info to detect dependencies:
-
-```bash
-backlog sequence list --plain
-```
-
-Parse both. Extract: id, title, priority, status, assignee, dependencies, blocked-by.
+Parse both outputs. Extract: id, title, priority, status, assignee, dependencies, blocked-by.
 
 If the `backlog` CLI is absent but the `backlog/` directory is present, read the task markdown files directly and parse frontmatter for the same fields.
 
@@ -135,7 +132,7 @@ Start with **AGENTSAPI-1**. It's the next unblocked HIGH-priority item and clear
 - Group headers use H3 (`###`) for top-priority only; secondary groups use a bold-emoji line (e.g., `🔵 DOCREVIEW epic subtasks`), not an H-level heading.
 - Omit groups that have zero tasks. If In Progress is empty, skip the section.
 - Never emit a table. No pipes, no box-drawing characters.
-- **Escape any pipes inside task titles** with `\|` as a defensive measure. Do not truncate titles.
+- Do not truncate titles; rely on bullets to wrap cleanly at any width.
 
 ### Step 5: Offer a next step
 

--- a/docs/plans/2026-04-24-002-feat-ghcp-review-resolve-dual-subagent-and-resolve-plan.md
+++ b/docs/plans/2026-04-24-002-feat-ghcp-review-resolve-dual-subagent-and-resolve-plan.md
@@ -1,0 +1,503 @@
+---
+title: "feat: ghcp-review-resolve dual-subagent fallback and inline resolve"
+type: feat
+status: active
+date: 2026-04-24
+origin: docs/plans/2026-04-24-001-fix-ghcp-review-resolve-skill-robustness-plan.md
+---
+
+# feat: ghcp-review-resolve dual-subagent fallback and inline resolve
+
+**Target file:** `~/.claude/skills/ghcp-review-resolve/SKILL.md` (global user skill — file paths in this plan are relative to that skill file unless otherwise noted)
+
+## Overview
+
+Two gaps in the current `ghcp-review-resolve` skill:
+
+1. **Single-reviewer fallback is too thin.** When Copilot is unavailable (org without Copilot code review enabled, or 422/not-a-collaborator), the skill drops to pr-review-toolkit alone. That loses the "two independent reviewers, overlap is high-confidence" signal that the whole adjudication step depends on. The user wants: when Copilot can't run, spawn **two** distinct subagent reviewers instead — preserving the dual-reviewer adjudication property.
+
+2. **Threads are replied to but never resolved.** After fixing and replying, the GitHub review threads stay open. Reviewers (and the next run of this skill) see them as outstanding. The user wants: after a verified fix-and-reply, resolve the thread on GitHub. After all replies are posted, summarize back to the user in chat.
+
+This plan reshapes Step 1 (reviewer dispatch) into a 3-mode decision tree, and extends Step 6 with a resolve sub-step gated on verified fixes.
+
+## Problem Frame
+
+Concretely, the current skill behavior:
+
+- `EXPECTED_REVIEWERS` is always `{pr-review-toolkit}` plus optionally `copilot`. Never two subagent reviewers.
+- The fix loop posts replies via `POST /pulls/{n}/comments` with `in_reply_to=<id>`, but never calls the GraphQL `resolveReviewThread` mutation.
+- Single-reviewer mode is degraded by design — the adjudicator note says "loses the 'both bots flagged it' signal".
+
+What the user wants:
+
+| Preflight state | Reviewers |
+|---|---|
+| Copilot already reviewed AND threads resolved-fresh | 1 subagent reviewer (Copilot's prior verdict + 1 independent) |
+| Copilot available, no prior review | Copilot + 1 subagent reviewer |
+| Copilot unavailable | 2 distinct subagent reviewers (security-focused + quality-focused) |
+
+And the fix-loop should: reply on the thread, then resolve the thread, **only if the fix was actually verified**.
+
+## Requirements Trace
+
+- R1. When Copilot is unavailable for the run, the skill must dispatch two distinct subagent reviewers (security + quality) and treat their findings as the dual-reviewer pair for adjudication overlap.
+- R2. When Copilot's prior review on this PR is resolved-and-fresh at the current HEAD, the skill must run only one additional subagent reviewer and feed the prior Copilot findings (already accepted by virtue of being resolved) plus the new subagent's findings to adjudication.
+- R3. When Copilot is available and no prior resolved review exists, the skill must run Copilot plus one subagent reviewer (current behavior, but explicitly named).
+- R4. After replying on a review comment thread with the fix description, the skill must resolve that thread on GitHub — but only if the fix was edited, committed, pushed, and verified (tests/build/lint passed). Unverified or skipped fixes must reply but NOT resolve.
+- R5. Final chat summary must include per-thread outcome: replied+resolved / replied-only (verification skipped or failed) / not-actioned.
+- R6. Existing guardrails (no approve, no merge, no close, never act on adjudicator-rejected findings, stop on mid-run head-SHA change) remain intact across all three reviewer modes and the new resolve step.
+- R7. The reviewer-mode decision must be deterministic from preflight flags — no mid-run mode switching.
+
+## Scope Boundaries
+
+In scope:
+- Reviewer-dispatch decision tree (3 modes)
+- Two new subagent reviewer roles (security-focused + quality-focused) with prompt scaffolding
+- One subagent reviewer role used in the "1 additional" cases (general-purpose code-reviewer)
+- GraphQL `resolveReviewThread` integration in the fix loop
+- Verification-gated resolve policy
+- Summary table extension to show resolve state
+
+Out of scope:
+- Changing the adjudicator subagent (Step 4) — it already operates on a list of findings; it doesn't care whether they came from Copilot, pr-review-toolkit, or two subagents
+- Adding a third subagent reviewer
+- Changing how Copilot is configured on the org (still a repo admin task)
+- Resolving threads that this skill did not create or did not directly act on
+- Bulk-resolve at end-of-run (per-thread resolve happens inside the fix loop, not after)
+- Making the skill language-aware beyond the existing per-language verification hint
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `~/.claude/skills/ghcp-review-resolve/SKILL.md` — the only file changing
+- Step 0f (Copilot probe) — already produces `COPILOT_AVAILABLE`
+- Step 0g (prior-resolved check) — already produces `PRIOR_RESOLVED`
+- Step 0j (preflight flags) — `EXPECTED_REVIEWERS` derivation; this is what the new decision tree replaces
+- Step 1a/1b — current Copilot + pr-review-toolkit dispatch
+- Step 4 — adjudicator subagent prompt; takes a flat findings list, source-agnostic
+- Step 6 step 6 — `gh api .../comments -X POST -F in_reply_to=<id>` reply pattern (already correct, just needs resolve added after)
+
+### Institutional Learnings
+
+- Global instinct (90%): "Run two independent reviewers with different focus areas (security + quality) in parallel. Neither reviewer should have written the code. Compare findings — overlapping issues are highest confidence, unique findings from each are the bonus." This plan operationalizes that instinct as the Copilot-unavailable fallback.
+- Global instinct (80%): "When a feature requires creating 3+ files that don't depend on each other ... spawn parallel agents — one per file group." Reviewers in this plan run in parallel via a single message with multiple Agent tool calls.
+- Prior plan `2026-04-24-001-fix-ghcp-review-resolve-skill-robustness-plan.md` already established the 3-state preflight matrix this plan extends.
+
+### External References
+
+- GitHub GraphQL `resolveReviewThread` mutation: https://docs.github.com/en/graphql/reference/mutations#resolvereviewthread — takes `threadId` (the GraphQL node ID, not the REST comment ID) and returns the updated thread. Requires `repo` scope; `gh auth` already provides this.
+- The thread ID is reachable from the same `reviewThreads` query Step 0g already runs. The skill needs to retain `thread.id` (not just `comments[0].id`) when collecting findings so it can resolve later.
+
+## Key Technical Decisions
+
+- **Decision: Three reviewer modes, derived from preflight flags, named explicitly.**
+  Rationale: The current skill conflates "Copilot unavailable" with "single-reviewer mode" which loses the dual-reviewer property. Naming the modes (`copilot-plus-subagent`, `prior-resolved-plus-subagent`, `dual-subagent`) makes the decision auditable in logs and the preflight table.
+
+- **Decision: Two subagents in `dual-subagent` mode use a security/quality split, not two general-purpose reviewers.**
+  Rationale: User chose this in planning. Reduces redundancy — two general reviewers tend to flag the same surface-level issues; specialized reviewers diversify the finding set, which makes overlap a stronger signal when it occurs and gives unique findings clearer provenance.
+
+- **Decision: Thread resolution is gated on verification, not on edit success.**
+  Rationale: User chose this. An unverified fix replied with "not independently verified" should NOT close the thread — the human reviewer needs to see it's still open. This matches the global rule that fix-fatigue is real and silent hand-waving is worse than admitting uncertainty.
+
+- **Decision: Resolve happens per-thread inside the fix loop, immediately after the reply.**
+  Rationale: Keeps the per-finding state machine local. End-of-run bulk-resolve would have to re-derive verification state, doubling the surface area for bugs.
+
+- **Decision: When Copilot's prior review is resolved-and-fresh, treat those prior findings as already-accepted (no re-adjudication) and only adjudicate the new subagent's findings.**
+  Rationale: The threads were resolved by a human; second-guessing that with another adjudication pass adds noise without signal. The new subagent's job in that mode is to find anything Copilot missed or anything that regressed since.
+
+- **Decision: Prior-resolved Copilot threads are NOT touched by this skill's resolve step.**
+  Rationale: They're already resolved. Re-resolving an already-resolved thread is a no-op at best; at worst it surfaces as activity in the PR timeline. Skip.
+
+- **Decision: Subagent reviewers post their findings back to the orchestrator as structured data, not as PR comments.**
+  Rationale: pr-review-toolkit posts directly to the PR; subagent reviewers in this skill operate one layer earlier — they hand findings to the adjudicator. Posting from both subagent reviewers AND the adjudicator would duplicate inline comments.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Q: Should both subagents be code-reviewer agents, or one specialized? → A: Security-focused + quality-focused split (user choice; matches global instinct).
+- Q: Should resolve be unconditional or verification-gated? → A: Verification-gated (user choice).
+- Q: When prior Copilot review is resolved-and-fresh, should we skip the additional subagent too? → A: No — the additional subagent is the "did anything regress since the prior review" check. Always run one in that mode.
+- Q: Can we resolve threads via REST? → A: No. GitHub only exposes resolution via GraphQL `resolveReviewThread`. The query in Step 0g already uses GraphQL, so the dependency is consistent.
+- Q: What if the GraphQL resolve mutation fails? → A: Fall back to logging the failure, leaving the thread open, and noting it in the summary. Do not retry indefinitely.
+
+### Deferred to Implementation
+
+- The exact subagent reviewer prompts may need iteration after first real-world runs. The plan defines the role split and required output shape; tuning the prompt language is an execution-time concern.
+- Whether to cache the thread-id ↔ comment-id mapping in `/tmp/ghcp-thread-map.json` or thread it through Python-style return values is an implementation choice. The contract is: at fix-loop time, every accepted finding must know its `thread.id` for resolution.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+### Reviewer mode decision tree (replaces current Step 0j `EXPECTED_REVIEWERS` derivation)
+
+```
+preflight flags: COPILOT_AVAILABLE, PRIOR_RESOLVED
+
+if PRIOR_RESOLVED:
+    REVIEWER_MODE = "prior-resolved-plus-subagent"
+    EXPECTED_REVIEWERS = {"subagent-general"}
+    PRIOR_FINDINGS_SOURCE = "copilot-resolved-threads"   # treated as accepted
+
+elif COPILOT_AVAILABLE:
+    REVIEWER_MODE = "copilot-plus-subagent"
+    EXPECTED_REVIEWERS = {"copilot", "subagent-general"}
+    PRIOR_FINDINGS_SOURCE = none
+
+else:
+    REVIEWER_MODE = "dual-subagent"
+    EXPECTED_REVIEWERS = {"subagent-security", "subagent-quality"}
+    PRIOR_FINDINGS_SOURCE = none
+```
+
+### End-to-end pipeline (mode-aware)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as Skill orchestrator
+    participant GH as GitHub
+    participant R1 as Reviewer A
+    participant R2 as Reviewer B (or n/a)
+    participant ADJ as Adjudicator subagent
+    participant FX as Fix loop
+
+    U->>S: /ghcp-review-resolve
+    S->>GH: preflight (size, merge, copilot probe, prior-resolved)
+    S->>S: pick REVIEWER_MODE
+    par Reviewer A
+        S->>R1: review prompt (or assign @copilot)
+    and Reviewer B
+        S->>R2: review prompt (or skip if prior-resolved)
+    end
+    R1-->>S: findings A
+    R2-->>S: findings B
+    S->>ADJ: normalize + dedupe + adjudicate
+    ADJ-->>S: accepted findings (with thread.id when from prior-resolved? no — those are already-resolved, excluded from adjudication input)
+    S->>GH: post inline comments (capture new thread.id)
+    loop per accepted finding
+        FX->>FX: read, edit, verify, commit, push
+        FX->>GH: reply on thread
+        alt verification passed
+            FX->>GH: resolveReviewThread(thread.id)
+        else verification failed/skipped
+            FX-->>FX: leave thread open, mark in summary
+        end
+    end
+    S->>U: summary table (per-thread outcome)
+```
+
+### Findings record shape (extended)
+
+```
+finding := {
+  source: "copilot" | "pr-toolkit" | "subagent-security" | "subagent-quality" | "subagent-general" | "copilot-prior-resolved",
+  file, line, severity, body,
+  comment_id,        // REST id, for in_reply_to
+  thread_id,         // GraphQL node id, for resolveReviewThread (set when known)
+  overlap: bool,
+  pre_accepted: bool // true only for copilot-prior-resolved findings — bypasses adjudicator
+}
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Add reviewer-mode decision tree to preflight (Step 0j)**
+
+**Goal:** Replace the existing `EXPECTED_REVIEWERS` derivation with a named, three-mode decision tree.
+
+**Requirements:** R1, R2, R3, R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `~/.claude/skills/ghcp-review-resolve/SKILL.md` (Step 0j, and the preflight table in Step 0h)
+
+**Approach:**
+- Replace the single-line `EXPECTED_REVIEWERS` derivation with explicit `REVIEWER_MODE` + `EXPECTED_REVIEWERS` + `PRIOR_FINDINGS_SOURCE` flag set
+- Add a row to the preflight table: `Reviewer mode    <copilot-plus-subagent | prior-resolved-plus-subagent | dual-subagent>`
+- Update the "Decision" line to reference `REVIEWER_MODE` so the user sees it before any reviewer is dispatched
+- Update Step 0i's short-circuit ("nothing useful to do") to use the mode names — large + dual-subagent without `--force` is still allowed (user wanted dual-subagent fallback to actually run); large + prior-resolved-plus-subagent without `--force` keeps current short-circuit behavior
+
+**Patterns to follow:**
+- Existing flag block in Step 0j (`PR_NUMBER`, `PR_HEAD_SHA`, etc.) — keep the same prose-with-bash-snippet style
+- Existing preflight-table layout in Step 0h
+
+**Test scenarios:**
+- Edge case: prior-resolved + copilot-available → should pick `prior-resolved-plus-subagent` (PRIOR_RESOLVED takes precedence over COPILOT_AVAILABLE in the tree)
+- Edge case: copilot-unavailable + no-prior-review → `dual-subagent`
+- Edge case: copilot-available + no-prior-review → `copilot-plus-subagent`
+- Edge case: copilot-unavailable + prior-resolved-stale → `dual-subagent` (stale doesn't count as "resolved" for skip purposes — current Step 0g behavior preserved)
+- Happy path: preflight table renders the new `Reviewer mode` row and the matching decision line
+
+**Verification:**
+- Reading Step 0 end-to-end, a human can trace any combination of (COPILOT_AVAILABLE, PRIOR_RESOLVED) to exactly one `REVIEWER_MODE` without ambiguity
+
+- [ ] **Unit 2: Replace Step 1 reviewer dispatch with mode-aware dispatcher**
+
+**Goal:** Step 1 now branches on `REVIEWER_MODE` and dispatches the right reviewers in parallel (single message, multiple Agent tool calls per the global parallel-agent instinct).
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `~/.claude/skills/ghcp-review-resolve/SKILL.md` (Step 1, Step 1a, Step 1b — restructure into Step 1a/b/c by mode)
+
+**Approach:**
+- Drop `pr-review-toolkit` from the default reviewer set. (Existing behavior makes pr-review-toolkit always-on; this plan replaces that with the mode-driven set. Not a regression — pr-review-toolkit can still be invoked manually via `/pr-review-toolkit:review-pr` if a user wants it.)
+- Step 1a (`copilot-plus-subagent`): assign `@copilot` reviewer + spawn one general-purpose subagent code reviewer in the same turn
+- Step 1b (`prior-resolved-plus-subagent`): spawn one general-purpose subagent code reviewer (no Copilot re-request); preload `PRIOR_FINDINGS` from the resolved Copilot threads as `pre_accepted=true` records
+- Step 1c (`dual-subagent`): spawn `subagent-security` + `subagent-quality` in the same turn (parallel via single message, multiple Agent tool calls)
+- Each subagent prompt receives: PR number, head SHA, base ref, size class, the diff (full for `small`, per-file file list for `large`), and a focused role description
+- Subagents return structured findings as JSON (same shape as Step 3 normalizes to), not PR comments
+
+**Patterns to follow:**
+- Existing pr-review-toolkit Skill() invocation style for inspiration on argument shape
+- The "parallel via single message" pattern documented in the user's global agents.md rule
+
+**Test scenarios:**
+- Happy path (`copilot-plus-subagent`): both reviewers fire in one turn; orchestrator collects findings from both
+- Happy path (`dual-subagent`): security and quality subagents fire in parallel; their findings carry distinct `source` values
+- Happy path (`prior-resolved-plus-subagent`): only one new reviewer runs; prior Copilot findings are loaded with `pre_accepted=true`
+- Edge case: subagent reviewer crashes or returns malformed JSON → log, treat that reviewer as zero findings, continue with the others (don't abort pipeline)
+- Edge case: in `dual-subagent` mode, if one of the two subagents returns nothing usable, the run continues with one reviewer's findings only and the summary notes "degraded to single-reviewer findings due to subagent-X failure"
+- Integration: parallel dispatch must happen in a single orchestrator message containing multiple Agent tool calls — not sequential
+
+**Verification:**
+- Step 1 prose explicitly names which reviewers fire in each mode and why
+- The dispatch instruction tells the implementer to use a single message with multiple parallel Agent tool calls when two reviewers are needed
+
+- [ ] **Unit 3: Define security-focused and quality-focused subagent reviewer prompts**
+
+**Goal:** Codify the role split for `dual-subagent` mode and the general role for `copilot-plus-subagent` / `prior-resolved-plus-subagent` modes.
+
+**Requirements:** R1
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `~/.claude/skills/ghcp-review-resolve/SKILL.md` (new subsection under Step 1 or a small reference section; choose the location that keeps Step 1 scannable)
+
+**Approach:**
+- Define three reviewer prompt scaffolds (security, quality, general) — each ~10–15 lines of instructions
+- Security reviewer focuses: auth/authz, input validation, injection, secrets, data exposure, unsafe deserialization, race conditions with security implications, OWASP Top 10
+- Quality reviewer focuses: correctness bugs, error handling, resource leaks, edge cases, complexity, naming, dead code, maintainability, test coverage gaps
+- General reviewer focuses: a balanced superset (used when the second axis of diversity comes from Copilot or prior-Copilot rather than from the role)
+- Each prompt requires a JSON output shape matching the Step 3 finding record (file, line, severity, body)
+- Each prompt explicitly instructs: do NOT post PR comments yourself, return findings to the orchestrator only
+- Each prompt receives the same diff/file context the adjudicator gets in Step 4
+
+**Patterns to follow:**
+- Existing adjudicator subagent prompt in Step 4 (independence framing, "did NOT write the code")
+- User's global instincts file: security + quality split is already the canonical phrasing
+
+**Test scenarios:**
+- Happy path: a security finding (e.g., unsanitized user input flows to SQL) is more likely to surface from the security reviewer than the quality reviewer
+- Happy path: a maintainability finding (e.g., a 200-line function with deep nesting) is more likely to surface from the quality reviewer
+- Edge case: an issue that crosses both axes (e.g., a race condition that's both a correctness bug and a security risk) should surface in both — that overlap is exactly the signal the adjudicator uses
+- Integration: subagent JSON outputs are directly consumable by the existing Step 3 normalizer without transformation
+
+**Verification:**
+- Each role's prompt is concrete enough that re-running the skill with the same inputs would produce roughly the same finding set (low-variance reviewer behavior)
+- The "do not post PR comments yourself" instruction is unambiguous — the orchestrator owns the PR-comment surface
+
+- [ ] **Unit 4: Adjudicator pre-accepts prior-resolved Copilot findings**
+
+**Goal:** When `REVIEWER_MODE == prior-resolved-plus-subagent`, prior Copilot findings bypass adjudication (already accepted by virtue of being resolved by a human) and only the new subagent's findings go through the adjudicator.
+
+**Requirements:** R2
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `~/.claude/skills/ghcp-review-resolve/SKILL.md` (Step 4 prompt scaffold and Step 3 normalization)
+
+**Approach:**
+- In Step 3, mark prior-resolved Copilot findings with `pre_accepted=true` and skip them when building the adjudicator input
+- Note in Step 4: prior-resolved findings are already accepted; they are NOT re-adjudicated
+- Make sure prior-resolved findings still flow into Step 5 only if there's a NEW edit needed — but typically they don't, because they're already resolved. Most concretely: prior-resolved findings appear in the final summary as "previously resolved by human reviewer" but generate no new PR comments and no new edits
+- Add a guard: a prior-resolved finding that the new subagent independently re-flags (regression detection) should be lifted to a NEW finding under the subagent's source, with a note "regression of previously-resolved finding"
+
+**Patterns to follow:**
+- Existing Step 3 dedup logic (file + overlapping line range + similar body) — extend with a regression check against prior-resolved findings
+
+**Test scenarios:**
+- Happy path: 8 prior-resolved findings + 0 new subagent findings → 0 new comments posted, summary lists "8 prior-resolved (no action needed)"
+- Edge case: 8 prior-resolved + 1 new subagent finding that flags one of the same file/line ranges → that finding gets posted as a new comment with "regression of previously-resolved finding" framing
+- Edge case: prior-resolved finding's referenced file no longer exists in the diff → drop silently (already-resolved + file removed = no concern)
+- Integration: adjudicator input contains zero prior-resolved findings; adjudicator output is unaffected by the prior-resolved set
+
+**Verification:**
+- Adjudicator subagent prompt in Step 4 explicitly states it receives only non-pre-accepted findings
+- Final summary distinguishes "prior-resolved" from "newly accepted" counts
+
+- [ ] **Unit 5: Capture thread.id when posting inline comments**
+
+**Goal:** Step 5 (post inline comments) currently only captures REST `comment_id`. Extend it to also capture the GraphQL `thread.id` so Step 6 can resolve the thread later.
+
+**Requirements:** R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `~/.claude/skills/ghcp-review-resolve/SKILL.md` (Step 5)
+
+**Approach:**
+- After posting the review with `event=COMMENT`, the response includes `comments[].id` (REST) but not the thread node ID. Run a follow-up GraphQL query to map each newly-posted REST comment ID to its `pullRequestReviewThread.id`
+- Cache the mapping on the in-memory finding records: `finding.thread_id = <GraphQL id>`
+- If the GraphQL mapping query fails for a particular comment, log it and leave `thread_id=null`; that finding will reply but not resolve in Step 6, with summary noting "thread id unavailable, left open"
+
+**Patterns to follow:**
+- Existing GraphQL query in Step 0g — reuse the `reviewThreads(first: 100)` query, filter to threads where `comments.nodes[].databaseId == <our REST comment id>`
+
+**Test scenarios:**
+- Happy path: 4 inline comments posted → 4 thread IDs captured, all findings have `thread_id` set
+- Edge case: GraphQL pagination — if the PR has >100 review threads (unlikely but possible on long-lived PRs), paginate or use `last:` to find the most recent threads
+- Edge case: GraphQL query fails (auth scope, transient error) → 4 comments still posted, thread_id null, Step 6 replies but does not resolve, summary flags it
+- Integration: thread_id capture happens after the POST review call returns, before Step 6 starts iterating
+
+**Verification:**
+- Every accepted finding either has `thread_id` set or has a logged reason why it doesn't
+- Step 5 prose explicitly notes that thread_id capture is required for Step 6's resolve substep
+
+- [ ] **Unit 6: Add resolve substep to Step 6 fix loop, gated on verification**
+
+**Goal:** After replying on a comment thread with the fix description, resolve the thread on GitHub — but only if the fix was edited, committed, pushed, AND verification passed.
+
+**Requirements:** R4, R6
+
+**Dependencies:** Unit 5
+
+**Files:**
+- Modify: `~/.claude/skills/ghcp-review-resolve/SKILL.md` (Step 6, specifically substeps 6 and 7 — extend with a 6.5 "resolve thread")
+
+**Approach:**
+- Add a per-finding `verified` boolean tracked through substeps 2–5: starts false, set true only when verification (substep 3) explicitly passes
+- After substep 6 (reply posted), if `verified=true` AND `thread_id` is non-null, call:
+
+  ```graphql
+  mutation { resolveReviewThread(input: {threadId: "<id>"}) { thread { id isResolved } } }
+  ```
+
+- If `verified=false` (skipped, repair-failed, or no test command found), reply mentions verification status and the thread is left open; summary records "replied, not resolved (verification: <reason>)"
+- If the GraphQL resolve mutation itself fails, log the error and treat the thread as replied-only; do not retry indefinitely (one retry max, then give up and surface in summary)
+- Re-check `PR_HEAD_SHA` before the resolve call — if HEAD has moved, treat it the same as the existing Step 5 head-SHA-changed guardrail (stop, don't resolve, surface)
+
+**Patterns to follow:**
+- Existing Step 5 head-SHA recheck pattern
+- Existing Step 6 substep 6 (`gh api ... -F in_reply_to=<id>`) reply pattern
+
+**Test scenarios:**
+- Happy path: 4 findings, all verified → 4 replies + 4 resolves; PR shows all 4 threads resolved
+- Edge case (mixed): 4 findings, 3 verified + 1 skipped (verification couldn't be run) → 3 replies+resolves, 1 reply-only with "not independently verified" in body
+- Edge case (mixed): 4 findings, 3 verified + 1 verification failed after one retry → 3 replies+resolves, 1 revert + reply-only with "fix attempted, verification failed twice, reverted"
+- Edge case: GraphQL resolve mutation returns 4xx → reply already posted, thread stays open, summary flags it as "replied, resolve mutation failed"
+- Edge case: HEAD moved between reply and resolve → stop the loop entirely (per existing guardrail), don't resolve any further threads
+- Integration: a thread that was already resolved by a human between the post and the resolve call → mutation is idempotent (resolving an already-resolved thread is a no-op in GitHub's API), so this is safe; just log "already resolved" and continue
+- Error path: thread_id is null (Unit 5 capture failed for this comment) → reply-only, summary flags "thread id unavailable, left open"
+
+**Verification:**
+- Step 6 prose explicitly defines the verified→resolve gate
+- The resolve substep is unambiguously tied to the per-finding `verified` flag, not to "did the edit happen"
+- Guardrails section is updated to note that `resolveReviewThread` is the only mutation that may close threads, and only on verified fixes
+
+- [ ] **Unit 7: Extend Step 7 final summary with per-thread outcome table**
+
+**Goal:** The final chat summary should make it obvious which threads were verified+resolved, replied-only, or never actioned. User explicitly asked for "summarize back to user in chat" after all the resolution work.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 6
+
+**Files:**
+- Modify: `~/.claude/skills/ghcp-review-resolve/SKILL.md` (Step 7)
+
+**Approach:**
+- Add a per-thread outcome table to the final summary:
+
+  ```
+  Threads acted on:
+    Thread (file:line)              Outcome
+    ──────────────────────────────  ──────────────────────────────────
+    src/auth.go:88                  fixed + verified + resolved (commit def456)
+    src/api.go:142                  fixed + verified + resolved (commit ghi789)
+    src/cache.go:203                replied — verification failed, reverted
+    src/util.go:55                  replied — thread id unavailable
+  ```
+
+- Add a one-line mode summary up top: `Reviewer mode: dual-subagent (security + quality)`
+- Keep all existing summary fields (PR URL, preflight outcome, fixes, guardrails confirmation)
+- Final line stays unchanged: **PR was not closed, approved, or merged.**
+
+**Patterns to follow:**
+- Existing Step 7 markdown layout
+
+**Test scenarios:**
+- Happy path: all threads resolved → table is uniform "fixed + verified + resolved"
+- Mixed: some skipped → outcomes column makes the reason scannable in one line each
+- Edge case: zero accepted findings → table is omitted, summary just notes "0 findings accepted by adjudicator"
+- Integration: each row's data comes directly from the per-finding state from Unit 6
+
+**Verification:**
+- A user reading only the summary can answer: which threads are still open and why?
+
+- [ ] **Unit 8: Update Guardrails and Examples sections**
+
+**Goal:** Reflect the new modes and the resolve mutation in the skill's Guardrails and Example runs sections so they don't drift from behavior.
+
+**Requirements:** R6
+
+**Dependencies:** Units 1–7 (cosmetic dependency — examples should reflect actual behavior)
+
+**Files:**
+- Modify: `~/.claude/skills/ghcp-review-resolve/SKILL.md` (Guardrails section, Example runs section)
+
+**Approach:**
+- Guardrails: add "Never resolve a review thread for a fix that was not verified" as an explicit rule. Keep all existing guardrails verbatim.
+- Examples: replace Example 3 ("single-reviewer mode on a large PR") with a `dual-subagent` mode example showing security + quality reviewers, the adjudicator output, and per-thread resolve outcomes. Update Example 1 to mention the new `Reviewer mode` row in the preflight table. Update Example 2 (degraded path / merge conflict) — no behavior change there, just preserve.
+- Add an Example 4 covering `prior-resolved-plus-subagent` mode where prior 8 Copilot findings are pre-accepted and 0 new findings come from the subagent → skill exits cleanly with summary noting all prior threads remain resolved.
+
+**Patterns to follow:**
+- Existing Example 1/2/3 formatting
+
+**Test scenarios:**
+- Test expectation: none -- documentation/example update with no behavioral assertion. The verification is human-read coherence between examples and the new Steps 0–7.
+
+**Verification:**
+- Each example's "Decision:" line and reviewer dispatch matches the mode it claims
+- The Guardrails list contains the new "never resolve unverified" rule
+
+## System-Wide Impact
+
+- **Interaction graph:** Three subagent reviewer roles join the existing adjudicator subagent — four subagent roles total in this skill. The adjudicator is unchanged in behavior but receives input from a wider set of sources.
+- **Error propagation:** Subagent reviewer failures must NOT abort the pipeline (current pr-review-toolkit failure behavior is preserved and extended). Resolve mutation failures must NOT abort the fix loop — they're per-thread degradations, not pipeline blockers.
+- **State lifecycle risks:** The `verified` flag travels through substeps 2–5 of Step 6; if the implementation drops it on the floor (e.g., reset between substeps), threads will be resolved that shouldn't be. Test scenario in Unit 6 covers this.
+- **API surface parity:** The skill currently has implicit reviewer modes (Copilot+toolkit, toolkit-only). After this plan, modes are explicit and named. Any other skill that orchestrates reviews can model this same pattern.
+- **Integration coverage:** The cross-layer behavior — preflight flag → mode selection → reviewer dispatch → finding source attribution → adjudicator input → comment post → reply → resolve — must hold end-to-end in each mode. Unit-level test scenarios cover individual hops; the example runs in Unit 8 are the integration check.
+- **Unchanged invariants:** Guardrails (no approve/merge/close, never act on adjudicator-rejected findings, stop on mid-run head-SHA change). The 30s/10min poll cadence in Step 2 is unchanged. The size-class diff strategy from the prior plan is unchanged. pr-review-toolkit is dropped from the always-on default reviewer set; users who want it can still invoke it manually via `/pr-review-toolkit:review-pr`. This is the one intentional behavior break vs. the prior plan; it is called out here so reviewers can confirm the trade-off.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Two subagent reviewers produce highly correlated findings (security/quality split is too thin) | Adjudicator still runs and trims noise; if real-world signal is weak, the prompt scaffolds in Unit 3 are easy to retune without reshaping the skill |
+| `resolveReviewThread` GraphQL mutation requires a scope `gh auth` doesn't provide on some setups | Falls back to reply-only with an explicit summary flag; user can manually resolve. Detected on first call, not as a precondition (don't gate the whole skill on it) |
+| Thread ID capture race (Unit 5) — GitHub may not have indexed the new thread by the time the GraphQL query runs | One retry with a 2s sleep before falling back to thread_id=null. Documented in Unit 5 implementation guidance |
+| pr-review-toolkit users notice the always-on behavior was dropped | Surfaced in System-Wide Impact above and in Unit 2 Approach. If demand emerges, an opt-in flag can re-add it without reshaping the modes |
+| Prior-resolved Copilot finding flagged as a regression by the new subagent (Unit 4) — false positive risk | Adjudicator still runs on regression-flagged findings before they become PR comments; this is the existing tiebreaker mechanism doing its job |
+| HEAD SHA changes mid-fix-loop — current guardrail handles edits, plan extends it to the new resolve substep | Unit 6 scenario covers this explicitly |
+
+## Documentation / Operational Notes
+
+- The skill description in the YAML frontmatter (`description: ...`) should be updated to mention "two distinct subagent reviewers when Copilot is unavailable" and "resolves threads after verified fixes" so the trigger heuristics in the agent harness pick up the right invocations. Cosmetic but high-value for skill discoverability.
+- No migration concerns — the skill is global user-state, not repo-state. Each next invocation just picks up the new behavior.
+
+## Sources & References
+
+- **Origin document:** [docs/plans/2026-04-24-001-fix-ghcp-review-resolve-skill-robustness-plan.md](2026-04-24-001-fix-ghcp-review-resolve-skill-robustness-plan.md) — established the 3-state preflight matrix this plan extends
+- Skill source: `~/.claude/skills/ghcp-review-resolve/SKILL.md`
+- Global instinct on dual-reviewer security+quality split (90% confidence)
+- GitHub GraphQL `resolveReviewThread` mutation: https://docs.github.com/en/graphql/reference/mutations#resolvereviewthread

--- a/docs/plans/2026-04-24-002-feat-port-land-takeoff-skills-copilot-plan.md
+++ b/docs/plans/2026-04-24-002-feat-port-land-takeoff-skills-copilot-plan.md
@@ -1,0 +1,235 @@
+---
+title: "feat: Port /land and /takeoff skills to ATV-starterkit for GitHub Copilot"
+type: feat
+status: active
+date: 2026-04-24
+---
+
+# feat: Port /land and /takeoff skills to ATV-starterkit for GitHub Copilot
+
+## Overview
+
+Port two Claude Code skills — `/land` (session completion: commit → push → PR → handoff) and `/takeoff` (session kickoff: prioritized backlog briefing) — into the ATV-starterkit repo so they are usable via GitHub Copilot. The ATV-starterkit already hosts a large library of Copilot-compatible skills under `.github/skills/<skill-name>/SKILL.md`, so this port follows the established pattern rather than introducing anything new structurally.
+
+The primary adaptation work is:
+
+1. Remove Claude-Code-specific surface area (e.g., `ExitWorktree` tool calls, `mcp__backlog__*` MCP tool references) and replace with Copilot-equivalent behavior (plain shell / `gh` CLI / prose guidance).
+2. Adjust skill frontmatter and triggers to match Copilot's skill invocation model as used by the sibling skills already in `.github/skills/`.
+3. Align both skills with the ATV-starterkit's documented conventions (conventional commits, `docs/plans/` naming, optional Backlog.md support, gstack interop) as described in `.github/copilot-instructions.md`.
+
+## Problem Frame
+
+The user has two battle-tested session bookends — `/takeoff` to start a session and `/land` to finish one — defined as Claude Code user-scope skills at `~/.claude/skills/{land,takeoff}/SKILL.md`. They want these same flows available inside ATV-starterkit when driving work via GitHub Copilot, which in this repo means the Copilot Skills mechanism backed by `.github/skills/<name>/SKILL.md` files (see sibling skills like `git-commit/`, `git-commit-push-pr/`, `ce-work/`, etc.).
+
+Directly copying the SKILL.md files is insufficient: the Claude versions assume tools and conventions that Copilot does not have (e.g., `ExitWorktree`, `mcp__backlog__task_create`, Claude's keyword-trigger "this is not an exact match" language). They also make assumptions about stack detection that should be tightened for this specific repo (Go primary, with Node tooling under `npm/`).
+
+## Requirements Trace
+
+- R1. Provide a Copilot-invokable `land` skill that runs commit → push → PR → handoff, matching the intent of `~/.claude/skills/land/SKILL.md`.
+- R2. Provide a Copilot-invokable `takeoff` skill that produces a prioritized backlog briefing, matching the intent of `~/.claude/skills/takeoff/SKILL.md`.
+- R3. Both skills must live under `.github/skills/<name>/SKILL.md` and follow the same frontmatter/structure shape as existing ATV-starterkit skills (`git-commit`, `git-commit-push-pr`).
+- R4. Skills must use only Copilot-available tooling — shell, `gh`, `git`, optional `backlog` CLI. No Claude-Code-only tool references (`ExitWorktree`, `mcp__backlog__*`, `AskUserQuestion`, etc.).
+- R5. Both skills must preserve the signature UX affordances that make the originals useful: the terminal banners (`🛬 PLANE LANDED — NICE WORK`, `✈️ TAKE OFF — NOW AT 30,000 FEET`), the "never merge the PR" rule, the "never stop before pushing" rule, and the bullet-group takeoff shape with emoji headers.
+- R6. Skills must interoperate with this repo's conventions: conventional commits, `docs/plans/` as the plan home, graceful fallback when no `backlog/` directory exists, and deference to `.github/copilot-instructions.md`.
+- R7. The pair must be registered/discoverable the same way other skills in this repo are (mere presence under `.github/skills/<name>/SKILL.md` appears to be the registration mechanism — verify during implementation).
+
+## Scope Boundaries
+
+**In scope:**
+- Creating `.github/skills/land/SKILL.md` and `.github/skills/takeoff/SKILL.md`.
+- Tailoring language, triggers, and tool references for GitHub Copilot.
+- Detecting ATV-starterkit's actual stack (Go + Node) in the `land` quality-gate step.
+- A short mention in `.github/copilot-instructions.md` under "Available Workflows" so users know the skills exist.
+
+**Out of scope / non-goals:**
+- Not porting to other coding agents (Cursor, Cline, etc.) — Copilot only.
+- Not modifying the original Claude skills at `~/.claude/skills/{land,takeoff}/`.
+- Not auto-invoking these skills via hooks; invocation remains user-initiated.
+- Not building a Backlog.md integration for ATV-starterkit itself — the repo currently has no `backlog/` directory, and the skill should fall back gracefully, matching the original's edge-case handling.
+- Not merging PRs as part of `/land`. That remains an explicit human action.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.github/skills/git-commit/SKILL.md` — canonical shape for a git-oriented Copilot skill in this repo. Uses YAML frontmatter with `name` and `description`, then numbered `### Step N:` sections. No `argument-hint` in the Copilot variant.
+- `.github/skills/git-commit-push-pr/SKILL.md` — the closest functional cousin to `/land`. Shows the repo's pattern for `gh pr view` / `gh pr create`, exit-code capture, and PR description construction. `/land` should not duplicate this skill's PR-body authoring logic — it should either delegate ("follow the conventions in `git-commit-push-pr`") or stay terse on PR body, focusing on the commit-push-PR *sequence* rather than the body craft.
+- `.github/skills/ce-work/` and similar — confirm the `.github/skills/<name>/SKILL.md` structure is the registration mechanism for Copilot skills in this repo.
+- `.github/copilot-instructions.md` — lists available workflows (`/ce-brainstorm`, `/ce-plan`, etc.). New skills should be added to this index so Copilot users discover them.
+- `~/.claude/skills/land/SKILL.md` and `~/.claude/skills/takeoff/SKILL.md` — source documents. Carry over the 10-step / 6-step structures, the banners, and the "never merge / never skip push" rules verbatim. Strip Claude-specific tool calls.
+
+### Institutional Learnings
+
+- Sibling Copilot skills in this repo drop Claude-specific frontmatter keys (`argument-hint`) — follow their shape for portability.
+- Stack detection in `/land`'s quality-gate step should be *adaptive* — check repo root for `go.mod`, `package.json`, `pnpm-workspace.yaml`, `Cargo.toml`, `pyproject.toml` and run the matching commands. ATV-starterkit has both Go and Node surfaces (`go.mod` at root, `npm/` subproject), so the skill should run Go checks at root and note the Node subproject.
+- Backlog CLI support is optional. ATV-starterkit does not currently have `backlog/` at the root; the skill should fall back as the original does.
+
+### External References
+
+- None required. This is an internal port with existing reference implementations.
+
+## Key Technical Decisions
+
+- **Copy-then-adapt, not rewrite.** Start from the original SKILL.md files and make surgical edits. Wholesale rewrites would lose hard-won UX details (banners, bullet-group shapes, the "never merge the PR" language).
+- **Drop Claude-only tool references.** Replace `ExitWorktree(action: "keep")` with a prose note ("if working in a git worktree, leave it in place for PR review; remove manually when merged"). Replace `mcp__backlog__task_create` references with CLI-only (`backlog task create ...`) guarded behind a `command -v backlog` check.
+- **Drop the `argument-hint` frontmatter key** to match sibling Copilot skills in this repo (`git-commit`, `git-commit-push-pr`). Argument handling instructions stay in the skill body.
+- **Keep both banners exactly as-is.** They are part of the skill's identity and user muscle memory.
+- **Keep "never merge the PR" as a critical rule in `/land`.** Copilot is more likely than Claude to interpret "finish the work" as "merge" — the rule is more important here, not less.
+- **Delegate PR-body craft to `git-commit-push-pr` where possible.** `/land` should call out that PR body construction follows the conventions of the existing `git-commit-push-pr` skill rather than reimplementing it, keeping the two skills in sync.
+- **Tighten stack detection for ATV-starterkit.** Detect stack from repo-root signal files; if `go.mod` is present, run `go build ./... && go vet ./...`; if `npm/package.json` exists, optionally run `(cd npm && npm run build)` when npm-subproject files changed in this session. This avoids the "run everything" sprawl the generic skill could fall into.
+- **Mention the pair in `.github/copilot-instructions.md` under a new "Session bookends" heading** so users can discover them alongside the `/ce-*` workflows.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **How are Copilot skills invoked in this repo?** — By user slash command (e.g., `/land`, `/takeoff`) matching the skill directory name under `.github/skills/`. Registration is implicit via presence; no manifest update needed. Verified by inspecting sibling skills.
+- **Should we keep `argument-hint`?** — No. Sibling skills don't use it. Argument handling stays in the skill body prose.
+- **Which skill owns PR body craft?** — `git-commit-push-pr`. `/land` references it rather than duplicating.
+
+### Deferred to Implementation
+
+- **Exact wording of the Copilot-specific worktree fallback** — decide once during implementation; short prose note is sufficient.
+- **Whether to add a one-line cross-reference from `git-commit-push-pr` back to `/land`** — evaluate during implementation; if natural, add it; if forced, skip.
+
+## Implementation Units
+
+- [ ] **Unit 1: Port `/land` skill to `.github/skills/land/SKILL.md`**
+
+**Goal:** Create a Copilot-compatible `land` skill that executes the full session-completion checklist.
+
+**Requirements:** R1, R3, R4, R5, R6
+
+**Dependencies:** None
+
+**Files:**
+- Create: `.github/skills/land/SKILL.md`
+
+**Approach:**
+- Copy `~/.claude/skills/land/SKILL.md` as the starting point.
+- Strip the `argument-hint` frontmatter key.
+- Rewrite the description field to match the voice of sibling Copilot skills (concise, starts with action verbs, lists trigger phrases).
+- Replace `ExitWorktree(action: ...)` calls in Step 7 with a short prose block: "If you are working inside a git worktree, leave it in place while the PR is open; remove it manually with `git worktree remove` only after the PR is merged or abandoned."
+- Replace `mcp__backlog__task_create` references in Step 1 with guarded CLI usage: `if command -v backlog >/dev/null 2>&1 && [ -d backlog ]; then backlog task create ...; fi`, and fall back to the handoff list otherwise.
+- In Step 2 (quality gates), replace the generic multi-stack block with an ordered, adaptive detection sequence tuned for this repo (check `go.mod` → run `go build ./... && go vet ./...`; check `npm/package.json` → run Node build only if npm files changed; add generic fallbacks for Python/Rust/pnpm for portability when this skill is copied to other repos).
+- Preserve Steps 1–10 numbering and all critical rules verbatim. Keep the `🛬 PLANE LANDED — NICE WORK` banner rule unchanged.
+- Add a one-line pointer in Step 6 that PR body construction should follow the conventions in `.github/skills/git-commit-push-pr/SKILL.md`.
+- Update the "Project-specific considerations" footer to reference `.github/copilot-instructions.md` and `AGENTS.md` (both exist in this repo) instead of the Claude-world `CLAUDE.md`/`AGENTS.md` pair.
+
+**Patterns to follow:**
+- `.github/skills/git-commit/SKILL.md` for frontmatter shape and step headers.
+- `.github/skills/git-commit-push-pr/SKILL.md` for `gh pr view` exit-code-capture idiom — reuse that exact pattern in Step 6.
+
+**Test scenarios:**
+- Happy path: Dirty working tree with Go changes → skill stages specific files, commits with conventional message, pushes, creates PR, emits banner.
+- Happy path (nothing to commit): Clean tree, already pushed → skill skips Steps 4–5, still emits banner.
+- Edge case: Branch has no upstream → skill runs `git push -u origin "$branch"` without attempting a pre-push rebase.
+- Edge case: `backlog/` directory absent → Step 1 falls back to the handoff list without error.
+- Edge case: Running inside a git worktree → skill emits the prose worktree note, does not attempt `ExitWorktree`.
+- Error path: `git push` fails due to protected branch or hook rejection → skill surfaces the failure, does *not* emit the banner, loops back per the critical rules.
+- Error path: Quality gate (`go build` or `go vet`) fails → skill halts before commit, does *not* emit the banner.
+- Integration: After `/land` succeeds, `git log origin/<branch>..HEAD` returns empty and `git status` reports a clean tree.
+
+**Verification:**
+- Skill file parses as valid Markdown + YAML frontmatter (same linter posture as sibling skills).
+- No string matches for Claude-only tool names (`ExitWorktree`, `mcp__backlog__`, `AskUserQuestion`) remain in the file.
+- Invoking `/land` in a dummy branch with a single file change produces a commit, push, PR, handoff, and final banner line.
+
+- [ ] **Unit 2: Port `/takeoff` skill to `.github/skills/takeoff/SKILL.md`**
+
+**Goal:** Create a Copilot-compatible `takeoff` skill that produces a prioritized backlog briefing at session start.
+
+**Requirements:** R2, R3, R4, R5, R6
+
+**Dependencies:** None (parallelizable with Unit 1)
+
+**Files:**
+- Create: `.github/skills/takeoff/SKILL.md`
+
+**Approach:**
+- Copy `~/.claude/skills/takeoff/SKILL.md` as the starting point.
+- Strip the `argument-hint` frontmatter key; move argument docs into a body section as sibling skills do.
+- Rewrite the description field in the sibling-skill voice.
+- Replace `mcp__backlog__task_list` references with CLI-only: prefer `backlog task list --plain --sort priority` when the CLI is available and `backlog/` exists; otherwise fall back to reading `docs/plans/*.md` frontmatter for active plan titles.
+- Preserve the bullet-group output shape, emoji headers (🛫, 🔵, 🟢, ⚪, 🔴), and the `✈️ TAKE OFF — NOW AT 30,000 FEET` final banner verbatim.
+- Preserve the edge-case list (no backlog, everything blocked, empty list, tasks without priority) and the "ask before starting work" recommendation pattern at Step 5.
+- Update the fallback path: when `backlog/` is absent, scan `docs/plans/` for files with `status: active` frontmatter and render a bullet list of those plan titles + filenames as the actionable group. Mention the fallback in the output so the user knows why the shape differs.
+
+**Patterns to follow:**
+- `.github/skills/git-commit/SKILL.md` for frontmatter shape.
+- Existing `docs/plans/YYYY-MM-DD-NNN-*-plan.md` filename convention — the fallback should parse these filenames to extract type and slug.
+
+**Test scenarios:**
+- Happy path: `backlog/` directory exists with a mix of To Do / In Progress / Done tasks → skill renders 🛫, 🟢, ⚪ groups correctly, emits banner.
+- Happy path (this repo today): No `backlog/` directory, `docs/plans/` has several `status: active` plans → skill renders the plan-based fallback list, states that it's falling back, emits banner.
+- Edge case: Task with unresolved dependency → skill annotates the line with `(blocked by <ID>)` rather than hiding it.
+- Edge case: Empty backlog and empty plans → skill congratulates the user, suggests `/ce-ideate` or `/ce-plan`, still emits banner.
+- Edge case: `--top 3` argument → skill truncates the top-priority group to 3 items.
+- Edge case: Task title contains a `|` pipe character → skill escapes it as `\|`.
+- Error path: `backlog` CLI is present but returns a non-zero exit code → skill reports the error honestly, falls back to `docs/plans/`, emits banner.
+
+**Verification:**
+- Skill file parses as valid Markdown + YAML frontmatter.
+- No string matches for `mcp__backlog__` or other Claude-only tools remain in the file.
+- Invoking `/takeoff` in ATV-starterkit today (no backlog present) returns the `docs/plans/` fallback list with the banner.
+
+- [ ] **Unit 3: Index the new skills in `.github/copilot-instructions.md`**
+
+**Goal:** Make the skills discoverable via the repo's Copilot onboarding file.
+
+**Requirements:** R7
+
+**Dependencies:** Units 1 and 2
+
+**Files:**
+- Modify: `.github/copilot-instructions.md`
+
+**Approach:**
+- Add a new subsection under the top-level workflow list (alongside `/ce-brainstorm` etc.) titled "Session bookends" with two bullets:
+  - `/takeoff` — Prioritized backlog briefing to start a session
+  - `/land` — Commit → push → PR → handoff to finish a session
+- Keep the phrasing terse to match the rest of the file.
+- Do not restructure or renumber existing sections.
+
+**Patterns to follow:**
+- Current bullet shape in `.github/copilot-instructions.md` (single-line, em-dash-separated).
+
+**Test scenarios:**
+- Test expectation: none — documentation-only change, verified by visual inspection and markdown lint.
+
+**Verification:**
+- Diff is limited to the new section; no unrelated lines changed.
+- File still renders cleanly on GitHub.
+
+## System-Wide Impact
+
+- **Interaction graph:** Both skills shell out to `git` and `gh`; `/land` also optionally to `backlog`. No runtime callbacks or observers.
+- **Error propagation:** Failures in `/land` quality gates or `git push` must halt the routine without emitting the success banner. `/takeoff` failures should prefer graceful degradation (fallback to `docs/plans/`) over halting.
+- **State lifecycle risks:** `/land` must not leave partial state — if push fails after commit, it must surface that cleanly so the user can resolve and re-run. The "never `git add -A`" rule protects against accidental secret staging.
+- **API surface parity:** Other Copilot skills in this repo invoke `gh pr view` with exit-code capture (see `git-commit-push-pr`). `/land` should use the same idiom rather than inventing a new one.
+- **Integration coverage:** The `/land` → `git-commit-push-pr` reference relationship should be tested end-to-end at least once; drift between the two skills is a likely future bug source.
+- **Unchanged invariants:** Existing skills (`git-commit`, `git-commit-push-pr`, `ce-*`) are untouched. Existing `docs/plans/` naming convention is respected by `/takeoff`'s fallback. `AGENTS.md` and `.github/copilot-instructions.md` conventions remain authoritative.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Copilot's slash-command invocation semantics differ subtly from Claude's and cause a skill to not trigger | Mirror the frontmatter + directory-name shape of existing working skills (`git-commit`, `git-commit-push-pr`); smoke-test by invoking `/land` and `/takeoff` once after creation. |
+| `/land` runs `go build ./...` against a large module graph and stalls the session | Note the command's cost in the skill body; if it proves slow in practice, follow up with a targeted-test variant (e.g., `go build ./cmd/... ./pkg/...`) rather than blanket disabling the gate. |
+| `/land` is interpreted as "finish and merge" by a Copilot user or future automation | Keep the "NEVER merge the PR unless the user explicitly says 'merge this PR'" line in the Critical Rules section, verbatim, and repeat it in the description where users scan first. |
+| Drift between `/land`'s PR creation and `git-commit-push-pr`'s richer PR-body craft | `/land` references `git-commit-push-pr` as the source of truth for PR body conventions rather than restating them. Drift becomes a one-line skill update instead of two full rewrites. |
+| `/takeoff` fallback to `docs/plans/` surfaces too many stale plans and overwhelms the briefing | Filter to `status: active` frontmatter only; cap at the same default `--top 5` as the backlog path. |
+
+## Documentation / Operational Notes
+
+- Update `.github/copilot-instructions.md` (Unit 3) is the only documentation change required.
+- No rollout, feature-flag, or migration work. Skills take effect on the branch that introduces them.
+- Rollback is a `git revert` of the introducing commit — skills are additive and have no persistent state.
+
+## Sources & References
+
+- Source skill: `~/.claude/skills/land/SKILL.md`
+- Source skill: `~/.claude/skills/takeoff/SKILL.md`
+- Sibling pattern: `.github/skills/git-commit/SKILL.md`
+- Sibling pattern: `.github/skills/git-commit-push-pr/SKILL.md`
+- Repo conventions: `.github/copilot-instructions.md`, `AGENTS.md`


### PR DESCRIPTION
## Summary

Ports two Claude Code session-bookend skills into GitHub Copilot skills under `.github/skills/`:

- **`land/SKILL.md`** — Commit → push → PR → handoff. Never merges the PR.
- **`takeoff/SKILL.md`** — Prioritized backlog briefing at session start. Falls back to `docs/plans/` when no `backlog/` directory exists (the current state of this repo).

Also indexes the pair under a new **Session Bookends** section in `.github/copilot-instructions.md` so Copilot users discover them alongside the `/ce-*` workflows.

## Port notes

- **Claude-only tool references removed.** No `ExitWorktree`, `mcp__backlog__*`, or `AskUserQuestion`. Everything shells out to `git` / `gh` / `backlog` CLI.
- **Adaptive quality gates in `/land`** tuned for this repo: Go at root (`go build ./... && go vet ./...`), optional npm subproject (only when `npm/` files are staged/unstaged/untracked — quality gates run *before* commit, so `HEAD~1` wouldn't work). Generic fallbacks preserved for portability.
- **No `|| true` swallowing failures.** A failing gate halts the routine and suppresses the success banner — matches the original's critical rules.
- **PR body craft delegated to `git-commit-push-pr`** rather than duplicated — keeps the two skills in sync.
- **Signature UX preserved:** banners (`🛬 PLANE LANDED — NICE WORK` / `✈️ TAKE OFF — NOW AT 30,000 FEET`), bullet-group shape with emoji headers (🛫🔵🟢⚪🔴), em-dash separator, `never merge the PR` critical rule, `never git add -A` rule, `never stop before push` rule.
- **Takeoff fallback** filters `docs/plans/*.md` by `status: active` frontmatter via `awk`/`grep` — verified on-repo, returns the 6 active plans cleanly.

## Plan

Full planning doc: [`docs/plans/2026-04-24-002-feat-port-land-takeoff-skills-copilot-plan.md`](docs/plans/2026-04-24-002-feat-port-land-takeoff-skills-copilot-plan.md)

## Test plan

- [ ] Invoke `/takeoff` in this repo → produces `docs/plans/` fallback list with banner
- [ ] Invoke `/land` on a dummy branch with a single file change → commit + push + PR + banner
- [ ] Invoke `/land` with a broken `go build` → routine halts before commit, no banner
- [ ] Verify `/land` inside a git worktree → emits prose worktree note, does not attempt tool-based teardown
- [ ] Verify no residual Claude-only tool references: `grep -rE 'ExitWorktree|mcp__backlog__|AskUserQuestion' .github/skills/{land,takeoff}/` returns nothing