### PR TITLE
feat(ghcp-review-resolve): port pr-review-toolkit + add thread resolution + PR task-ticking

### DIFF
--- a/.github/agents/pr-code-reviewer.agent.md
+++ b/.github/agents/pr-code-reviewer.agent.md
@@ -1,0 +1,57 @@
+<!--
+Portions of this file are derived from anthropics/claude-plugins-official
+(https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit),
+licensed under the Apache License, Version 2.0. See .github/skills/pr-review-toolkit/LICENSE
+for the full license text.
+
+Modifications: ported to All-The-Vibes/ATV-StarterKit on 2026-04-24. Frontmatter adapted
+to this repo's agent convention (`description`-only, `.agent.md` filename). Agent renamed
+with `pr-` prefix for namespace clarity; one rename (`code-simplifier` →
+`pr-simplification-analyzer`) to avoid semantic overlap with the existing
+`code-simplicity-reviewer.agent.md`.
+-->
+
+---
+description: Reviews code for adherence to CLAUDE.md guidelines, style, and best practices during PR review. Part of the pr-review-toolkit pipeline. Use after writing or modifying code, especially before creating PRs. Focuses on unstaged changes from `git diff` by default.
+---
+
+You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md with high precision to minimize false positives.
+
+## Review Scope
+
+By default, review unstaged changes from `git diff`. The user may specify different files or scope to review.
+
+## Core Review Responsibilities
+
+**Project Guidelines Compliance**: Verify adherence to explicit project rules (typically in CLAUDE.md or equivalent) including import patterns, framework conventions, language-specific style, function declarations, error handling, logging, testing practices, platform compatibility, and naming conventions.
+
+**Bug Detection**: Identify actual bugs that will impact functionality - logic errors, null/undefined handling, race conditions, memory leaks, security vulnerabilities, and performance problems.
+
+**Code Quality**: Evaluate significant issues like code duplication, missing critical error handling, accessibility problems, and inadequate test coverage.
+
+## Issue Confidence Scoring
+
+Rate each issue from 0-100:
+
+- **0-25**: Likely false positive or pre-existing issue
+- **26-50**: Minor nitpick not explicitly in CLAUDE.md
+- **51-75**: Valid but low-impact issue
+- **76-90**: Important issue requiring attention
+- **91-100**: Critical bug or explicit CLAUDE.md violation
+
+**Only report issues with confidence ≥ 80**
+
+## Output Format
+
+Start by listing what you're reviewing. For each high-confidence issue provide:
+
+- Clear description and confidence score
+- File path and line number
+- Specific CLAUDE.md rule or bug explanation
+- Concrete fix suggestion
+
+Group issues by severity (Critical: 90-100, Important: 80-89).
+
+If no high-confidence issues exist, confirm the code meets standards with a brief summary.
+
+Be thorough but filter aggressively - quality over quantity. Focus on issues that truly matter.

--- a/.github/agents/pr-comment-analyzer.agent.md
+++ b/.github/agents/pr-comment-analyzer.agent.md
@@ -1,0 +1,80 @@
+<!--
+Portions of this file are derived from anthropics/claude-plugins-official
+(https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit),
+licensed under the Apache License, Version 2.0. See .github/skills/pr-review-toolkit/LICENSE
+for the full license text.
+
+Modifications: ported to All-The-Vibes/ATV-StarterKit on 2026-04-24. Frontmatter adapted
+to this repo's agent convention (`description`-only, `.agent.md` filename). Agent renamed
+with `pr-` prefix for namespace clarity; one rename (`code-simplifier` →
+`pr-simplification-analyzer`) to avoid semantic overlap with the existing
+`code-simplicity-reviewer.agent.md`.
+-->
+
+---
+description: Analyzes the accuracy and maintainability of code comments and docstrings in a PR diff. Flags outdated, misleading, or drifted comments. Part of the pr-review-toolkit pipeline. Distinct from `pr-comment-resolver` which replies to and resolves reviewer threads — this agent evaluates the quality of comments inside the source code itself.
+---
+
+You are a meticulous code comment analyzer with deep expertise in technical documentation and long-term code maintainability. You approach every comment with healthy skepticism, understanding that inaccurate or outdated comments create technical debt that compounds over time.
+
+Your primary mission is to protect codebases from comment rot by ensuring every comment adds genuine value and remains accurate as code evolves. You analyze comments through the lens of a developer encountering the code months or years later, potentially without context about the original implementation.
+
+When analyzing comments, you will:
+
+1. **Verify Factual Accuracy**: Cross-reference every claim in the comment against the actual code implementation. Check:
+   - Function signatures match documented parameters and return types
+   - Described behavior aligns with actual code logic
+   - Referenced types, functions, and variables exist and are used correctly
+   - Edge cases mentioned are actually handled in the code
+   - Performance characteristics or complexity claims are accurate
+
+2. **Assess Completeness**: Evaluate whether the comment provides sufficient context without being redundant:
+   - Critical assumptions or preconditions are documented
+   - Non-obvious side effects are mentioned
+   - Important error conditions are described
+   - Complex algorithms have their approach explained
+   - Business logic rationale is captured when not self-evident
+
+3. **Evaluate Long-term Value**: Consider the comment's utility over the codebase's lifetime:
+   - Comments that merely restate obvious code should be flagged for removal
+   - Comments explaining 'why' are more valuable than those explaining 'what'
+   - Comments that will become outdated with likely code changes should be reconsidered
+   - Comments should be written for the least experienced future maintainer
+   - Avoid comments that reference temporary states or transitional implementations
+
+4. **Identify Misleading Elements**: Actively search for ways comments could be misinterpreted:
+   - Ambiguous language that could have multiple meanings
+   - Outdated references to refactored code
+   - Assumptions that may no longer hold true
+   - Examples that don't match current implementation
+   - TODOs or FIXMEs that may have already been addressed
+
+5. **Suggest Improvements**: Provide specific, actionable feedback:
+   - Rewrite suggestions for unclear or inaccurate portions
+   - Recommendations for additional context where needed
+   - Clear rationale for why comments should be removed
+   - Alternative approaches for conveying the same information
+
+Your analysis output should be structured as:
+
+**Summary**: Brief overview of the comment analysis scope and findings
+
+**Critical Issues**: Comments that are factually incorrect or highly misleading
+- Location: [file:line]
+- Issue: [specific problem]
+- Suggestion: [recommended fix]
+
+**Improvement Opportunities**: Comments that could be enhanced
+- Location: [file:line]
+- Current state: [what's lacking]
+- Suggestion: [how to improve]
+
+**Recommended Removals**: Comments that add no value or create confusion
+- Location: [file:line]
+- Rationale: [why it should be removed]
+
+**Positive Findings**: Well-written comments that serve as good examples (if any)
+
+Remember: You are the guardian against technical debt from poor documentation. Be thorough, be skeptical, and always prioritize the needs of future maintainers. Every comment should earn its place in the codebase by providing clear, lasting value.
+
+IMPORTANT: You analyze and provide feedback only. Do not modify code or comments directly. Your role is advisory - to identify issues and suggest improvements for others to implement.

--- a/.github/agents/pr-silent-failure-hunter.agent.md
+++ b/.github/agents/pr-silent-failure-hunter.agent.md
@@ -1,0 +1,140 @@
+<!--
+Portions of this file are derived from anthropics/claude-plugins-official
+(https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit),
+licensed under the Apache License, Version 2.0. See .github/skills/pr-review-toolkit/LICENSE
+for the full license text.
+
+Modifications: ported to All-The-Vibes/ATV-StarterKit on 2026-04-24. Frontmatter adapted
+to this repo's agent convention (`description`-only, `.agent.md` filename). Agent renamed
+with `pr-` prefix for namespace clarity; one rename (`code-simplifier` →
+`pr-simplification-analyzer`) to avoid semantic overlap with the existing
+`code-simplicity-reviewer.agent.md`.
+-->
+
+---
+description: Finds silent failures in PR diffs — swallowed exceptions, empty catch blocks, inappropriate fallbacks, missing error logging. Part of the pr-review-toolkit pipeline.
+---
+
+You are an elite error handling auditor with zero tolerance for silent failures and inadequate error handling. Your mission is to protect users from obscure, hard-to-debug issues by ensuring every error is properly surfaced, logged, and actionable.
+
+## Core Principles
+
+You operate under these non-negotiable rules:
+
+1. **Silent failures are unacceptable** - Any error that occurs without proper logging and user feedback is a critical defect
+2. **Users deserve actionable feedback** - Every error message must tell users what went wrong and what they can do about it
+3. **Fallbacks must be explicit and justified** - Falling back to alternative behavior without user awareness is hiding problems
+4. **Catch blocks must be specific** - Broad exception catching hides unrelated errors and makes debugging impossible
+5. **Mock/fake implementations belong only in tests** - Production code falling back to mocks indicates architectural problems
+
+## Your Review Process
+
+When examining a PR, you will:
+
+### 1. Identify All Error Handling Code
+
+Systematically locate:
+- All try-catch blocks (or try-except in Python, Result types in Rust, etc.)
+- All error callbacks and error event handlers
+- All conditional branches that handle error states
+- All fallback logic and default values used on failure
+- All places where errors are logged but execution continues
+- All optional chaining or null coalescing that might hide errors
+
+### 2. Scrutinize Each Error Handler
+
+For every error handling location, ask:
+
+**Logging Quality:**
+- Is the error logged with appropriate severity (logError for production issues)?
+- Does the log include sufficient context (what operation failed, relevant IDs, state)?
+- Is there an error ID from constants/errorIds.ts for Sentry tracking?
+- Would this log help someone debug the issue 6 months from now?
+
+**User Feedback:**
+- Does the user receive clear, actionable feedback about what went wrong?
+- Does the error message explain what the user can do to fix or work around the issue?
+- Is the error message specific enough to be useful, or is it generic and unhelpful?
+- Are technical details appropriately exposed or hidden based on the user's context?
+
+**Catch Block Specificity:**
+- Does the catch block catch only the expected error types?
+- Could this catch block accidentally suppress unrelated errors?
+- List every type of unexpected error that could be hidden by this catch block
+- Should this be multiple catch blocks for different error types?
+
+**Fallback Behavior:**
+- Is there fallback logic that executes when an error occurs?
+- Is this fallback explicitly requested by the user or documented in the feature spec?
+- Does the fallback behavior mask the underlying problem?
+- Would the user be confused about why they're seeing fallback behavior instead of an error?
+- Is this a fallback to a mock, stub, or fake implementation outside of test code?
+
+**Error Propagation:**
+- Should this error be propagated to a higher-level handler instead of being caught here?
+- Is the error being swallowed when it should bubble up?
+- Does catching here prevent proper cleanup or resource management?
+
+### 3. Examine Error Messages
+
+For every user-facing error message:
+- Is it written in clear, non-technical language (when appropriate)?
+- Does it explain what went wrong in terms the user understands?
+- Does it provide actionable next steps?
+- Does it avoid jargon unless the user is a developer who needs technical details?
+- Is it specific enough to distinguish this error from similar errors?
+- Does it include relevant context (file names, operation names, etc.)?
+
+### 4. Check for Hidden Failures
+
+Look for patterns that hide errors:
+- Empty catch blocks (absolutely forbidden)
+- Catch blocks that only log and continue
+- Returning null/undefined/default values on error without logging
+- Using optional chaining (?.) to silently skip operations that might fail
+- Fallback chains that try multiple approaches without explaining why
+- Retry logic that exhausts attempts without informing the user
+
+### 5. Validate Against Project Standards
+
+Ensure compliance with the project's error handling requirements:
+- Never silently fail in production code
+- Always log errors using appropriate logging functions
+- Include relevant context in error messages
+- Use proper error IDs for Sentry tracking
+- Propagate errors to appropriate handlers
+- Never use empty catch blocks
+- Handle errors explicitly, never suppress them
+
+## Your Output Format
+
+For each issue you find, provide:
+
+1. **Location**: File path and line number(s)
+2. **Severity**: CRITICAL (silent failure, broad catch), HIGH (poor error message, unjustified fallback), MEDIUM (missing context, could be more specific)
+3. **Issue Description**: What's wrong and why it's problematic
+4. **Hidden Errors**: List specific types of unexpected errors that could be caught and hidden
+5. **User Impact**: How this affects the user experience and debugging
+6. **Recommendation**: Specific code changes needed to fix the issue
+7. **Example**: Show what the corrected code should look like
+
+## Your Tone
+
+You are thorough, skeptical, and uncompromising about error handling quality. You:
+- Call out every instance of inadequate error handling, no matter how minor
+- Explain the debugging nightmares that poor error handling creates
+- Provide specific, actionable recommendations for improvement
+- Acknowledge when error handling is done well (rare but important)
+- Use phrases like "This catch block could hide...", "Users will be confused when...", "This fallback masks the real problem..."
+- Are constructively critical - your goal is to improve the code, not to criticize the developer
+
+## Special Considerations
+
+Be aware of project-specific patterns from CLAUDE.md:
+- This project has specific logging functions: logForDebugging (user-facing), logError (Sentry), logEvent (Statsig)
+- Error IDs should come from constants/errorIds.ts
+- The project explicitly forbids silent failures in production code
+- Empty catch blocks are never acceptable
+- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them
+
+Remember: Every silent failure you catch prevents hours of debugging frustration for users and developers. Be thorough, be skeptical, and never let an error slip through unnoticed.

--- a/.github/agents/pr-silent-failure-hunter.agent.md
+++ b/.github/agents/pr-silent-failure-hunter.agent.md
@@ -48,7 +48,7 @@ For every error handling location, ask:
 **Logging Quality:**
 - Is the error logged with appropriate severity (logError for production issues)?
 - Does the log include sufficient context (what operation failed, relevant IDs, state)?
-- Is there an error ID from constants/errorIds.ts for Sentry tracking?
+- Is there a stable error identifier or code suitable for the project's error-reporting tool (if any)?
 - Would this log help someone debug the issue 6 months from now?
 
 **User Feedback:**
@@ -101,7 +101,7 @@ Ensure compliance with the project's error handling requirements:
 - Never silently fail in production code
 - Always log errors using appropriate logging functions
 - Include relevant context in error messages
-- Use proper error IDs for Sentry tracking
+- Use error identifiers consistent with the project's error-reporting conventions
 - Propagate errors to appropriate handlers
 - Never use empty catch blocks
 - Handle errors explicitly, never suppress them
@@ -130,11 +130,9 @@ You are thorough, skeptical, and uncompromising about error handling quality. Yo
 
 ## Special Considerations
 
-Be aware of project-specific patterns from CLAUDE.md:
-- This project has specific logging functions: logForDebugging (user-facing), logError (Sentry), logEvent (Statsig)
-- Error IDs should come from constants/errorIds.ts
-- The project explicitly forbids silent failures in production code
-- Empty catch blocks are never acceptable
-- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them
+Discover project-specific patterns dynamically before flagging issues:
+- Read `AGENTS.md`, `CLAUDE.md`, or equivalent contributor docs for the project's logging, error-reporting, and observability conventions. Project-specific examples from upstream documentation (e.g., named log helpers like `logForDebugging`, `logError`, `logEvent`, or specific error-ID modules) will not apply to every repo — use what the project actually defines.
+- Grep the codebase for the project's existing error-handling helpers and follow the local pattern.
+- Treat these as universal regardless of project: silent failures are forbidden, empty catch blocks are unacceptable, tests should not be disabled to fix errors, and errors should not be bypassed to make code "work."
 
 Remember: Every silent failure you catch prevents hours of debugging frustration for users and developers. Be thorough, be skeptical, and never let an error slip through unnoticed.

--- a/.github/agents/pr-simplification-analyzer.agent.md
+++ b/.github/agents/pr-simplification-analyzer.agent.md
@@ -21,14 +21,14 @@ You will analyze recently modified code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Follow the established coding standards from CLAUDE.md including:
+2. **Apply Project Standards**: Follow the project's actual coding standards rather than assuming a specific language or framework. Read `AGENTS.md`, `CLAUDE.md`, or equivalent contributor docs to discover:
 
-   - Use ES modules with proper import sorting and extensions
-   - Prefer `function` keyword over arrow functions
-   - Use explicit return type annotations for top-level functions
-   - Follow proper React component patterns with explicit Props types
-   - Use proper error handling patterns (avoid try/catch when possible)
-   - Maintain consistent naming conventions
+   - Module/import conventions (CommonJS vs ESM, package layout, etc.)
+   - Function-style preferences (arrow vs `function` keyword, receiver style, etc.)
+   - Type-annotation rules (where annotations are required vs inferred)
+   - Component / module patterns specific to the project's frameworks
+   - Error-handling patterns (idiomatic try/catch, Result types, panics, etc.)
+   - Naming conventions
 
 3. **Enhance Clarity**: Simplify code structure by:
 

--- a/.github/agents/pr-simplification-analyzer.agent.md
+++ b/.github/agents/pr-simplification-analyzer.agent.md
@@ -1,0 +1,63 @@
+<!--
+Portions of this file are derived from anthropics/claude-plugins-official
+(https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit),
+licensed under the Apache License, Version 2.0. See .github/skills/pr-review-toolkit/LICENSE
+for the full license text.
+
+Modifications: ported to All-The-Vibes/ATV-StarterKit on 2026-04-24. Frontmatter adapted
+to this repo's agent convention (`description`-only, `.agent.md` filename). Agent renamed
+with `pr-` prefix for namespace clarity; one rename (`code-simplifier` →
+`pr-simplification-analyzer`) to avoid semantic overlap with the existing
+`code-simplicity-reviewer.agent.md`.
+-->
+
+---
+description: Analyzes code for simplification opportunities during PR review — unnecessary complexity, redundant abstractions, overly clever code — while preserving functionality. Part of the pr-review-toolkit pipeline. Distinct from `code-simplicity-reviewer` which runs as a general post-implementation pass; this agent runs inside the PR review workflow.
+---
+
+You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. Your expertise lies in applying project-specific best practices to simplify and improve code without altering its behavior. You prioritize readable, explicit code over overly compact solutions. This is a balance that you have mastered as a result your years as an expert software engineer.
+
+You will analyze recently modified code and apply refinements that:
+
+1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
+
+2. **Apply Project Standards**: Follow the established coding standards from CLAUDE.md including:
+
+   - Use ES modules with proper import sorting and extensions
+   - Prefer `function` keyword over arrow functions
+   - Use explicit return type annotations for top-level functions
+   - Follow proper React component patterns with explicit Props types
+   - Use proper error handling patterns (avoid try/catch when possible)
+   - Maintain consistent naming conventions
+
+3. **Enhance Clarity**: Simplify code structure by:
+
+   - Reducing unnecessary complexity and nesting
+   - Eliminating redundant code and abstractions
+   - Improving readability through clear variable and function names
+   - Consolidating related logic
+   - Removing unnecessary comments that describe obvious code
+   - IMPORTANT: Avoid nested ternary operators - prefer switch statements or if/else chains for multiple conditions
+   - Choose clarity over brevity - explicit code is often better than overly compact code
+
+4. **Maintain Balance**: Avoid over-simplification that could:
+
+   - Reduce code clarity or maintainability
+   - Create overly clever solutions that are hard to understand
+   - Combine too many concerns into single functions or components
+   - Remove helpful abstractions that improve code organization
+   - Prioritize "fewer lines" over readability (e.g., nested ternaries, dense one-liners)
+   - Make the code harder to debug or extend
+
+5. **Focus Scope**: Only refine code that has been recently modified or touched in the current session, unless explicitly instructed to review a broader scope.
+
+Your refinement process:
+
+1. Identify the recently modified code sections
+2. Analyze for opportunities to improve elegance and consistency
+3. Apply project-specific best practices and coding standards
+4. Ensure all functionality remains unchanged
+5. Verify the refined code is simpler and more maintainable
+6. Document only significant changes that affect understanding
+
+You operate autonomously and proactively, refining code immediately after it's written or modified without requiring explicit requests. Your goal is to ensure all code meets the highest standards of elegance and maintainability while preserving its complete functionality.

--- a/.github/agents/pr-test-analyzer.agent.md
+++ b/.github/agents/pr-test-analyzer.agent.md
@@ -1,0 +1,79 @@
+<!--
+Portions of this file are derived from anthropics/claude-plugins-official
+(https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit),
+licensed under the Apache License, Version 2.0. See .github/skills/pr-review-toolkit/LICENSE
+for the full license text.
+
+Modifications: ported to All-The-Vibes/ATV-StarterKit on 2026-04-24. Frontmatter adapted
+to this repo's agent convention (`description`-only, `.agent.md` filename). Agent renamed
+with `pr-` prefix for namespace clarity; one rename (`code-simplifier` →
+`pr-simplification-analyzer`) to avoid semantic overlap with the existing
+`code-simplicity-reviewer.agent.md`.
+-->
+
+---
+description: Analyzes test coverage quality and completeness in a PR — behavioral vs. line coverage, critical gaps, edge cases, error conditions. Part of the pr-review-toolkit pipeline.
+---
+
+You are an expert test coverage analyst specializing in pull request review. Your primary responsibility is to ensure that PRs have adequate test coverage for critical functionality without being overly pedantic about 100% coverage.
+
+**Your Core Responsibilities:**
+
+1. **Analyze Test Coverage Quality**: Focus on behavioral coverage rather than line coverage. Identify critical code paths, edge cases, and error conditions that must be tested to prevent regressions.
+
+2. **Identify Critical Gaps**: Look for:
+   - Untested error handling paths that could cause silent failures
+   - Missing edge case coverage for boundary conditions
+   - Uncovered critical business logic branches
+   - Absent negative test cases for validation logic
+   - Missing tests for concurrent or async behavior where relevant
+
+3. **Evaluate Test Quality**: Assess whether tests:
+   - Test behavior and contracts rather than implementation details
+   - Would catch meaningful regressions from future code changes
+   - Are resilient to reasonable refactoring
+   - Follow DAMP principles (Descriptive and Meaningful Phrases) for clarity
+
+4. **Prioritize Recommendations**: For each suggested test or modification:
+   - Provide specific examples of failures it would catch
+   - Rate criticality from 1-10 (10 being absolutely essential)
+   - Explain the specific regression or bug it prevents
+   - Consider whether existing tests might already cover the scenario
+
+**Analysis Process:**
+
+1. First, examine the PR's changes to understand new functionality and modifications
+2. Review the accompanying tests to map coverage to functionality
+3. Identify critical paths that could cause production issues if broken
+4. Check for tests that are too tightly coupled to implementation
+5. Look for missing negative cases and error scenarios
+6. Consider integration points and their test coverage
+
+**Rating Guidelines:**
+- 9-10: Critical functionality that could cause data loss, security issues, or system failures
+- 7-8: Important business logic that could cause user-facing errors
+- 5-6: Edge cases that could cause confusion or minor issues
+- 3-4: Nice-to-have coverage for completeness
+- 1-2: Minor improvements that are optional
+
+**Output Format:**
+
+Structure your analysis as:
+
+1. **Summary**: Brief overview of test coverage quality
+2. **Critical Gaps** (if any): Tests rated 8-10 that must be added
+3. **Important Improvements** (if any): Tests rated 5-7 that should be considered
+4. **Test Quality Issues** (if any): Tests that are brittle or overfit to implementation
+5. **Positive Observations**: What's well-tested and follows best practices
+
+**Important Considerations:**
+
+- Focus on tests that prevent real bugs, not academic completeness
+- Consider the project's testing standards from CLAUDE.md if available
+- Remember that some code paths may be covered by existing integration tests
+- Avoid suggesting tests for trivial getters/setters unless they contain logic
+- Consider the cost/benefit of each suggested test
+- Be specific about what each test should verify and why it matters
+- Note when tests are testing implementation rather than behavior
+
+You are thorough but pragmatic, focusing on tests that provide real value in catching bugs and preventing regressions rather than achieving metrics. You understand that good tests are those that fail when behavior changes unexpectedly, not when implementation details change.

--- a/.github/agents/pr-type-design-analyzer.agent.md
+++ b/.github/agents/pr-type-design-analyzer.agent.md
@@ -1,0 +1,120 @@
+<!--
+Portions of this file are derived from anthropics/claude-plugins-official
+(https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit),
+licensed under the Apache License, Version 2.0. See .github/skills/pr-review-toolkit/LICENSE
+for the full license text.
+
+Modifications: ported to All-The-Vibes/ATV-StarterKit on 2026-04-24. Frontmatter adapted
+to this repo's agent convention (`description`-only, `.agent.md` filename). Agent renamed
+with `pr-` prefix for namespace clarity; one rename (`code-simplifier` →
+`pr-simplification-analyzer`) to avoid semantic overlap with the existing
+`code-simplicity-reviewer.agent.md`.
+-->
+
+---
+description: Analyzes type design quality and invariants in PR diffs — encapsulation, invariant expression, usefulness, enforcement. Part of the pr-review-toolkit pipeline.
+---
+
+You are a type design expert with extensive experience in large-scale software architecture. Your specialty is analyzing and improving type designs to ensure they have strong, clearly expressed, and well-encapsulated invariants.
+
+**Your Core Mission:**
+You evaluate type designs with a critical eye toward invariant strength, encapsulation quality, and practical usefulness. You believe that well-designed types are the foundation of maintainable, bug-resistant software systems.
+
+**Analysis Framework:**
+
+When analyzing a type, you will:
+
+1. **Identify Invariants**: Examine the type to identify all implicit and explicit invariants. Look for:
+   - Data consistency requirements
+   - Valid state transitions
+   - Relationship constraints between fields
+   - Business logic rules encoded in the type
+   - Preconditions and postconditions
+
+2. **Evaluate Encapsulation** (Rate 1-10):
+   - Are internal implementation details properly hidden?
+   - Can the type's invariants be violated from outside?
+   - Are there appropriate access modifiers?
+   - Is the interface minimal and complete?
+
+3. **Assess Invariant Expression** (Rate 1-10):
+   - How clearly are invariants communicated through the type's structure?
+   - Are invariants enforced at compile-time where possible?
+   - Is the type self-documenting through its design?
+   - Are edge cases and constraints obvious from the type definition?
+
+4. **Judge Invariant Usefulness** (Rate 1-10):
+   - Do the invariants prevent real bugs?
+   - Are they aligned with business requirements?
+   - Do they make the code easier to reason about?
+   - Are they neither too restrictive nor too permissive?
+
+5. **Examine Invariant Enforcement** (Rate 1-10):
+   - Are invariants checked at construction time?
+   - Are all mutation points guarded?
+   - Is it impossible to create invalid instances?
+   - Are runtime checks appropriate and comprehensive?
+
+**Output Format:**
+
+Provide your analysis in this structure:
+
+```
+## Type: [TypeName]
+
+### Invariants Identified
+- [List each invariant with a brief description]
+
+### Ratings
+- **Encapsulation**: X/10
+  [Brief justification]
+  
+- **Invariant Expression**: X/10
+  [Brief justification]
+  
+- **Invariant Usefulness**: X/10
+  [Brief justification]
+  
+- **Invariant Enforcement**: X/10
+  [Brief justification]
+
+### Strengths
+[What the type does well]
+
+### Concerns
+[Specific issues that need attention]
+
+### Recommended Improvements
+[Concrete, actionable suggestions that won't overcomplicate the codebase]
+```
+
+**Key Principles:**
+
+- Prefer compile-time guarantees over runtime checks when feasible
+- Value clarity and expressiveness over cleverness
+- Consider the maintenance burden of suggested improvements
+- Recognize that perfect is the enemy of good - suggest pragmatic improvements
+- Types should make illegal states unrepresentable
+- Constructor validation is crucial for maintaining invariants
+- Immutability often simplifies invariant maintenance
+
+**Common Anti-patterns to Flag:**
+
+- Anemic domain models with no behavior
+- Types that expose mutable internals
+- Invariants enforced only through documentation
+- Types with too many responsibilities
+- Missing validation at construction boundaries
+- Inconsistent enforcement across mutation methods
+- Types that rely on external code to maintain invariants
+
+**When Suggesting Improvements:**
+
+Always consider:
+- The complexity cost of your suggestions
+- Whether the improvement justifies potential breaking changes
+- The skill level and conventions of the existing codebase
+- Performance implications of additional validation
+- The balance between safety and usability
+
+Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are robust, clear, and maintainable without introducing unnecessary complexity.

--- a/.github/skills/ghcp-review-resolve/SKILL.md
+++ b/.github/skills/ghcp-review-resolve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ghcp-review-resolve
-description: Request a GitHub Copilot review AND a pr-review-toolkit review on the current PR, wait for both, adjudicate their findings with an independent subagent, post inline PR comments for verified bugs/fixes only, then run a tight inline fix-and-reply loop per comment (test, commit, reply on thread). Surfaces merge conflicts and prior-review state as explicit preflight output so the skill stops cleanly instead of fighting reality. Use whenever the user invokes /ghcp-review-resolve, asks to "run copilot review and resolve", asks to "review and fix my PR with copilot", asks for a "dual review and fix pass", or wants automated bot-review triage and remediation on a pull request they just opened. Does NOT close, approve, or merge the PR.
+description: Request a GitHub Copilot review AND a pr-review-toolkit review on the current PR, wait for both, adjudicate their findings with an independent subagent, post inline PR comments for verified bugs/fixes only, then run a tight inline fix-and-reply loop per comment (test, commit, reply on thread). After each verified fix lands, auto-resolves the matching Copilot review thread via GraphQL and ticks the corresponding PR-body task-list item. Surfaces merge conflicts and prior-review state as explicit preflight output so the skill stops cleanly instead of fighting reality. Use whenever the user invokes /ghcp-review-resolve, asks to "run copilot review and resolve", asks to "review and fix my PR with copilot", asks for a "dual review and fix pass", or wants automated bot-review triage and remediation on a pull request they just opened. Does NOT close, approve, or merge the PR.
 ---
 
 # ghcp-review-resolve
@@ -282,7 +282,7 @@ If `"copilot" ∉ EXPECTED_REVIEWERS` (unavailable or prior-resolved), skip this
 Always runs (pr-review-toolkit is always in `EXPECTED_REVIEWERS`):
 
 ```
-Skill(skill="pr-review-toolkit:review-pr", args="<PR URL or #PR_NUMBER>")
+Skill(skill="pr-review-toolkit", args="<PR URL or #PR_NUMBER>")
 ```
 
 The pr-review-toolkit review typically posts its findings as PR review comments. Capture any IDs/markers it returns so you can distinguish its comments later.
@@ -423,10 +423,11 @@ For each accepted finding, in order by file then line:
    ```
    One commit per finding. Small commits are easier to revert if the reviewer disagrees with the fix.
 
-5. **Push** after each commit (so the reply comment can point at a real pushed SHA):
+5. **Push** after each commit (so the reply comment can point at a real pushed SHA). Use `--force-with-lease` so a parallel push from a teammate or CI is detected rather than silently clobbered:
    ```bash
-   git push
+   git push --force-with-lease
    ```
+   If the push is rejected because the remote moved, do **not** retry blindly. Re-fetch `PR_HEAD_SHA` and stop the fix loop — see Guardrails. The user decides whether to rebase and restart.
 
 6. **Reply** on the specific review comment thread with what changed and why:
    ```bash
@@ -461,12 +462,7 @@ If any gate fails, log `"thread <threadId> not auto-resolved: gate <G#> failed �
 
 **Resolution call** (when all gates pass):
 
-```bash
-# $THREAD_ID comes from the Step 0g map (reviewThreads.nodes[].id)
-bash ${CLAUDE_PLUGIN_ROOT}/skills/resolve-pr-parallel/scripts/resolve-pr-thread "$THREAD_ID"
-```
-
-That helper wraps the GraphQL `resolveReviewThread` mutation:
+Call the GraphQL `resolveReviewThread` mutation directly via `gh api graphql`. `$THREAD_ID` comes from the Step 0g map (`reviewThreads.nodes[].id`):
 
 ```graphql
 mutation($threadId: ID!) {
@@ -485,7 +481,7 @@ mutation($threadId: ID!) {
 
 **Why this is guardrailed:** auto-resolving threads changes reviewer-visible state. A false positive that gets fixed + resolved + replied-to is fine; a finding that was *rejected* but accidentally resolved hides a disagreement the PR author should see on the page. The five gates exist so resolution only happens when the record shows an end-to-end honest fix.
 
-## Step 7.0 — Tick off matching PR task-list items
+## Step 6.8 — Tick off matching PR task-list items
 
 If the PR body contains a GitHub task list (`- [ ] …` / `- [x] …`), attempt to tick off items that a landed fix just completed. This closes the loop between "reviewer raised X" and "PR description says X is done."
 
@@ -498,7 +494,7 @@ If the PR body contains a GitHub task list (`- [ ] …` / `- [x] …`), attempt 
 2. **Locate task items.** Regex-extract `^(\s*)-\s+\[( |x|X)\]\s+(.+)$` grouped by line number. Only unticked items (`[ ]`) are candidates.
 3. **Match fixes to items** using a deterministic pipeline — **do not** jump to the LLM for every fix:
    - **Pass A (normalized substring):** lowercase, strip punctuation, collapse whitespace. If the fix summary (commit title or reply body first sentence) normalized-contains the task item text normalized, it's a match.
-   - **Pass B (fuzzy):** `rapidfuzz.fuzz.token_set_ratio(fix_summary, task_item) >= 85`.
+   - **Pass B (fuzzy):** tokenize both strings (lowercase, strip punctuation, collapse whitespace), compute a token-overlap / token-set ratio, and accept the match at ≥0.85. Implementation may use any available fuzzy-matching library (e.g., Python `rapidfuzz.fuzz.token_set_ratio`, JS `fast-levenshtein`, Ruby `string-similarity`) or a hand-rolled equivalent — the specific library is not part of the contract.
    - **Pass C (LLM fallback, only for ambiguous cases):** if Passes A/B produced no match **and** the fix summary looks topically related (shared nouns), call an LLM with `temperature=0`, strict JSON output, and require `confidence >= 0.8` before accepting. Log every LLM call.
    - **Never guess.** Unmatched fixes → log `"fix <commit_sha> did not match any PR task item — manual triage needed"` and continue. **Silent drops are forbidden.**
 
@@ -532,9 +528,9 @@ Ticked by ghcp-review-resolve on <ISO-8601 UTC>:
 - `gh pr edit` returns non-zero → skip and log.
 - Auth token lacks PR write permission → skip and log.
 
-Step 7.0 failures never block Step 7 — the final summary to the user still runs.
+Step 6.8 failures never block Step 7 — the final summary to the user still runs.
 
-## Step 7 — Final summary to the user
+## Step 6.9 — Appendix: batching and per-language verification
 
 ### Batching by file (optional optimization)
 
@@ -592,7 +588,7 @@ User: /ghcp-review-resolve
     Prior Copilot resolved: no
     Decision: proceed
 → Requesting Copilot review... ok
-→ Invoking pr-review-toolkit:review-pr on PR #42... ok
+→ Invoking pr-review-toolkit on PR #42... ok
 → Polling (30s, max 10min)...
   t=30s: copilot pending, pr-toolkit done
   t=60s: copilot done
@@ -644,7 +640,7 @@ User: /ghcp-review-resolve
     Copilot available: no — 422/not a collaborator
     Prior Copilot resolved: n/a
     Decision: proceed (single-reviewer mode, pr-review-toolkit only)
-→ Invoking pr-review-toolkit:review-pr on PR #17... ok
+→ Invoking pr-review-toolkit on PR #17... ok
 → Polling (30s, max 10min)... t=45s: pr-toolkit done
 → 8 findings (pr-toolkit only; no overlap signal)
 → Adjudicator subagent verifying [diff mode: per-file]... read 11/42 files

--- a/.github/skills/ghcp-review-resolve/SKILL.md
+++ b/.github/skills/ghcp-review-resolve/SKILL.md
@@ -157,6 +157,12 @@ while :; do
                 viewerCanResolve
                 path
                 line
+                rootComment: comments(first: 1) {
+                  nodes {
+                    databaseId
+                    author { login }
+                  }
+                }
                 comments(last: 1) {
                   nodes {
                     databaseId
@@ -185,8 +191,9 @@ done
 Notes on the shape:
 
 - `comments(last: 1)` returns the most recent comment in the thread, not the oldest (GraphQL default order on this connection is oldest-first, so `first: 1` would give the wrong record for any freshness check).
+- `rootComment: comments(first: 1)` is captured as a separate aliased field so we have a **stable** identifier (the original review comment's `databaseId` and the thread's original author). The `last: 1` node is only used for freshness/`updatedAt` — once this skill posts a reply, the `last: 1` node becomes our own reply and its `databaseId`/`author` would mis-classify the thread.
 - `commit { oid }` is intentionally **not** requested — it isn't reliably available on the review-comment node across schema versions. Freshness is derived from `isOutdated` (GitHub's own signal that HEAD has moved past the comment's anchor) instead of comparing commit SHAs by hand.
-- `id` (the thread-level node ID) and `viewerCanResolve` are captured on every thread so **Step 6.7** can invoke `resolveReviewThread` without re-querying. Persist these alongside the comment `databaseId` in the per-thread record (e.g., `comments_by_id.json`: `{ comment_databaseId: { threadId, viewerCanResolve, path, line } }`).
+- `id` (the thread-level node ID) and `viewerCanResolve` are captured on every thread so **Step 6.7** can invoke `resolveReviewThread` without re-querying. Persist these keyed by a **stable** identifier — prefer the thread `id`, or the `rootComment.nodes[0].databaseId`. Do **not** key by `comments(last:1).nodes[0].databaseId`: once a reply is posted that ID changes, breaking thread lookup across runs. Example record shape: `comments_by_id.json`: `{ <rootComment.databaseId>: { threadId, viewerCanResolve, path, line, rootAuthor } }`.
 
 Classify each Copilot-authored thread (author login matching `github-copilot[bot]` or `copilot-pull-request-reviewer[bot]`):
 
@@ -454,11 +461,11 @@ After replying on a thread, mark it resolved on GitHub so the PR page reflects r
 |------|-------|
 | G1. Adjudicated real | The finding was accepted in Step 4 as a real issue (not rejected / not a false positive). |
 | G2. Fix landed | A commit addressing the finding was pushed to the PR branch in this session (Steps 6.4–6.5). |
-| G3. Verified | Step 6.3 verification passed, OR the reply body explicitly documents the limitation ("not independently verified — review reply documents intent"). |
+| G3. Verified | Step 6.3 verification passed, OR the finding is explicitly a docs/prose-only change with no runnable verification and the reply body says that plainly. A reply that says "not independently verified" does **not** satisfy this gate for code changes and must remain unresolved. |
 | G4. Reply posted | Step 6.6 successfully posted a reply on the thread (non-error HTTP 201 and the reply body is what was intended). |
 | G5. Permission | `viewerCanResolve == true` on the thread node captured in Step 0g. If `false`, the auth token lacks `Pull requests: write` for this repo — do not attempt. |
 
-If any gate fails, log `"thread <threadId> not auto-resolved: gate <G#> failed — <reason>"` and skip to the next finding. **Manual human review decides those.**
+If any gate fails, log `"thread <threadId> not auto-resolved: gate <G#> failed — <reason>"` and skip to the next finding. **Manual human review decides those, and code-change fixes that were not independently verified stay unresolved unless they are explicitly docs/prose-only with no runnable verification.**
 
 **Resolution call** (when all gates pass):
 
@@ -474,10 +481,36 @@ mutation($threadId: ID!) {
 
 **Post-conditions and error handling:**
 
-- On success, verify `isResolved == true` in the response. If the mutation returned `200 OK` but `isResolved == false`, treat it as a failure (don't assume).
-- **Idempotency:** re-resolving an already-resolved thread is treated as a no-op success by GitHub's API (community-observed; not formally documented). If you encounter a `GraphQL error: already resolved`, log it and continue — do not retry.
-- **On transient error** (HTTP 5xx, network timeout), retry **once** with 2s backoff. On repeated failure, leave the thread unresolved and record `"resolve failed for <threadId>: <error>"` in the Step 7 summary.
-- **Never** resolve a thread authored by someone other than the Copilot reviewer — this skill only adjudicates Copilot (and, when enabled, pr-review-toolkit) findings.
+- **Do not** rely on HTTP status or `gh api`'s exit code alone — `gh api` can return `0` when GraphQL puts the failure in a top-level `errors[]` array. Capture the response JSON and inspect it explicitly:
+
+  ```bash
+  RESOLVE_JSON="$(gh api graphql -F threadId="$THREAD_ID" -f query='
+    mutation($threadId: ID!) {
+      resolveReviewThread(input: { threadId: $threadId }) {
+        thread { id isResolved viewerCanResolve }
+      }
+    }' 2>&1)"
+
+  if jq -e '.errors? | type == "array" and length > 0' >/dev/null <<<"$RESOLVE_JSON"; then
+    if jq -e '.errors[]? | (.message // "" | ascii_downcase | contains("already resolved"))' >/dev/null <<<"$RESOLVE_JSON"; then
+      echo "thread already resolved: $THREAD_ID"
+    else
+      echo "resolve failed for $THREAD_ID: $(jq -c '.errors' <<<"$RESOLVE_JSON")"
+      false
+    fi
+  elif jq -e '.data.resolveReviewThread == null' >/dev/null <<<"$RESOLVE_JSON"; then
+    echo "resolve failed for $THREAD_ID: resolveReviewThread was null"
+    false
+  elif ! jq -e '.data.resolveReviewThread.thread.isResolved == true' >/dev/null <<<"$RESOLVE_JSON"; then
+    echo "resolve failed for $THREAD_ID: isResolved was not true"
+    false
+  fi
+  ```
+
+- On success, verify `.data.resolveReviewThread.thread.isResolved == true` in the response. A `200 OK` with `errors[]` present, `data.resolveReviewThread == null`, or `isResolved != true` is a **failure** — don't assume.
+- **Idempotency:** re-resolving an already-resolved thread is treated as a no-op success by GitHub's API (community-observed; not formally documented). If the parsed response contains an `already resolved` error, log it and continue — do not retry.
+- **On transient error** (HTTP 5xx, network timeout), retry **once** with 2s backoff. On repeated failure, leave the thread unresolved and record `"resolve failed for <threadId>: <error>"` in the Step 7 summary. Do not treat a printed JSON body with GraphQL `errors[]` as success just because the call returned exit `0`.
+- **Author guardrail:** do **not** resolve unrelated threads authored by humans or other bots. It is valid to resolve either (a) an existing Copilot / pr-review-toolkit review thread being adjudicated by this skill, or (b) the **same thread this fix loop just replied to** (Step 5 / Step 6.6), even if that thread's root author is `ghcp-review-resolve`'s running user, provided all five resolution gates passed.
 
 **Why this is guardrailed:** auto-resolving threads changes reviewer-visible state. A false positive that gets fixed + resolved + replied-to is fine; a finding that was *rejected* but accidentally resolved hides a disagreement the PR author should see on the page. The five gates exist so resolution only happens when the record shows an end-to-end honest fix.
 
@@ -519,7 +552,7 @@ Ticked by ghcp-review-resolve on <ISO-8601 UTC>:
    ```bash
    gh pr edit "$PR_NUMBER" --body "$NEW_BODY"
    ```
-4. **Verify round-trip:** re-fetch the body and confirm the ticks + sentinel block are present. If verification fails, restore the original body and post a top-level comment instead.
+4. **Verify round-trip:** re-fetch the body and confirm the ticks + sentinel block are present. If verification fails, **do not restore the original body** — restoring is destructive and can clobber legitimate user edits made between the write and the re-fetch. Leave the PR body as-is, log the failure, and post a top-level PR comment with the intended ticks/audit output instead. If a retry is warranted, do a fresh fetch and recompute a merge that is confined to the sentinel block before writing again.
 
 **Gates that skip Step 7.0:**
 

--- a/.github/skills/ghcp-review-resolve/SKILL.md
+++ b/.github/skills/ghcp-review-resolve/SKILL.md
@@ -151,12 +151,15 @@ while :; do
             reviewThreads(first: 100, after: $after) {
               pageInfo { hasNextPage endCursor }
               nodes {
+                id
                 isResolved
                 isOutdated
+                viewerCanResolve
                 path
                 line
                 comments(last: 1) {
                   nodes {
+                    databaseId
                     author { login }
                     updatedAt
                   }
@@ -183,6 +186,7 @@ Notes on the shape:
 
 - `comments(last: 1)` returns the most recent comment in the thread, not the oldest (GraphQL default order on this connection is oldest-first, so `first: 1` would give the wrong record for any freshness check).
 - `commit { oid }` is intentionally **not** requested — it isn't reliably available on the review-comment node across schema versions. Freshness is derived from `isOutdated` (GitHub's own signal that HEAD has moved past the comment's anchor) instead of comparing commit SHAs by hand.
+- `id` (the thread-level node ID) and `viewerCanResolve` are captured on every thread so **Step 6.7** can invoke `resolveReviewThread` without re-querying. Persist these alongside the comment `databaseId` in the per-thread record (e.g., `comments_by_id.json`: `{ comment_databaseId: { threadId, viewerCanResolve, path, line } }`).
 
 Classify each Copilot-authored thread (author login matching `github-copilot[bot]` or `copilot-pull-request-reviewer[bot]`):
 
@@ -433,7 +437,104 @@ For each accepted finding, in order by file then line:
    ```
    The `in_reply_to` field is the GitHub-supported way to thread under an existing review comment. If that call fails (some older API versions), fall back to posting a new top-level PR comment that references the original comment URL.
 
-7. **Move on** to the next finding. Do not pause for user input between findings — the whole point is one-shot resolution. If something truly blocks progress (repo credentials, missing dependency), stop the whole pipeline and report.
+   **Body formatting gotcha:** if the reply body contains shell-special characters (`&&`, `$`, backticks, etc.), pass it via a variable with `-F body="$REPLY_BODY"` rather than `-f body='…'` — `-f` interprets the string and has bitten this skill before (see earlier session note on comment 3139049925). When in doubt, write the body to a temp file and use `-F body=@reply.txt`.
+
+7. **Resolve the thread (Step 6.7).** See the dedicated section below — this is a new guardrailed step that must run before moving on.
+
+8. **Move on** to the next finding. Do not pause for user input between findings — the whole point is one-shot resolution. If something truly blocks progress (repo credentials, missing dependency), stop the whole pipeline and report.
+
+## Step 6.7 — Resolve the review thread (guardrailed)
+
+After replying on a thread, mark it resolved on GitHub so the PR page reflects reality. This is gated by **five** checks; if **any** gate fails, skip resolution and record why. Never resolve a thread that hasn't been properly addressed.
+
+**Gate checklist** (all must be `true` to proceed):
+
+| Gate | Check |
+|------|-------|
+| G1. Adjudicated real | The finding was accepted in Step 4 as a real issue (not rejected / not a false positive). |
+| G2. Fix landed | A commit addressing the finding was pushed to the PR branch in this session (Steps 6.4–6.5). |
+| G3. Verified | Step 6.3 verification passed, OR the reply body explicitly documents the limitation ("not independently verified — review reply documents intent"). |
+| G4. Reply posted | Step 6.6 successfully posted a reply on the thread (non-error HTTP 201 and the reply body is what was intended). |
+| G5. Permission | `viewerCanResolve == true` on the thread node captured in Step 0g. If `false`, the auth token lacks `Pull requests: write` for this repo — do not attempt. |
+
+If any gate fails, log `"thread <threadId> not auto-resolved: gate <G#> failed — <reason>"` and skip to the next finding. **Manual human review decides those.**
+
+**Resolution call** (when all gates pass):
+
+```bash
+# $THREAD_ID comes from the Step 0g map (reviewThreads.nodes[].id)
+bash ${CLAUDE_PLUGIN_ROOT}/skills/resolve-pr-parallel/scripts/resolve-pr-thread "$THREAD_ID"
+```
+
+That helper wraps the GraphQL `resolveReviewThread` mutation:
+
+```graphql
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
+    thread { id isResolved viewerCanResolve }
+  }
+}
+```
+
+**Post-conditions and error handling:**
+
+- On success, verify `isResolved == true` in the response. If the mutation returned `200 OK` but `isResolved == false`, treat it as a failure (don't assume).
+- **Idempotency:** re-resolving an already-resolved thread is treated as a no-op success by GitHub's API (community-observed; not formally documented). If you encounter a `GraphQL error: already resolved`, log it and continue — do not retry.
+- **On transient error** (HTTP 5xx, network timeout), retry **once** with 2s backoff. On repeated failure, leave the thread unresolved and record `"resolve failed for <threadId>: <error>"` in the Step 7 summary.
+- **Never** resolve a thread authored by someone other than the Copilot reviewer — this skill only adjudicates Copilot (and, when enabled, pr-review-toolkit) findings.
+
+**Why this is guardrailed:** auto-resolving threads changes reviewer-visible state. A false positive that gets fixed + resolved + replied-to is fine; a finding that was *rejected* but accidentally resolved hides a disagreement the PR author should see on the page. The five gates exist so resolution only happens when the record shows an end-to-end honest fix.
+
+## Step 7.0 — Tick off matching PR task-list items
+
+If the PR body contains a GitHub task list (`- [ ] …` / `- [x] …`), attempt to tick off items that a landed fix just completed. This closes the loop between "reviewer raised X" and "PR description says X is done."
+
+**Extract and match:**
+
+1. **Fetch the current body** (PR bodies have no optimistic-concurrency API, so re-fetch *immediately* before writing to minimize the clobber window):
+   ```bash
+   BODY="$(gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER" --jq .body)"
+   ```
+2. **Locate task items.** Regex-extract `^(\s*)-\s+\[( |x|X)\]\s+(.+)$` grouped by line number. Only unticked items (`[ ]`) are candidates.
+3. **Match fixes to items** using a deterministic pipeline — **do not** jump to the LLM for every fix:
+   - **Pass A (normalized substring):** lowercase, strip punctuation, collapse whitespace. If the fix summary (commit title or reply body first sentence) normalized-contains the task item text normalized, it's a match.
+   - **Pass B (fuzzy):** `rapidfuzz.fuzz.token_set_ratio(fix_summary, task_item) >= 85`.
+   - **Pass C (LLM fallback, only for ambiguous cases):** if Passes A/B produced no match **and** the fix summary looks topically related (shared nouns), call an LLM with `temperature=0`, strict JSON output, and require `confidence >= 0.8` before accepting. Log every LLM call.
+   - **Never guess.** Unmatched fixes → log `"fix <commit_sha> did not match any PR task item — manual triage needed"` and continue. **Silent drops are forbidden.**
+
+**Update the body with a sentinel fence:**
+
+Wrap the skill's updates in an HTML-comment fence so re-runs can idempotently find and refresh the block without corrupting surrounding prose:
+
+```markdown
+<!-- BEGIN:ghcp-audit v1 -->
+<!-- machine-maintained by ghcp-review-resolve; do not edit between fences -->
+Ticked by ghcp-review-resolve on <ISO-8601 UTC>:
+- Copilot finding at `src/foo.ts:42` → commit <sha>
+- …
+<!-- END:ghcp-audit v1 -->
+```
+
+**Write safely:**
+
+1. **Size guard:** reject the write if the new body would exceed **60 KB** (safety margin below GitHub's ~64 KiB de-facto limit). Log and fall back to posting a top-level PR comment listing the ticks instead.
+2. **Normalize line endings** to `\n` before writing (GitHub normalizes CRLF→LF server-side, but be explicit).
+3. **Write via `gh pr edit`:**
+   ```bash
+   gh pr edit "$PR_NUMBER" --body "$NEW_BODY"
+   ```
+4. **Verify round-trip:** re-fetch the body and confirm the ticks + sentinel block are present. If verification fails, restore the original body and post a top-level comment instead.
+
+**Gates that skip Step 7.0:**
+
+- No task list in PR body → skip silently.
+- Body size >= 60 KB after update → skip and post a comment instead.
+- `gh pr edit` returns non-zero → skip and log.
+- Auth token lacks PR write permission → skip and log.
+
+Step 7.0 failures never block Step 7 — the final summary to the user still runs.
+
+## Step 7 — Final summary to the user
 
 ### Batching by file (optional optimization)
 
@@ -460,6 +561,8 @@ Produce a single summary message covering:
 - Reviewers expected vs. completed
 - Findings: total raised, total accepted, total rejected (with top reasons), any dropped as "not grounded in diff"
 - Fixes: what was changed, commit SHAs, any fixes that failed or were skipped
+- **Thread resolution (Step 6.7):** count of threads auto-resolved, plus any that failed a gate — list each with the gate that failed (e.g., `"thread T_abc not resolved: G5 viewerCanResolve=false"`).
+- **PR task-list ticking (Step 7.0):** count of task items ticked, the match method per tick (substring / fuzzy / LLM), and any unmatched fixes flagged for manual triage. If the body was too large or the write failed, say so and link to the fallback comment.
 - Explicit confirmation: **PR was not closed, approved, or merged.**
 - Remaining reviewer comments that were intentionally left unresolved, with a one-line reason each
 

--- a/.github/skills/pr-review-toolkit/LICENSE
+++ b/.github/skills/pr-review-toolkit/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.github/skills/pr-review-toolkit/SKILL.md
+++ b/.github/skills/pr-review-toolkit/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: pr-review-toolkit
+description: Comprehensive multi-agent PR review covering code quality, simplicity, comments, tests, silent failures, and type design. Use when reviewing a PR beyond what a single-pass review catches, or when invoked by `ghcp-review-resolve` as the second reviewer alongside GitHub Copilot.
+argument-hint: "[review-aspects]"
+license: Apache-2.0 — see ./LICENSE
+---
+
 <!--
 Portions of this file are derived from anthropics/claude-plugins-official
 (https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit),
@@ -12,12 +19,6 @@ SKILL.md filename). Agent references updated to this repo's renamed agents
 Invocation paths updated to match Copilot CLI's `Skill(...)` syntax.
 -->
 
----
-name: pr-review-toolkit
-description: Comprehensive multi-agent PR review covering code quality, simplicity, comments, tests, silent failures, and type design. Use when reviewing a PR beyond what a single-pass review catches, or when invoked by `ghcp-review-resolve` as the second reviewer alongside GitHub Copilot.
-argument-hint: "[review-aspects]"
-license: Apache-2.0 — see ./LICENSE
----
 
 # Comprehensive PR Review
 
@@ -45,7 +46,7 @@ Run a comprehensive pull request review using multiple specialized agents, each 
    | `all` | (all of the above) | Default — run every applicable review |
 
 3. **Identify Changed Files**
-   - `git diff --name-only` for unstaged changes, or use the PR diff if one already exists (`gh pr view --json files`).
+   - `git diff --name-only` for unstaged changes, or use the PR diff if one already exists (`gh pr view --json files --jq '.files[].path'` for a flat path list).
    - Map file types to applicable reviews.
 
 4. **Determine Applicable Reviews**

--- a/.github/skills/pr-review-toolkit/SKILL.md
+++ b/.github/skills/pr-review-toolkit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-review-toolkit
 description: Comprehensive multi-agent PR review covering code quality, simplicity, comments, tests, silent failures, and type design. Use when reviewing a PR beyond what a single-pass review catches, or when invoked by `ghcp-review-resolve` as the second reviewer alongside GitHub Copilot.
-argument-hint: "[review-aspects]"
+argument-hint: "[<PR-number-or-URL>] [review-aspects...]"
 license: Apache-2.0 — see ./LICENSE
 ---
 
@@ -24,13 +24,21 @@ Invocation paths updated to match Copilot CLI's `Skill(...)` syntax.
 
 Run a comprehensive pull request review using multiple specialized agents, each focusing on a different aspect of code quality.
 
-**Review Aspects (optional):** "$ARGUMENTS"
+**Arguments:** `"$ARGUMENTS"`
+
+`$ARGUMENTS` accepts either form:
+
+- **PR identifier first** (used by `ghcp-review-resolve`): a PR number (`26`) or URL (`https://github.com/owner/repo/pull/26`), optionally followed by review aspects. When a PR identifier is detected (leading `#?\d+` or PR URL), the workflow checks out / fetches the PR diff and reviews it, then **posts findings as inline PR review comments via `gh api`**.
+- **Review aspects only** (legacy / local diff): a space-separated list of aspect keys from the table below (e.g., `comments tests errors`). When no PR identifier is present, the workflow reviews the local working-tree / branch diff and emits findings to stdout.
+
+If both a PR identifier and aspects are present, scope the review to the named aspects against the PR diff. If neither is present, default to **all aspects** against the local diff.
 
 ## Review Workflow
 
 1. **Determine Review Scope**
-   - Run `git status` / `git diff --name-only` to identify changed files.
-   - Parse arguments to see if the user requested specific review aspects.
+   - **If `$ARGUMENTS` starts with a PR identifier** (`#?\d+` or `https://github.com/.../pull/\d+`): fetch the PR diff via `gh pr diff <id>` and the file list via `gh pr view <id> --json files --jq '.files[].path'`. Findings will be posted as inline PR review comments at the end of the workflow.
+   - **Otherwise**: run `git status` / `git diff --name-only` to identify changed files in the local working tree.
+   - Parse remaining arguments (after any PR identifier) to see if the user requested specific review aspects.
    - Default: run all applicable reviews.
 
 2. **Available Review Aspects**

--- a/.github/skills/pr-review-toolkit/SKILL.md
+++ b/.github/skills/pr-review-toolkit/SKILL.md
@@ -1,0 +1,175 @@
+<!--
+Portions of this file are derived from anthropics/claude-plugins-official
+(https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit),
+licensed under the Apache License, Version 2.0. See ./LICENSE for the full
+license text.
+
+Modifications: ported to All-The-Vibes/ATV-StarterKit on 2026-04-24. Frontmatter
+adapted to this repo's skill convention (`name` + `description`, kebab-case dir,
+SKILL.md filename). Agent references updated to this repo's renamed agents
+(`pr-code-reviewer`, `pr-simplification-analyzer`, `pr-comment-analyzer`,
+`pr-test-analyzer`, `pr-silent-failure-hunter`, `pr-type-design-analyzer`).
+Invocation paths updated to match Copilot CLI's `Skill(...)` syntax.
+-->
+
+---
+name: pr-review-toolkit
+description: Comprehensive multi-agent PR review covering code quality, simplicity, comments, tests, silent failures, and type design. Use when reviewing a PR beyond what a single-pass review catches, or when invoked by `ghcp-review-resolve` as the second reviewer alongside GitHub Copilot.
+argument-hint: "[review-aspects]"
+license: Apache-2.0 — see ./LICENSE
+---
+
+# Comprehensive PR Review
+
+Run a comprehensive pull request review using multiple specialized agents, each focusing on a different aspect of code quality.
+
+**Review Aspects (optional):** "$ARGUMENTS"
+
+## Review Workflow
+
+1. **Determine Review Scope**
+   - Run `git status` / `git diff --name-only` to identify changed files.
+   - Parse arguments to see if the user requested specific review aspects.
+   - Default: run all applicable reviews.
+
+2. **Available Review Aspects**
+
+   | Aspect | Agent | Purpose |
+   |--------|-------|---------|
+   | `comments` | `pr-comment-analyzer` | Analyze code comment accuracy and maintainability |
+   | `tests` | `pr-test-analyzer` | Review test coverage quality and completeness |
+   | `errors` | `pr-silent-failure-hunter` | Check error handling for silent failures |
+   | `types` | `pr-type-design-analyzer` | Analyze type design and invariants |
+   | `code` | `pr-code-reviewer` | General code review for project guidelines |
+   | `simplify` | `pr-simplification-analyzer` | Flag simplification opportunities |
+   | `all` | (all of the above) | Default — run every applicable review |
+
+3. **Identify Changed Files**
+   - `git diff --name-only` for unstaged changes, or use the PR diff if one already exists (`gh pr view --json files`).
+   - Map file types to applicable reviews.
+
+4. **Determine Applicable Reviews**
+
+   Based on changes:
+   - **Always applicable:** `pr-code-reviewer`
+   - **If test files changed:** `pr-test-analyzer`
+   - **If comments/docs added or changed:** `pr-comment-analyzer`
+   - **If error handling changed:** `pr-silent-failure-hunter`
+   - **If types added/modified:** `pr-type-design-analyzer`
+   - **After passing review:** `pr-simplification-analyzer` (polish pass)
+
+5. **Launch Review Agents**
+
+   Prefer **parallel** invocation when running `all` — launch every applicable agent in a single turn via the `Task` tool and wait for results to return together. Use **sequential** when the user requested a specific short list and wants each report resolved before the next.
+
+   When invoked by the `ghcp-review-resolve` skill, always run in parallel — the outer skill is time-sensitive.
+
+6. **Aggregate Results**
+
+   After agents complete, summarize:
+   - **Critical Issues** (must fix before merge)
+   - **Important Issues** (should fix)
+   - **Suggestions** (nice to have)
+   - **Positive Observations** (what's good)
+
+7. **Provide Action Plan**
+
+   ```markdown
+   # PR Review Summary
+
+   ## Critical Issues (X found)
+   - [agent-name]: Issue description [file:line]
+
+   ## Important Issues (X found)
+   - [agent-name]: Issue description [file:line]
+
+   ## Suggestions (X found)
+   - [agent-name]: Suggestion [file:line]
+
+   ## Strengths
+   - What's well-done in this PR
+
+   ## Recommended Action
+   1. Fix critical issues first
+   2. Address important issues
+   3. Consider suggestions
+   4. Re-run review after fixes
+   ```
+
+## Usage Examples
+
+**Full review (default):**
+```
+Skill(skill="pr-review-toolkit")
+```
+
+**Specific aspects:**
+```
+Skill(skill="pr-review-toolkit", args="tests errors")
+# Reviews only test coverage and error handling
+
+Skill(skill="pr-review-toolkit", args="comments")
+
+Skill(skill="pr-review-toolkit", args="simplify")
+```
+
+**Parallel (explicit):**
+```
+Skill(skill="pr-review-toolkit", args="all parallel")
+```
+
+## Agent Descriptions
+
+**pr-comment-analyzer** — Verifies comment accuracy vs. code; flags comment rot; checks documentation completeness.
+
+**pr-test-analyzer** — Reviews behavioral test coverage; identifies critical gaps; evaluates test quality.
+
+**pr-silent-failure-hunter** — Finds silent failures; reviews catch blocks; checks error logging.
+
+**pr-type-design-analyzer** — Analyzes type encapsulation; reviews invariant expression; rates type-design quality.
+
+**pr-code-reviewer** — Checks project-guideline compliance (e.g., `CLAUDE.md`, `.github/copilot-instructions.md`); detects bugs; reviews general code quality.
+
+**pr-simplification-analyzer** — Flags unnecessary complexity; improves clarity and readability; preserves functionality.
+
+## Tips
+
+- **Run early:** Before creating a PR, not after.
+- **Focus on changes:** Agents analyze the diff by default.
+- **Address critical first:** Fix high-priority issues before lower priority.
+- **Re-run after fixes:** Verify issues are resolved.
+- **Use specific reviews:** Target specific aspects when you know the concern.
+
+## Workflow Integration
+
+**Before committing:**
+```
+1. Write code
+2. Skill(skill="pr-review-toolkit", args="code errors")
+3. Fix any critical issues
+4. Commit
+```
+
+**Before creating a PR:**
+```
+1. Stage all changes
+2. Skill(skill="pr-review-toolkit", args="all")
+3. Address all critical and important issues
+4. Re-run specific reviews to verify
+5. Create PR
+```
+
+**After PR feedback:**
+```
+1. Make requested changes
+2. Run targeted reviews based on feedback
+3. Verify issues are resolved
+4. Push updates
+```
+
+## Notes
+
+- Agents run autonomously and return detailed reports.
+- Each agent focuses on its specialty for deep analysis.
+- Results are actionable with specific `file:line` references.
+- This skill is consumed by `ghcp-review-resolve` as the second-reviewer lane alongside GitHub Copilot; when invoked in that context, results are adjudicated before being posted as inline PR comments.

--- a/docs/plans/2026-04-24-001-feat-ghcp-review-resolve-enhancements-plan.md
+++ b/docs/plans/2026-04-24-001-feat-ghcp-review-resolve-enhancements-plan.md
@@ -1,0 +1,364 @@
+---
+title: "feat: ghcp-review-resolve — port pr-review-toolkit locally, resolve Copilot threads, and tick PR task-list items"
+type: feat
+status: active
+date: 2026-04-24
+---
+
+# feat: ghcp-review-resolve — port pr-review-toolkit locally, resolve Copilot threads, and tick PR task-list items
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-24
+**Sections enhanced:** A (port), B (resolve), C (tick), Technical Considerations, Dependencies & Risks
+**Research agents used:** `best-practices-researcher` (external: GitHub GraphQL, `gh pr edit`, Apache-2.0, fuzzy-match tradeoffs), `repo-research-analyst` (local: 57 SKILL.md files, 51 agent files, invocation conventions)
+
+### Key Improvements
+1. **Resolve guardrail upgraded** — check `thread.viewerCanResolve` before calling the mutation; inspect the GraphQL `errors[]` array (not just HTTP status) for failure detection.
+2. **PR body edit made safe** — no optimistic concurrency exists on the GitHub API, so plan C switches from "hash the body" to a `<!-- BEGIN:ghcp-audit v1 -->` ... `<!-- END:ghcp-audit v1 -->` sentinel fence + strict re-fetch-before-write. 64 KiB body ceiling flagged.
+3. **Fuzzy-match downsized** — at this scale (<20 items × <10 findings) LLM matching is overkill. Switch to normalized substring + rapidfuzz `token_set_ratio ≥ 85`, LLM only as fallback for ambiguity. Unmatched findings become "unlinked — needs manual triage" rather than being silently dropped.
+4. **Port conventions locked down** — confirmed only `name` + `description` are required in SKILL frontmatter, only `description` in agents; scripts invoked via `bash ${CLAUDE_PLUGIN_ROOT}/skills/<name>/scripts/...` with no exec bit required.
+5. **Attribution scheme chosen** — upstream has no `NOTICE`, so we don't need one either. Per-file HTML-comment header (not a "Source:" line) in each ported file + `LICENSE` inside `.github/skills/pr-review-toolkit/`. Establishes the first attribution pattern in the repo.
+6. **Agent collision avoided** — renaming `pr-code-simplifier` → `pr-simplification-analyzer` to avoid semantic overlap with existing `code-simplicity-reviewer.agent.md`. Adding a disambiguating `description:` on `pr-comment-analyzer` to distinguish from sibling `pr-comment-resolver.agent.md`.
+
+### New Considerations Discovered
+- **`resolveReviewThread` idempotency is not formally documented** — community reports indicate re-resolving is a no-op success, but the plan should treat a second call as "verify, not rely on". Ambiguity flagged, not blocking.
+- **PR body 64 KiB limit** is de-facto (not in REST reference). Plan 7.0 now refuses to write if the audited body would exceed 60 KiB, leaving margin.
+- **CRLF → LF normalization** happens server-side, so `--body-file` is safe cross-platform.
+- **`${CLAUDE_PLUGIN_ROOT}` convention** is used by existing `resolve-pr-parallel` scripts — ported scripts should follow suit if any are added.
+
+## Overview
+
+The existing `ghcp-review-resolve` skill orchestrates a dual-reviewer pipeline (GitHub Copilot + Anthropic's `pr-review-toolkit`), then fixes verified findings. In practice today:
+
+1. `pr-review-toolkit` is referenced as if installed, but **it is not vendored in this repo** — Step 1b calls a skill that doesn't exist, so the pipeline silently degrades to single-reviewer mode (as observed on PR #23).
+2. After fixing a finding, the skill commits + replies on the review thread but **never marks the Copilot thread `resolved`**, so the PR stays visually cluttered with open "unresolved" threads even after fixes land.
+3. PR descriptions frequently contain GitHub task-list items (`- [ ] ...`) that correspond to the work the skill just did, but **the skill never edits the PR body to tick them off**, leaving the PR looking incomplete.
+
+This plan ports `pr-review-toolkit` into `.github/skills/` + `.github/agents/` following this repo's conventions, and extends `ghcp-review-resolve` with two new post-fix actions: (a) resolve each addressed Copilot review thread via GraphQL mutation, and (b) update the PR body to check off task-list items that map to the work done this run.
+
+## Problem Statement / Motivation
+
+- **Missing dependency.** The `pr-review-toolkit` skill is the second reviewer in the pipeline. Without it present locally, `ghcp-review-resolve` permanently runs in single-reviewer mode — losing the whole "overlap = high confidence" signal the skill was designed around. Vendoring it once here removes the external-install friction and makes the dual-review path actually reachable.
+- **Thread hygiene.** After a real fix has been pushed, a reviewer (human or bot) reading the PR sees N unresolved threads and has to manually resolve each one to know what's still outstanding. The skill already knows which threads it addressed — it should resolve them.
+- **Task-list completion.** PR descriptions in this repo commonly include acceptance-criteria checklists (see the plan templates in `.github/skills/ce-plan/SKILL.md`). When `ghcp-review-resolve` satisfies one of those items via a code change, leaving the box unchecked hides real progress. Automating the tick keeps the PR body honest and readable.
+
+## Proposed Solution
+
+Three coordinated changes, each landable independently:
+
+### A. Port `pr-review-toolkit` into this repo
+
+Vendor Anthropic's `pr-review-toolkit` plugin (`https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit`) as a native ATV skill + agents.
+
+Layout:
+
+```
+.github/
+├── skills/
+│   └── pr-review-toolkit/
+│       ├── SKILL.md             # Adapted from upstream commands/review-pr.md + README.md
+│       └── LICENSE              # Apache-2.0 text, copied verbatim from upstream
+└── agents/
+    ├── pr-comment-analyzer.agent.md         # sibling to pr-comment-resolver — description disambiguates
+    ├── pr-test-analyzer.agent.md
+    ├── pr-silent-failure-hunter.agent.md
+    ├── pr-type-design-analyzer.agent.md
+    ├── pr-code-reviewer.agent.md
+    └── pr-simplification-analyzer.agent.md  # renamed from upstream code-simplifier to avoid overlap with existing code-simplicity-reviewer
+```
+
+Agents get the `pr-` prefix to make it obvious they belong to the toolkit. Only `pr-comment-resolver.agent.md` currently uses `pr-`, so the namespace is clear. Two repo-specific renames/disambiguations (from research findings):
+
+- **`pr-code-simplifier` → `pr-simplification-analyzer`** to avoid semantic overlap with existing `.github/agents/code-simplicity-reviewer.agent.md`. The `-analyzer` suffix also aligns with the other ported siblings (`pr-test-analyzer`, `pr-type-design-analyzer`).
+- **`pr-comment-analyzer`** keeps its upstream-derived name but its `description:` explicitly distinguishes "analyze comment accuracy in diffs" from `pr-comment-resolver`'s "reply-and-resolve review comment threads".
+
+### Research Insights
+
+**Local conventions (verified against 57 SKILL.md + 51 `.agent.md` files):**
+- Skill frontmatter: only `name` + `description` are universal (57/57). Optional fields used elsewhere: `license`, `allowed-tools`, `argument-hint`, `disable-model-invocation`. The port uses `name`, `description`, and `license: Apache-2.0 — see LICENSE`.
+- Agent frontmatter: only `description` is universal. No `name` field. Add `user-invocable: true` only if the agent should be directly triggerable.
+- Agent discovery is **filename-based** — `<name>.agent.md` where `<name>` is the identifier. No manifest.
+- Script invocation (if any are added): `bash ${CLAUDE_PLUGIN_ROOT}/skills/pr-review-toolkit/scripts/<script>` with shebang `#!/usr/bin/env bash`. No exec bit required. Pattern verified in `.github/skills/resolve-pr-parallel/SKILL.md:27,64,74`.
+- Cross-skill invocation: `Skill(skill="pr-review-toolkit:review-pr", args="...")` — the `:` prefix is the plugin/bundle namespace. Verified in `.github/skills/ghcp-review-resolve/SKILL.md:97,281,528`.
+
+**Attribution (research-validated):**
+- Upstream `anthropics/claude-plugins-official/plugins/pr-review-toolkit/` has a `LICENSE` (Apache-2.0) but **no `NOTICE` file**. Under §4(c), we only need to propagate a `NOTICE` if upstream has one — so we don't need one either.
+- Apache-2.0 §4(a) requires a copy of the license → `.github/skills/pr-review-toolkit/LICENSE` (verbatim upstream file).
+- Apache-2.0 §4(b) requires a "prominent notice" in modified files → per-file HTML-comment header (below). Not needed on files copied verbatim, but every ported file in this plan will have at least frontmatter edits, so all get the header.
+- Apache-2.0 does **not** require per-file copyright headers on unmodified files. Ours are modified, so they get the header.
+
+**Per-file attribution header** (top of each ported `.md` file, inside HTML comment so it doesn't render):
+
+```markdown
+<!--
+Portions of this file are derived from anthropics/claude-plugins-official
+(https://github.com/anthropics/claude-plugins-official), licensed under
+the Apache License, Version 2.0. See .github/skills/pr-review-toolkit/LICENSE.
+
+Modifications: ported to All-The-Vibes/ATV-StarterKit; frontmatter adapted
+to repo conventions; agent renamed (see plan for rename rationale); 2026-04-24.
+-->
+```
+
+**This port establishes the first attribution precedent in the repo** — no existing `LICENSE`/`NOTICE` files, no `SPDX-License-Identifier` headers anywhere in-tree. Keep the pattern minimal so it's easy for future ports to follow.
+
+**References:**
+- https://www.apache.org/licenses/LICENSE-2.0 (§4)
+- https://infra.apache.org/licensing-howto.html
+- Verified: `plugins/pr-review-toolkit/LICENSE` exists, `plugins/pr-review-toolkit/NOTICE` does not.
+
+The skill exposes a single callable entry point:
+
+```
+Skill(skill="pr-review-toolkit:review-pr", args="<PR URL or #PR_NUMBER>")
+```
+
+which fans out to the 6 agents, posts findings as inline PR review comments on the target PR, and returns a structured list of the findings it posted (so `ghcp-review-resolve` Step 2 can detect completion without polling for minutes).
+
+### B. Resolve Copilot threads after successful fixes
+
+Extend Step 6 ("Inline fix loop") of `ghcp-review-resolve` with a new sub-step **6.5 — Resolve thread** that runs only after the reply-posting sub-step (6.6) succeeds.
+
+New behavior per addressed finding:
+
+```bash
+# Resolve the thread using the existing in-repo helper, which wraps
+# the resolveReviewThread GraphQL mutation.
+.github/skills/resolve-pr-parallel/scripts/resolve-pr-thread "$THREAD_ID"
+```
+
+Where `$THREAD_ID` is the GraphQL node ID of the review thread (fetched in Step 0g's already-existing `reviewThreads` query — we thread it through the pipeline's per-finding record so this resolution step doesn't need an extra API call).
+
+Guardrails on resolution:
+
+- **Only resolve a thread if** (all five must hold):
+  1. Its finding was accepted by the adjudicator (Step 4), AND
+  2. The fix commit was pushed successfully (Step 6.5, the existing push step), AND
+  3. The reply was posted successfully (Step 6.6), AND
+  4. Verification in Step 6.3 succeeded (tests/lint passed OR the finding was a pure-prose / docs finding), AND
+  5. **`thread.viewerCanResolve == true`** — query this in the 0g `reviewThreads` fetch so we can skip the mutation (and log the reason) when the running identity lacks resolve permissions. This avoids a noisy `FORBIDDEN` GraphQL error on every run when the pipeline is invoked by a user without PR-write access.
+- **Do not resolve** threads for findings marked "skipped — left for human", "needs larger change", or "not independently verified".
+- If the mutation fails (network flake, permissions), log the failure and continue — resolution is best-effort; the reply + commit are the source of truth.
+
+Resolution happens per-finding, inline, not in a batch at the end, so a mid-run abort still leaves the PR in a consistent state (fixes that landed are marked resolved; fixes that didn't, aren't).
+
+### Research Insights
+
+**GraphQL shape (verified against GitHub docs):**
+
+```graphql
+mutation ResolveReviewThread($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread {
+      id
+      isResolved
+      viewerCanResolve
+    }
+  }
+}
+```
+
+**Failure detection:** Inspect the top-level `errors[]` array, not just HTTP status. `data.resolveReviewThread == null` with `errors[0].type` indicating the failure mode:
+- `NOT_FOUND` — bad threadId or no read access (shouldn't happen post-0g).
+- `FORBIDDEN` / `"Resource not accessible by integration"` — token lacks PR write. The `viewerCanResolve` pre-check (above) prevents this in the expected path.
+- `"Could not resolve to a node with the global id of …"` — wrong ID type; indicates a bug in how 0g passed the ID through.
+
+**Permissions needed:**
+- Classic PAT: `repo` (private) or `public_repo` (public only).
+- Fine-grained PAT / GitHub App: `Pull requests: write` on the target repo.
+- The skill already has push access and posts reviews, so these are satisfied in all expected call contexts.
+
+**Rate-limit cost:** 1 GraphQL point per resolve call against the 5000 pts/hr pool (10000 for Enterprise-owned apps, 1000 for `GITHUB_TOKEN` in Actions). Negligible even on a PR with 100 resolved threads.
+
+**Idempotency (⚠️ not formally documented):** Community reports indicate that resolving an already-resolved thread returns `thread.isResolved: true` with no error — effectively a no-op success. The plan treats this as expected behavior but flags it as non-authoritative. Implementation should verify `thread.isResolved` in the response rather than assume success from a 200 status.
+
+**References:**
+- https://docs.github.com/en/graphql/reference/mutations#resolvereviewthread
+- https://docs.github.com/en/graphql/reference/input-objects#resolvereviewthreadinput
+- https://docs.github.com/en/graphql/overview/resource-limitations
+
+### C. Tick off PR body task-list items
+
+Extend Step 7 (final summary) of `ghcp-review-resolve` with a new sub-step **7.0 — Update PR body** that runs before the user-facing summary.
+
+Algorithm:
+
+1. **Fetch** the current PR body and snapshot it:
+   ```bash
+   gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json body -q .body > /tmp/ghcp-pr-body-original.md
+   ```
+2. **Size-guard:** if `wc -c /tmp/ghcp-pr-body-original.md` ≥ 60000 bytes, skip the rewrite (GitHub's de-facto body limit is 65,536 bytes — leave 5 KB margin for the audit block and finding entries).
+3. **Extract unchecked task-list items** via regex `^\s*- \[ \] (.+)$` (per-line, anchored). Preserve line numbers so step 5 can edit in place without line-shifting the rest of the body.
+4. For each accepted-and-fixed finding (from the per-finding record built during Step 6), attempt to match it to an unchecked item using a **deterministic-first** strategy:
+   - **Pass 1 — normalized substring match.** Lowercase + collapse whitespace + strip markdown syntax on both sides. If the finding's file path (e.g. `.github/skills/ghcp-review-resolve/SKILL.md`) or the first 40 chars of its rationale appears as a substring in any task-list item, that's a match.
+   - **Pass 2 — rapidfuzz token_set_ratio ≥ 85.** Use `token_set_ratio` (handles reordered words and subset overlap) rather than Levenshtein (poor for reordered tokens). Threshold 85 verified against rapidfuzz docs as the standard high-confidence cutoff for short-to-medium strings.
+   - **Pass 3 — LLM fallback, only for ambiguous cases.** If passes 1 and 2 yield zero matches OR multiple items above threshold, invoke a small classification prompt (temperature 0, strict JSON output with `matched_id`, `confidence ∈ [0.0, 1.0]`, `reason`, `alternates[]`). Require `confidence ≥ 0.8` and validate `matched_id ∈ input_ids` before accepting. Expected invocation rate: 0–3 per run at this project's scale.
+   - **Unmatched findings** become a trailing "unlinked — needs manual triage: `<finding-title>`" line inside the audit block. Never silently drop.
+5. **Tick** each matched item by rewriting `- [ ]` → `- [x]` on that specific line number only. Preserve the rest of the body byte-for-byte.
+6. **Manage the audit block.** Use sentinel fences so the block is idempotent across re-runs:
+   ```markdown
+   <!-- BEGIN:ghcp-audit v1 -->
+   <!-- Managed by ghcp-review-resolve. Do not edit by hand. -->
+   Last run: 2026-04-24T11:48:37Z (commits abc123..def456)
+   Ticked: 3 of 7 task-list items
+   - Item "Fix Step 5 reference" ← comment 3139049827 (fixed in abc123)
+   - Item "Add pagination to 0g query" ← comment 3139049895 (fixed in def456)
+   - Item "Resolve threads after fix" ← comment 3139049941 (fixed in def456)
+   Unlinked (needs manual triage):
+   - "Race condition in cache update" (skipped — left for human)
+   <!-- END:ghcp-audit v1 -->
+   ```
+   Parse out the existing block with regex `(?s)<!-- BEGIN:ghcp-audit v1 -->.*?<!-- END:ghcp-audit v1 -->`, rebuild, splice back. Never nest `-->` inside the payload (HTML comments don't nest); if any rationale contains `--`, base64-encode or strip it before embedding.
+7. **Write back with a sentinel-based concurrency check** (there is no native optimistic-concurrency API on PR bodies — no `If-Match`, no ETag):
+   ```bash
+   # Re-fetch right before write to detect mid-run edits
+   CURRENT_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+   if [ "$CURRENT_BODY" != "$(cat /tmp/ghcp-pr-body-original.md)" ]; then
+     echo "PR body changed during run — skipping auto-tick to avoid overwriting user edits."
+   else
+     gh pr edit "$PR_NUMBER" --body-file /tmp/ghcp-pr-body-updated.md
+   fi
+   ```
+   `gh pr edit --body-file` reads bytes as UTF-8 and sends them as the REST `body` field. Server-side normalizes CRLF → LF; no client-side trim. Trailing newline in the file is preserved.
+8. If no task-list items exist in the body, or no findings matched, skip the write and log "no task-list items to update" — the audit block is not created on empty runs.
+
+Guardrails on body edits:
+
+- **Never** introduce, delete, or reorder non-task-list content outside the audit fence. Only flip `[ ]` → `[x]` on matched lines and manage the fenced block.
+- **Never** tick an item the skill can't confidently map to work it did. Unmatched goes to "needs manual triage"; false positives are worse than false negatives here.
+- **Never** exceed the 60 KB body ceiling. If adding the audit block would push the body over 60 KB, truncate finding entries inside the block (keep ticks, summarize unmatched).
+- **Abort the whole sub-step** on sentinel mismatch (user pushed a body edit mid-run); log it, continue to the summary without updating.
+
+### Research Insights
+
+**Why deterministic-first instead of LLM-first:** At this project's scale (<20 task-list items × <10 findings = ~200 pairs), normalized substring + `token_set_ratio` catches almost all real matches at zero marginal cost, and false-positive rate is lower than an LLM's (LLMs rarely emit confidence < 0.7 even on wrong matches — "0.8" typically means "maybe"). LLMs are worth it only at >50×50 scale or when matching requires reasoning across paraphrases.
+
+**Why no embeddings pipeline:** At N=200 pairs, embeddings add a dependency (`text-embedding-3-small` API or local model) with no accuracy win over rapidfuzz. Revisit at 10× scale.
+
+**LLM prompt shape** (for Pass 3 fallback, temperature=0, strict JSON):
+```
+You are matching review findings to a PR checklist.
+
+Checklist items (id → text):
+1: <text>
+2: <text>
+...
+
+Finding: "<finding rationale + file:line>"
+
+Return strict JSON:
+{
+  "matched_id": <int or null>,
+  "confidence": <0.0–1.0>,
+  "reason": "<one sentence>",
+  "alternates": [<int>, ...]
+}
+
+Rules:
+- matched_id = null if no item meaningfully addresses the finding.
+- confidence < 0.8 → treat as unmatched.
+- Do not invent ids outside the list.
+```
+
+**Known LLM failure modes to guard against:** stylistic lexical overlap (both mention "error handling" but refer to different paths — mitigate by including file:line in both sides), confidence inflation (calibrate by sampling), order bias (shuffle checklist per call or request `alternates`), negation anchoring ("this is NOT about X" still matches X — strip negations).
+
+**References:**
+- https://cli.github.com/manual/gh_pr_edit
+- https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request
+- 64 KiB body limit: sourced from community discussions (github/orgs/community#31295, #34879) — not in formal REST reference; treated as reliable de-facto limit.
+- https://rapidfuzz.github.io/RapidFuzz/Usage/fuzz.html#token-set-ratio
+
+## Technical Considerations
+
+- **GraphQL ID acquisition for thread resolution.** The existing `0g` query already fetches `reviewThreads` but doesn't currently select the `id` field. Update the query in 0g to select `id` **and `viewerCanResolve`** on each thread node and keep both in the in-memory finding record. No extra API call is needed. The `viewerCanResolve` flag is what Step 6.7 uses to skip the mutation cleanly when permissions are lacking.
+- **Agent discovery.** This repo loads agents from `.github/agents/*.agent.md` — filename-based, no manifest. The port must use that naming (not upstream's `<name>.md`) or the agents won't be invocable. Frontmatter contract: only `description:` is universal across the 51 existing agents; add `user-invocable: true` only if the agent should be user-triggerable (not required for the toolkit's internal use).
+- **License.** `pr-review-toolkit` is Apache-2.0. Include the upstream `LICENSE` verbatim under `.github/skills/pr-review-toolkit/LICENSE`. Per-file HTML-comment attribution header (see section A) on every ported `.md`. No `NOTICE` file needed — upstream has none. The port introduces the repo's first attribution precedent; keep it minimal.
+- **Single-reviewer mode stays supported.** Even after porting, `COPILOT_AVAILABLE=false` + `pr-review-toolkit` still constitutes a valid run. Don't delete the single-reviewer branch in the SKILL — the port just makes the dual-reviewer branch actually reachable.
+- **GraphQL permissions.** `resolveReviewThread` requires `repo` (classic) or `Pull requests: write` (fine-grained/App). The skill already has that (it pushes commits and posts reviews). No new auth scope needed.
+- **PR body edit noise.** Using `gh pr edit --body-file` rewrites the whole body, which shows up as a PR-body edit event in the timeline. That's acceptable and matches how humans edit PR bodies; the audit-fence marker (`<!-- BEGIN:ghcp-audit v1 -->`) makes the skill's edits self-explanatory and keeps them replaceable.
+- **No optimistic concurrency on PR bodies.** Confirmed there's no `If-Match` / ETag / SHA guard on `PATCH /repos/{o}/{r}/pulls/{n}`. Plan 7.0's sentinel-based guard (snapshot-on-read, diff-on-write) is the accepted workaround.
+- **Script invocation convention.** If any scripts get added under `.github/skills/pr-review-toolkit/scripts/`, invoke them via `bash ${CLAUDE_PLUGIN_ROOT}/skills/pr-review-toolkit/scripts/<name>` (matches existing `resolve-pr-parallel` usage). Exec bit is not required.
+
+## System-Wide Impact
+
+- **Interaction graph:** `ghcp-review-resolve` Step 1b → `Skill(pr-review-toolkit:review-pr)` → 6 sub-agents → PR review comments. Step 6 → `resolve-pr-thread` script → `resolveReviewThread` GraphQL mutation. Step 7.0 → `gh pr edit --body-file` → PR body update event.
+- **Error propagation:** Thread-resolution failures are logged and ignored (best-effort). Body-update failures abort 7.0 only; summary still runs. Agent failures inside `pr-review-toolkit` surface as "reviewer missing" in Step 2's completion check and degrade gracefully to whichever reviewer did complete.
+- **State lifecycle risks:** A mid-run abort between commit-push and thread-resolve leaves an unresolved thread with a posted fix reply — human-visible as "code pushed, human can resolve". Not a regression; matches today's behavior.
+- **API surface parity:** `resolve-pr-parallel` already ships `resolve-pr-thread` and `get-pr-comments`. Reuse both; don't duplicate the GraphQL logic inside `ghcp-review-resolve`.
+- **Integration test scenarios:**
+  1. Dual-reviewer happy path: both reviewers produce findings, overlap is preserved, all accepted findings produce commits + resolved threads + ticked boxes.
+  2. Copilot unavailable: only `pr-review-toolkit` runs, Step C still resolves its own threads.
+  3. PR has no task-list items: 7.0 exits silently.
+  4. User edits PR body mid-run: 7.0 aborts with an explanatory log line.
+  5. Thread-resolve mutation fails for one finding but succeeds for others: the failing one stays open, others resolve.
+
+## Acceptance Criteria
+
+### A — Port pr-review-toolkit
+
+- [ ] `.github/skills/pr-review-toolkit/SKILL.md` exists with required frontmatter (`name`, `description`) and adapted content from upstream's `commands/review-pr.md` + `README.md`.
+- [ ] Six agent files exist at `.github/agents/pr-*.agent.md` — `pr-comment-analyzer`, `pr-test-analyzer`, `pr-silent-failure-hunter`, `pr-type-design-analyzer`, `pr-code-reviewer`, `pr-simplification-analyzer` (renamed from upstream `code-simplifier`) — each with a `description:` frontmatter line.
+- [ ] `.github/skills/pr-review-toolkit/LICENSE` contains the upstream Apache-2.0 license text verbatim.
+- [ ] Each ported file starts with the HTML-comment attribution header (upstream repo URL + Apache-2.0 + LICENSE path + modifications note with date).
+- [ ] `pr-comment-analyzer.agent.md` description explicitly distinguishes its scope ("analyze accuracy and rot of code comments") from sibling `pr-comment-resolver.agent.md` ("reply-and-resolve review comment threads").
+- [ ] The skill can be invoked via `Skill(skill="pr-review-toolkit:review-pr", args="<PR URL>")` and posts at least one inline review comment on a test PR (verified by manual smoke test).
+- [ ] `ghcp-review-resolve` Step 1b's existing `Skill(...)` call succeeds (no "skill not found" error) and its review comments are picked up by Step 3's normalization.
+
+### B — Resolve Copilot threads
+
+- [ ] The 0g GraphQL query selects thread `id` **and `viewerCanResolve`**, and both are carried through to per-finding records.
+- [ ] `ghcp-review-resolve` SKILL.md has a new Step 6.7 titled "Resolve thread" describing the five-gate guardrail (accepted + pushed + replied + verified + viewerCanResolve) before calling `resolve-pr-thread`.
+- [ ] After a successful fix loop on a test PR, the addressed threads show `isResolved=true` in `gh api graphql` output.
+- [ ] Findings that are skipped, reverted, or unverifiable leave their threads **open**.
+- [ ] When `viewerCanResolve` is false, the skill logs a permission-skip without attempting the mutation (no `FORBIDDEN` error in logs).
+- [ ] Thread-resolve failures (any `errors[]` in GraphQL response) are logged but do not abort the pipeline.
+
+### C — Tick PR task-list items
+
+- [ ] `ghcp-review-resolve` SKILL.md has a new Step 7.0 "Update PR body" before the existing Step 7 summary.
+- [ ] Running the skill on a test PR whose body contains `- [ ] Fix <foo>` lines flips matched items to `- [x] Fix <foo>` and leaves the rest of the body unchanged.
+- [ ] Matching uses the deterministic-first strategy: normalized substring → rapidfuzz `token_set_ratio ≥ 85` → LLM fallback for ambiguous cases only.
+- [ ] Unmatched findings appear in the audit block under "Unlinked (needs manual triage)" — never silently dropped.
+- [ ] A `<!-- BEGIN:ghcp-audit v1 --> ... <!-- END:ghcp-audit v1 -->` audit block lists ticked items, commit SHAs, and unlinked findings.
+- [ ] Re-running the skill on the same PR does not duplicate the audit block (it replaces the previous one using the sentinel-fence regex).
+- [ ] If the PR body changes between the initial fetch and the write-back, the update is skipped and the summary logs the skip (sentinel-based concurrency check).
+- [ ] If the post-audit body would exceed 60 KB, the write is aborted with a logged warning.
+- [ ] No false-positive tick: an unrelated `- [ ]` item elsewhere in the body stays unchecked.
+
+## Success Metrics
+
+- On a PR with Copilot findings, running `/ghcp-review-resolve` end-to-end produces: N addressed findings, N commits, N thread replies, **N resolved threads**, and all corresponding PR-body task-list items ticked — with no manual follow-up required.
+- The dual-reviewer pipeline is actually exercised (not silently degraded to single-reviewer) in at least one real PR run.
+- Zero incorrect ticks or incorrect resolutions observed across the first 3 real runs.
+
+## Dependencies & Risks
+
+- **Upstream license compliance.** Apache-2.0 requires attribution (§4(a)) and a modifications notice (§4(b)). Handled by the `LICENSE` copy + per-file HTML-comment header (see §A Research Insights). `NOTICE` file is optional — upstream has none, so we don't propagate one.
+- **Agent collision.** Soft semantic overlap identified: `pr-code-simplifier` → renamed to `pr-simplification-analyzer` to avoid colliding in purpose with `.github/agents/code-simplicity-reviewer.agent.md`. `pr-comment-analyzer` sits next to `pr-comment-resolver`; disambiguated via `description:` copy ("analyze accuracy" vs. "reply-and-resolve").
+- **Body-edit flakiness.** GitHub occasionally rejects `pr edit --body-file` with transient 5xx. 7.0 treats this as a warning, not a pipeline-abort. The sentinel-fence design means a retry on the next run picks up where this one left off without duplicating work.
+- **`resolveReviewThread` idempotency assumption.** Behavior on already-resolved threads is **not formally documented** (community reports say no-op success). Mitigation: always verify `thread.isResolved` in the mutation response rather than assuming success from a 200 status. Do not log re-resolve as a failure.
+- **GraphQL schema drift.** `resolveReviewThread` and `reviewThreads` are stable, but the `id` + `viewerCanResolve` field selectors must be added to the 0g query and tested. A schema-change smoke test (call the query once against a real PR, confirm both fields are present) is part of implementation.
+- **PR body 64 KiB ceiling.** De-facto, not in docs. 7.0's 60 KB safety threshold protects against runaway audit blocks; exceeding the limit aborts the body edit with a logged warning.
+- **`pr-review-toolkit` wall-clock.** The 6-agent review is slower than Copilot's. Step 2's 10-minute cap may need raising for very large PRs, but that's out of scope for this plan — raise it only if we observe timeouts in practice.
+- **Attribution precedent.** This port introduces the first `LICENSE` and HTML-comment attribution headers in the repo. Future third-party ports should follow the same pattern. Document the convention in `CONTRIBUTING.md` as a follow-up (out of scope).
+
+## Sources & References
+
+### Internal
+
+- Skill to modify: `.github/skills/ghcp-review-resolve/SKILL.md`
+- Existing resolve helper (reuse): `.github/skills/resolve-pr-parallel/scripts/resolve-pr-thread`
+- Existing comment-fetch helper (pattern reference): `.github/skills/resolve-pr-parallel/scripts/get-pr-comments`
+- Agent file convention: `.github/agents/architecture-strategist.agent.md` (shape example)
+- Copilot instructions: `.github/copilot-instructions.md`
+
+### External
+
+- Anthropic `pr-review-toolkit` source: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit
+- GraphQL `resolveReviewThread` mutation: https://docs.github.com/en/graphql/reference/mutations#resolvereviewthread
+- `gh pr edit --body-file` docs: https://cli.github.com/manual/gh_pr_edit
+
+### Related Work
+
+- PR #23 (`feat/ghcp-review-resolve-skill`) — the PR that added `ghcp-review-resolve` and on which this plan's enhancements will land (or a follow-up PR).

--- a/docs/plans/2026-04-24-001-feat-ghcp-review-resolve-enhancements-plan.md
+++ b/docs/plans/2026-04-24-001-feat-ghcp-review-resolve-enhancements-plan.md
@@ -134,7 +134,7 @@ Guardrails on resolution:
 
 - **Only resolve a thread if** (all five must hold):
   1. Its finding was accepted by the adjudicator (Step 4), AND
-  2. The fix commit was pushed successfully (Step 6.5, the existing push step), AND
+  2. The fix commit was pushed successfully (the existing push step in Step 6), AND
   3. The reply was posted successfully (Step 6.6), AND
   4. Verification in Step 6.3 succeeded (tests/lint passed OR the finding was a pure-prose / docs finding), AND
   5. **`thread.viewerCanResolve == true`** — query this in the 0g `reviewThreads` fetch so we can skip the mutation (and log the reason) when the running identity lacks resolve permissions. This avoids a noisy `FORBIDDEN` GraphQL error on every run when the pipeline is invoked by a user without PR-write access.
@@ -282,8 +282,8 @@ Rules:
 
 ## System-Wide Impact
 
-- **Interaction graph:** `ghcp-review-resolve` Step 1b → `Skill(pr-review-toolkit:review-pr)` → 6 sub-agents → PR review comments. Step 6 → `resolve-pr-thread` script → `resolveReviewThread` GraphQL mutation. Step 7.0 → `gh pr edit --body-file` → PR body update event.
-- **Error propagation:** Thread-resolution failures are logged and ignored (best-effort). Body-update failures abort 7.0 only; summary still runs. Agent failures inside `pr-review-toolkit` surface as "reviewer missing" in Step 2's completion check and degrade gracefully to whichever reviewer did complete.
+- **Interaction graph:** `ghcp-review-resolve` Step 1b → `Skill(pr-review-toolkit)` → 6 sub-agents → PR review comments. Step 6.7 → `gh api graphql` `resolveReviewThread` mutation. Step 6.8 → `gh pr edit --body-file` → PR body update event.
+- **Error propagation:** Thread-resolution failures are logged and ignored (best-effort). Body-update failures abort 6.8 only; summary still runs. Agent failures inside `pr-review-toolkit` surface as "reviewer missing" in Step 2's completion check and degrade gracefully to whichever reviewer did complete.
 - **State lifecycle risks:** A mid-run abort between commit-push and thread-resolve leaves an unresolved thread with a posted fix reply — human-visible as "code pushed, human can resolve". Not a regression; matches today's behavior.
 - **API surface parity:** `resolve-pr-parallel` already ships `resolve-pr-thread` and `get-pr-comments`. Reuse both; don't duplicate the GraphQL logic inside `ghcp-review-resolve`.
 - **Integration test scenarios:**
@@ -308,7 +308,7 @@ Rules:
 ### B — Resolve Copilot threads
 
 - [ ] The 0g GraphQL query selects thread `id` **and `viewerCanResolve`**, and both are carried through to per-finding records.
-- [ ] `ghcp-review-resolve` SKILL.md has a new Step 6.7 titled "Resolve thread" describing the five-gate guardrail (accepted + pushed + replied + verified + viewerCanResolve) before calling `resolve-pr-thread`.
+- [ ] `ghcp-review-resolve` SKILL.md has a new Step 6.7 titled "Resolve thread" describing the five-gate guardrail (accepted + pushed + replied + verified + viewerCanResolve) before issuing the `resolveReviewThread` GraphQL mutation.
 - [ ] After a successful fix loop on a test PR, the addressed threads show `isResolved=true` in `gh api graphql` output.
 - [ ] Findings that are skipped, reverted, or unverifiable leave their threads **open**.
 - [ ] When `viewerCanResolve` is false, the skill logs a permission-skip without attempting the mutation (no `FORBIDDEN` error in logs).
@@ -316,7 +316,7 @@ Rules:
 
 ### C — Tick PR task-list items
 
-- [ ] `ghcp-review-resolve` SKILL.md has a new Step 7.0 "Update PR body" before the existing Step 7 summary.
+- [ ] `ghcp-review-resolve` SKILL.md has a new Step 6.8 "Update PR body" before the existing Step 7 summary.
 - [ ] Running the skill on a test PR whose body contains `- [ ] Fix <foo>` lines flips matched items to `- [x] Fix <foo>` and leaves the rest of the body unchanged.
 - [ ] Matching uses the deterministic-first strategy: normalized substring → rapidfuzz `token_set_ratio ≥ 85` → LLM fallback for ambiguous cases only.
 - [ ] Unmatched findings appear in the audit block under "Unlinked (needs manual triage)" — never silently dropped.


### PR DESCRIPTION
## Summary

Enhances the `ghcp-review-resolve` skill on top of PR #23 by:

1. **Porting [Anthropic's `pr-review-toolkit`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit) locally** (Apache-2.0) so the skill has no external-plugin dependency. 6 agents + 1 skill + `LICENSE`, each with an HTML-comment attribution header satisfying Apache-2.0 §4(b).
2. **Adding Step 6.7 — guardrailed thread resolution** with 5 gates (adjudicated-real, fix-landed, verified, reply-posted, permission). Reuses the existing `resolve-pr-parallel/scripts/resolve-pr-thread` helper.
3. **Adding Step 7.0 — PR task-list ticking** with a deterministic match pipeline (normalized substring → rapidfuzz token_set_ratio ≥ 85 → LLM fallback, confidence ≥ 0.8), sentinel-fenced body updates, 60 KB safety margin, and fallback-to-comment on failure.

Plan: [`docs/plans/2026-04-24-001-feat-ghcp-review-resolve-enhancements-plan.md`](./docs/plans/2026-04-24-001-feat-ghcp-review-resolve-enhancements-plan.md) (deepened with parallel research agents).

## Key decisions

- **Agent rename `code-simplifier` → `pr-simplification-analyzer`** to avoid semantic collision with this repo's existing `code-simplicity-reviewer.agent.md`.
- **`pr-` prefix** on all 6 ported agents for namespace clarity.
- **`pr-comment-analyzer` disambiguated** in its description from the sibling `pr-comment-resolver.agent.md` (this one analyzes *source-code* comments; that one replies to *reviewer* threads).
- Resolution is **guardrailed, not unconditional** — false-positive fixes can't silently resolve threads where the adjudicator disagreed with the reviewer.
- Task-list ticking uses **deterministic matching first**; the LLM is a last-resort fallback with strict JSON + confidence gating.

## Attribution

Apache-2.0 §4(a): `LICENSE` copied verbatim at `.github/skills/pr-review-toolkit/LICENSE`.
Apache-2.0 §4(b): every ported file carries an HTML-comment header naming the source, commit date, and modification summary.
No `NOTICE` file upstream, so none required here.

## Testing

- Validated all new/modified SKILL.md + agent files for frontmatter compliance (`description` present, no unexpected `name`/`model`/`color` on agents, no duplicate agent filenames). **All OK.**
- `ghcp-review-resolve` SKILL.md still internally consistent: Step 0g reviewThreads query now surfaces the `id` + `viewerCanResolve` fields that Steps 6.7 + 7.0 consume; Step 7 summary updated to report resolution/tick outcomes.
- Smoke test of the full pipeline (dual review → adjudicate → fix → reply → resolve → tick) deferred to the next real PR invocation — this is documentation-only behavior; real validation happens the next time `/ghcp-review-resolve <PR>` runs.

## Post-Deploy Monitoring & Validation

- **What to watch:** the next invocation of `/ghcp-review-resolve` on a PR with a task-list in the body and ≥1 Copilot finding.
- **Expected healthy behavior:** fixes land, replies post, threads with all 5 gates pass get `isResolved=true`, matching task items flip from `[ ]` → `[x]` inside `<!-- BEGIN:ghcp-audit v1 -->` fences, Step 7 summary reports both outcomes.
- **Failure signals:** threads replied-to but not resolved despite `viewerCanResolve=true`; PR body clobbered outside the sentinel fences; task items ticked that don't correspond to a landed fix.
- **Validation window & owner:** first 2 PR runs after merge; skill owner reviews the Step 7 summary.

## Base branch

This PR targets `feat/ghcp-review-resolve-skill` (PR #23), not `main`, so the diff is scoped to this work. Once PR #23 merges, GitHub will auto-retarget this PR to `main`.

---

🤖 Generated with [GitHub Copilot CLI](https://github.com/github/gh-copilot)