### PR TITLE
feat(land): sweep stale ralph-loop state files in Step 7 cleanup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,10 @@ This project uses the ATV (Agentic Tool & Workflow) Starter Kit.
 - `/takeoff` — Prioritized backlog briefing to start a session
 - `/land` — Commit → push → PR → handoff to finish a session (never merges)
 
+### Session continuity
+
+At session start, if `.remember/now.md` exists in the repo, read it before responding — it contains a handoff from the previous session (branch, PR, accomplished, next steps, blockers). Treat it as authoritative context for continuing work. The `/land` skill writes this file as part of its checklist.
+
 ## Documentation Structure
 
 - `docs/plans/` — Implementation plans (living documents with checkboxes)

--- a/.github/skills/land/SKILL.md
+++ b/.github/skills/land/SKILL.md
@@ -154,7 +154,7 @@ git stash list                     # check for session-era stashes
 **Sweep stale ralph-loop state files.** If a previous session ran `ralph-loop` and the state file was orphaned (session crash, cwd drift into a worktree, completion promise emitted but not as the trailing tokens of the assistant message), the plugin's stop-hook will replay the loop's prompt verbatim in the next session as "Stop hook feedback." Run unconditionally — the cost is microseconds and detecting "did this session use ralph-loop?" is unreliable:
 
 ```bash
-DELETED_RL=$(find . -name ralph-loop.local.md -path '*/.claude/*' -print -delete 2>/dev/null)
+DELETED_RL=$(find . -name ralph-loop.local.md -path '*/.claude/*' -print -delete 2>/dev/null || true)
 if [ -n "$DELETED_RL" ]; then
   echo "ralph-loop state files removed (surface in Step 9 handoff under blockers/gotchas):"
   echo "$DELETED_RL"

--- a/.github/skills/land/SKILL.md
+++ b/.github/skills/land/SKILL.md
@@ -33,7 +33,7 @@ Review what was worked on this session. Capture anything that's unfinished, defe
     backlog task create "<title>" --description "<context>"
   fi
   ```
-- Otherwise, gather remaining work into a short handoff list and surface it at Step 9.
+- Otherwise, gather remaining work into a short handoff list and surface it at Step 10.
 
 Skip silently if nothing remains.
 
@@ -68,7 +68,7 @@ fi
 # Rust:    [ -f Cargo.toml ] && cargo build && cargo test
 ```
 
-If any gate fails (non-zero exit), **halt the routine, fix the failure, and re-run from Step 2 before proceeding to Step 4**. Do not append `|| true` to swallow failures — a broken build does not ship, and a swallowed failure would falsely emit the success banner at Step 10.
+If any gate fails (non-zero exit), **halt the routine, fix the failure, and re-run from Step 2 before proceeding to Step 4**. Do not append `|| true` to swallow failures — a broken build does not ship, and a swallowed failure would falsely emit the success banner at Step 11.
 
 If no code changed (docs-only, config-only, planning-only sessions), skip quality gates and note that in the handoff.
 
@@ -156,7 +156,7 @@ git stash list                     # check for session-era stashes
 ```bash
 DELETED_RL=$(find . -name ralph-loop.local.md -path '*/.claude/*' -print -delete 2>/dev/null || true)
 if [ -n "$DELETED_RL" ]; then
-  echo "ralph-loop state files removed (surface in Step 9 handoff under blockers/gotchas):"
+  echo "ralph-loop state files removed (surface in Step 10 handoff under blockers/gotchas):"
   echo "$DELETED_RL"
 fi
 ```
@@ -179,7 +179,36 @@ fi
 
 If either check fails, loop back and fix. Do not hand off a dirty or unpushed tree.
 
-### Step 9: Hand off
+### Step 9: Capture session state
+
+Persist a written handoff to `.remember/now.md` so the next session (Copilot, Claude, or human) can resume with full context — not just the verbal summary in Step 10. GitHub Copilot CLI reads `.github/copilot-instructions.md` on every session start, and the project-level instruction tells it to read `.remember/now.md` when it exists. This makes the handoff durable across sessions without requiring any tool-specific skill.
+
+Run unconditionally — even on docs-only or planning-only sessions. The buffer is cheap and the recovery value is high. Idempotent: overwrites the previous `now.md` each time.
+
+```bash
+mkdir -p .remember
+branch=$(git branch --show-current 2>/dev/null || echo "(unknown)")
+pr_url=$(gh pr view --json url -q .url 2>/dev/null || echo "(no PR)")
+cat > .remember/now.md <<EOF
+# Session handoff — $(date +%Y-%m-%d)
+
+**Branch:** $branch
+**PR:** $pr_url
+
+## Accomplished
+- (fill in: what shipped this session)
+
+## Next up
+- (fill in: what's queued for the next session)
+
+## Blockers / gotchas
+- (fill in: anything waiting on a decision or that tripped us up)
+EOF
+```
+
+After writing the file, replace the `(fill in: ...)` placeholders with the actual session content before moving on. The shell snippet creates the structure; the agent fills the substance.
+
+### Step 10: Hand off
 
 Provide a concise summary for the next session:
 
@@ -191,7 +220,7 @@ Provide a concise summary for the next session:
 
 Keep it scannable. The next session (human or agent) should be able to take off from this handoff without re-reading the whole transcript.
 
-### Step 10: Final banner
+### Step 11: Final banner
 
 After the handoff summary, emit a single final line:
 

--- a/.github/skills/land/SKILL.md
+++ b/.github/skills/land/SKILL.md
@@ -151,6 +151,18 @@ git stash list                     # check for session-era stashes
 
 **If working inside a git worktree:** leave the worktree in place while the PR is open. Remove it manually with `git worktree remove <path>` only after the PR is merged or abandoned. Do not attempt to tear down worktrees from this skill.
 
+**Sweep stale ralph-loop state files.** If a previous session ran `ralph-loop` and the state file was orphaned (session crash, cwd drift into a worktree, completion promise emitted but not as the trailing tokens of the assistant message), the plugin's stop-hook will replay the loop's prompt verbatim in the next session as "Stop hook feedback." Run unconditionally — the cost is microseconds and detecting "did this session use ralph-loop?" is unreliable:
+
+```bash
+DELETED_RL=$(find . -name ralph-loop.local.md -path '*/.claude/*' -print -delete 2>/dev/null)
+if [ -n "$DELETED_RL" ]; then
+  echo "ralph-loop state files removed (surface in Step 9 handoff under blockers/gotchas):"
+  echo "$DELETED_RL"
+fi
+```
+
+The path glob `*/.claude/*` ensures only state files inside `.claude/` directories are deleted — a legitimately named `ralph-loop.local.md` document elsewhere is left alone.
+
 ### Step 8: Verify
 
 Confirm a clean state:

--- a/docs/plans/2026-04-24-005-feat-guided-install-include-new-skills-plan.md
+++ b/docs/plans/2026-04-24-005-feat-guided-install-include-new-skills-plan.md
@@ -1,0 +1,330 @@
+---
+title: "feat: Include new skills (land, takeoff) in --guided installation"
+type: feat
+status: completed
+date: 2026-04-24
+---
+
+# feat: Include new skills (land, takeoff) in --guided installation
+
+## Overview
+
+Two skills landed in `.github/skills/` during the past week — `land` and `takeoff` — but they were never copied into `pkg/scaffold/templates/skills/` (the embedded `//go:embed all:templates` tree the installer ships) and were never registered in `pkg/scaffold/catalog.go` or the guided-mode TUI in `pkg/tui/`. As a result, `npm install ... --guided` does not offer or install them.
+
+This plan wires `land` and `takeoff` into the guided installer so users selecting any of the three presets (Starter / Pro / Full) get them by default, and customizers see them as discrete options in the appropriate category.
+
+It also adds a defensive parity check (test) so future skills added to `.github/skills/` cannot silently miss the installer pipeline again.
+
+## Problem Frame
+
+**Symptom.** User runs `npm install -g @atv/starterkit && atv-starterkit --guided` (or the equivalent), completes the wizard, and the resulting repo has no `.github/skills/land/SKILL.md` or `.github/skills/takeoff/SKILL.md` — even though those skills were merged this week.
+
+**Root cause.** The installer ships skills via `embed.FS` rooted at `pkg/scaffold/templates/skills/`. Files in `.github/skills/` (the source-of-truth dogfooding copy used by this repo's own Copilot configuration) are **not** automatically mirrored. Each new skill requires three coordinated edits:
+
+1. Copy `SKILL.md` (and any other files) into `pkg/scaffold/templates/skills/<name>/`.
+2. Register `<name>` in `coreSkillDirectories`, `orchestratorSkillDirectories`, or `easterEggSkillDirectories` in `pkg/scaffold/catalog.go`.
+3. Surface the skill in `pkg/tui/categories.go` `atvCategoryMapping` so customize-mode users can see and toggle it.
+
+When a skill is added but only step 1 (or only the dogfooding `.github/skills/` copy) is done, the `--guided` path silently omits it.
+
+**Past-week audit.** The full list of skills added or modified in `.github/skills/` since 2026-04-17:
+
+| Skill | Source copy (`.github/skills/`) | Template (`pkg/scaffold/templates/skills/`) | Catalog wired | TUI wired |
+|---|---|---|---|---|
+| `karpathy-guidelines` | (not present here, lives only as template) | ✅ present | ✅ in `coreSkillDirectories` | ✅ in `CategoryGuidelines` |
+| `meme-iq` | ✅ added 2026-04-24 | ✅ added same commit | ✅ in `easterEggSkillDirectories` | ✅ in `CategoryEasterEgg` |
+| `land` | ✅ added 2026-04-24 | ❌ **missing** | ❌ **missing** | ❌ **missing** |
+| `takeoff` | ✅ added 2026-04-24 | ❌ **missing** | ❌ **missing** | ❌ **missing** |
+
+Only `land` and `takeoff` are gaps. This plan closes them.
+
+## Requirements Trace
+
+- **R1.** After `--guided` install with the **Starter** preset, the resulting repo contains `.github/skills/land/SKILL.md` and `.github/skills/takeoff/SKILL.md`.
+- **R2.** After `--guided` install with **Pro** or **Full** presets, the same files are present (presets share `LayerCoreSkills` / `LayerOrchestrators`, so this follows from R1 once the right layer is chosen).
+- **R3.** In customize mode, `land` and `takeoff` appear as toggleable options in a category that makes sense to a user shipping work (Shipping).
+- **R4.** The two skills are pre-selected by default in customize mode (matching the behavior of all non-easter-egg ATV skills today).
+- **R5.** A regression test verifies that every directory under `pkg/scaffold/templates/skills/` is registered in exactly one of the three skill-directory slices in `catalog.go`. Adding a template without registering it must fail CI.
+- **R6.** A second regression test verifies that any skill present in `.github/skills/` is also present under `pkg/scaffold/templates/skills/` (so the dogfooding copy and shipped copy stay in sync), with an explicit allow-list for skills that intentionally only live in one place.
+
+## Scope Boundaries
+
+- **In scope:** Wiring `land` and `takeoff` into the installer, plus parity tests to prevent recurrence.
+- **Out of scope:**
+  - Editing the content of `land` / `takeoff` SKILL.md files. They were reviewed and merged this week; this plan ships them as-is.
+  - Reorganizing the existing preset structure or category taxonomy.
+  - Adding new presets.
+  - Backfilling other tools (Claude Code, Cursor) — `--guided` here means the ATV-starterkit Copilot installer.
+  - Migrating the dogfooding source-of-truth model. Today `.github/skills/` and `pkg/scaffold/templates/skills/` are both maintained by hand; that's a known cost we accept and only guard with a parity test.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `pkg/scaffold/catalog.go` — embeds templates and builds the install component list. Three slices control skill membership:
+  - `coreSkillDirectories` (~line 165) — always-on planning/learning/quality skills.
+  - `orchestratorSkillDirectories` (~line 187) — opt-in workflow orchestrators (`lfg`, `slfg`, `ralph-loop`, etc.).
+  - `easterEggSkillDirectories` (~line 197) — opt-in fun extras (`meme-iq`).
+- `pkg/scaffold/templates/skills/<name>/SKILL.md` — embedded via `//go:embed all:templates`. Walked by `skillComponents()` and filtered by the selected directories.
+- `pkg/tui/categories.go` `atvCategoryMapping` — maps display categories to ATV skill entries shown in the customize multi-select. The shipping category currently lists `ce-work`, `lfg`, `slfg`, `ce-compound`, `ce-compound-refresh`, `claude-permissions-optimizer`. Land/takeoff fit cleanly here.
+- `pkg/tui/presets.go` — Starter/Pro/Full all include `LayerCoreSkills` and `LayerOrchestrators`. Adding `land`/`takeoff` to either layer means all three presets pick them up automatically.
+
+### Decision: which layer for `land` and `takeoff`?
+
+They are session lifecycle workflows that wrap commit/push/PR (land) and backlog briefing (takeoff). The closest neighbors already in the repo are `lfg` and `slfg` in `orchestratorSkillDirectories`. Putting them in `coreSkillDirectories` is also defensible — they're broadly useful, not optional add-ons.
+
+**Decision:** Add to `coreSkillDirectories`. Rationale:
+
+1. They have no runtime prerequisites (unlike `lfg` which orchestrates other skills).
+2. They are short, self-contained protocols — closer to `setup` and `ce-plan` in spirit than to `lfg`.
+3. Putting them in core means the **Starter** preset gets them, which matches user intent: someone choosing the "lightest install" still expects basic session start/end protocols.
+4. Easy to revisit later — moving them to orchestrators is a one-line slice edit.
+
+### Institutional Learnings
+
+No directly applicable `docs/solutions/` entry. The closest prior precedent is the `meme-iq` PR (#22, commit 1f30760), which added a skill end-to-end across all three wiring sites in a single commit. We follow that pattern.
+
+### External References
+
+None needed. This is a wiring change against an existing internal API.
+
+## Key Technical Decisions
+
+- **Copy templates into `pkg/scaffold/templates/skills/`, do not symlink or runtime-load.** The installer uses `//go:embed`, which requires real files at build time. This matches existing convention.
+- **Place `land` and `takeoff` in `coreSkillDirectories`** (rationale above).
+- **Pre-select by default in customize mode.** `defaultSelectedSkillKeys` in `pkg/tui/wizard.go` already pre-selects every non-easter-egg ATV skill, so the new entries inherit this behavior automatically once added to `atvCategoryMapping`.
+- **Add a parity test** rather than a generator. A generator (auto-copy `.github/skills/` → `pkg/scaffold/templates/skills/`) is more invasive and changes the trust boundary between dogfooding and shipped artifacts. A test that fails CI when the two diverge gives the same protection at much lower cost.
+- **Keep `.github/skills/<name>/` as the editable source** for skills that exist in both places. The shipped template is a snapshot.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q:** Should land/takeoff go in core or orchestrators? **A:** Core (rationale above).
+- **Q:** Do they require any new directories in the installer (e.g., docs/changelog)? **A:** No — both are pure SKILL.md, no helper scripts.
+- **Q:** Is `karpathy-guidelines` in sync? **A:** Yes — it lives only as a template (no `.github/skills/karpathy-guidelines/` exists in this repo); already in core + Guidelines TUI category.
+- **Q:** Is `meme-iq` in sync? **A:** Yes — added in PR #22 across all three wiring sites.
+
+### Deferred to Implementation
+
+- **Q:** Exact wording for the TUI option labels for `land` and `takeoff`. **A:** Implementation will use one-line summaries derived from the SKILL.md descriptions; reviewer can tweak wording in the PR.
+- **Q:** Which existing test file to extend vs. create new. **A:** Decide once the implementer reads `pkg/scaffold/` test layout. If a `catalog_test.go` exists it gets extended; otherwise a new `parity_test.go` is added next to `catalog.go`.
+
+## Implementation Units
+
+- [x] **Unit 1: Copy `land` and `takeoff` templates into the embedded skills tree**
+
+**Goal:** Make the SKILL.md files available to `//go:embed` so the installer can write them.
+
+**Requirements:** R1, R2
+
+**Dependencies:** none
+
+**Files:**
+- Create: `pkg/scaffold/templates/skills/land/SKILL.md` (copy of `.github/skills/land/SKILL.md`)
+- Create: `pkg/scaffold/templates/skills/takeoff/SKILL.md` (copy of `.github/skills/takeoff/SKILL.md`)
+
+**Approach:**
+- Verbatim copy of the two SKILL.md files. No content edits.
+- After copying, run `go build ./...` to confirm the `embed.FS` picks them up cleanly.
+
+**Patterns to follow:**
+- `pkg/scaffold/templates/skills/lfg/SKILL.md` — single-file skill template precedent.
+- `pkg/scaffold/templates/skills/meme-iq/SKILL.md` — most recent precedent (PR #22).
+
+**Test scenarios:**
+- Test expectation: none for this unit alone — file presence is exercised by Unit 4's parity test and Unit 5's install integration test.
+
+**Verification:**
+- `find pkg/scaffold/templates/skills/land pkg/scaffold/templates/skills/takeoff -type f` returns exactly the two SKILL.md files.
+- `go build ./...` succeeds.
+
+---
+
+- [x] **Unit 2: Register `land` and `takeoff` in the catalog**
+
+**Goal:** Make the installer treat both skills as part of the core skill layer, so all three presets ship them.
+
+**Requirements:** R1, R2
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `pkg/scaffold/catalog.go`
+
+**Approach:**
+- Append `"land"` and `"takeoff"` to `coreSkillDirectories` (the slice currently containing `setup`, `learn`, `karpathy-guidelines`, etc.).
+- Place them alphabetically or grouped with similar lifecycle skills — implementer's call. Suggested placement: after `setup` since they bracket a session.
+- Do **not** add them to `orchestratorSkillDirectories` or `easterEggSkillDirectories`.
+
+**Patterns to follow:**
+- The existing entries in `coreSkillDirectories`. Style matches one-string-per-line.
+
+**Test scenarios:**
+- Happy path — Build a filtered catalog with `LayerCoreSkills` selected and assert that `.github/skills/land/SKILL.md` and `.github/skills/takeoff/SKILL.md` appear in the resulting `[]Component` paths.
+- Negative — Build a filtered catalog **without** `LayerCoreSkills` and assert neither file appears (proves they aren't accidentally smuggled in via another layer).
+
+**Verification:**
+- `go test ./pkg/scaffold/...` passes.
+- A small Go scratch program calling `BuildFilteredCatalog(detect.StackGeneral, []string{"core-skills"})` lists both files.
+
+---
+
+- [x] **Unit 3: Surface `land` and `takeoff` in the TUI customize categories**
+
+**Goal:** Customize-mode users see both skills as discrete options, pre-selected by default, in a category that matches their purpose.
+
+**Requirements:** R3, R4
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `pkg/tui/categories.go`
+
+**Approach:**
+- Add two entries to the `gstack.CategoryShipping` slice inside `atvCategoryMapping`:
+  - `{Label: "Takeoff — backlog briefing at session start", Key: "core-skills:takeoff", Source: "atv"}`
+  - `{Label: "Land — commit, push, and open a PR at session end", Key: "core-skills:land", Source: "atv"}`
+- Wording is suggestive — implementer may refine after re-reading the SKILL.md files.
+- Ordering: place `takeoff` before `ce-work` (start of session) and `land` after `claude-permissions-optimizer` (end of session). Keeps the category readable as a session timeline.
+- Default selection is automatic — `defaultSelectedSkillKeys` selects every non-easter-egg ATV entry.
+
+**Patterns to follow:**
+- The existing `lfg`/`slfg` entries in `CategoryShipping`.
+- The `meme-iq` entry's structure for category placement.
+
+**Test scenarios:**
+- Happy path — `BuildCategoryGroups` returns a Shipping group whose `Skills` slice contains `core-skills:takeoff` and `core-skills:land`.
+- Default-selection — `defaultSelectedSkillKeys` for the Shipping group (with empty preset gstack set) includes both keys.
+- Parse-roundtrip — `ParseSelections([]string{"core-skills:land", "core-skills:takeoff"})` returns `atvLayers` containing `core-skills` exactly once (deduped) and empty `gstackDirs`.
+
+**Verification:**
+- `go test ./pkg/tui/...` passes.
+- Manual smoke: run `go run ./cmd --guided` in a scratch directory, choose Starter, choose customize, confirm both entries appear and are checked in the Shipping screen.
+
+---
+
+- [x] **Unit 4: Parity regression test — every template directory must be registered**
+
+**Goal:** Prevent future drift where someone copies a skill into `pkg/scaffold/templates/skills/` but forgets to add it to one of the three slices.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Create: `pkg/scaffold/parity_test.go` (or extend an existing `catalog_test.go` if present)
+
+**Approach:**
+- Read the embedded template tree for `templates/skills/`, collect immediate subdirectory names.
+- Build the union of `coreSkillDirectories ∪ orchestratorSkillDirectories ∪ easterEggSkillDirectories`.
+- Assert the two sets are equal. Failure message must list both "registered but no template" and "template but not registered" entries so the offender knows which side to fix.
+- No allow-list — every templated skill should be assigned to a layer.
+
+**Patterns to follow:**
+- Standard Go `testing` package idioms.
+- `embed.FS.ReadDir("templates/skills")` to enumerate without filesystem assumptions.
+
+**Test scenarios:**
+- Happy path — With the codebase post-Unit 2, the test passes.
+- Negative (verified manually during development) — Temporarily delete `"land"` from `coreSkillDirectories` and rerun; the test must fail with a clear message naming `land`.
+- Negative (verified manually) — Temporarily create `pkg/scaffold/templates/skills/test-fixture-skill/SKILL.md` and rerun; the test must fail naming the unregistered directory.
+
+**Verification:**
+- `go test ./pkg/scaffold/ -run TestSkillDirectoryParity` passes.
+
+---
+
+- [x] **Unit 5: Parity regression test — `.github/skills/` and `pkg/scaffold/templates/skills/` stay in sync**
+
+**Goal:** Catch the exact failure this plan is fixing — a skill added to the dogfooding copy but never copied into the shipped templates.
+
+**Requirements:** R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `pkg/scaffold/dogfood_parity_test.go` (or fold into Unit 4's file)
+
+**Approach:**
+- Walk `.github/skills/` at test time using `os` (the dogfooding copy is at the repo root, not embedded).
+- Walk the embedded `templates/skills/` directories.
+- Define a small allow-list set in the test for skills that are **intentionally** template-only (today: `karpathy-guidelines`) or **intentionally** dogfooding-only (today: none, but reserve the slot).
+- Assert that the symmetric difference, minus the allow-list, is empty.
+- The test reads the repo via `runtime.Caller` or a relative `../../`-style traversal from the test file. Implementer chooses whichever idiom matches the rest of the test suite.
+
+**Patterns to follow:**
+- Look for existing tests that read repo-relative files (e.g., anything that opens `go.mod`); if none exists, use `filepath.Join(filepath.Dir(testFile), "../..")` derived from `runtime.Caller(0)`.
+
+**Test scenarios:**
+- Happy path — With Unit 1 done, the symmetric difference equals the allow-list and the test passes.
+- Negative (verified manually) — Temporarily delete `pkg/scaffold/templates/skills/land/SKILL.md` and rerun; the test must fail naming `land` as "in `.github/skills/` but not in templates."
+- Edge case — A skill present in both but whose SKILL.md content drifts: this test does **not** assert content equality. Document this explicitly in a code comment so future readers know the test is a presence check, not a content check. Content drift is an accepted cost — the dogfooding copy is the editable source and the template is a snapshot.
+
+**Verification:**
+- `go test ./pkg/scaffold/ -run TestDogfoodTemplateParity` passes.
+
+---
+
+- [x] **Unit 6: Smoke-test the full guided install end-to-end**
+
+**Goal:** Confirm the user-visible behavior — `--guided` install with the default preset writes both skills.
+
+**Requirements:** R1, R2
+
+**Dependencies:** Units 1–3
+
+**Files:**
+- Modify: existing sandbox/integration test if one exercises the guided path. Otherwise, a manual smoke test is sufficient — this unit produces a checklist, not new code, if no integration test exists.
+- Reference: `test/sandbox/sandbox_test.go` (already grep'd as a `--guided` consumer) — extend if it covers preset flows.
+
+**Approach:**
+- If `test/sandbox/sandbox_test.go` already exercises a preset install, add assertions for the two new SKILL.md files at the expected destination.
+- Otherwise, perform a manual smoke run: `go run ./cmd --guided` against a scratch directory, choose Starter without customize, confirm `.github/skills/land/SKILL.md` and `.github/skills/takeoff/SKILL.md` exist in the output.
+
+**Test scenarios:**
+- Happy path — Starter preset, no customize: both files written.
+- Happy path — Pro preset, no customize: both files written.
+- Happy path — Full preset, no customize: both files written.
+- Edge case — Starter preset, customize, deselect both options: neither file written. Confirms the toggle works in both directions.
+
+**Verification:**
+- All four scenarios above produce the expected outcome.
+- If an automated integration test was extended, `go test ./test/...` passes.
+
+## System-Wide Impact
+
+- **Interaction graph:** Three coordinated edits per skill (template copy, catalog slice, TUI category). The new parity tests close this multi-site update into a single enforced contract.
+- **Error propagation:** No runtime error paths affected. Only build-time embedding and install-time file writes.
+- **State lifecycle risks:** None — both skills are static markdown.
+- **API surface parity:** The installer's public-facing behavior changes additively: new files appear in installed repos. No flag changes, no removed behavior.
+- **Integration coverage:** Unit 6's end-to-end smoke covers the full pipeline that unit tests cannot — embed + filter + write to disk.
+- **Unchanged invariants:** Existing skills, presets, layer keys, and catalog behavior are unchanged. Existing repos that re-run the installer get the new skills additively (existing files are not overwritten, per the standard scaffold contract).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `land` or `takeoff` SKILL.md content depends on a helper script or asset that doesn't exist in the embedded tree | Both files are confirmed to be standalone single-file skills (verified via `git log --name-status`). If this changes in the future, Unit 4's parity test won't catch missing assets — but it will catch missing directories. Add to follow-up if asset-bearing skills land. |
+| Future skills get added to `.github/skills/` and forgotten again | Unit 5's dogfood parity test fails CI immediately. |
+| Choosing core over orchestrators surprises Starter-preset users with two extra files | Acceptable — both skills are short, low-noise, and explicitly about session lifecycle. Preset descriptions don't need updating; "core ATV planning, execution, review, and docs flow" already implies session lifecycle. |
+| TUI label wording confuses customize-mode users | Plan calls out wording as deferred to implementation. PR review tightens copy. |
+
+## Documentation / Operational Notes
+
+- No CHANGELOG entry strictly required — this is an installer wiring fix, not a user-facing feature change. However, since `land` and `takeoff` are net-new to `--guided` users, a one-line note under the next release ("Guided installer now ships `land` and `takeoff` skills by default") is worth adding to `CHANGELOG.md` as part of Unit 2 or Unit 3.
+- No README updates required — the README already describes the guided installer in general terms.
+- No migration or rollout coordination needed.
+
+## Sources & References
+
+- Related code:
+  - `pkg/scaffold/catalog.go` (`coreSkillDirectories`, `orchestratorSkillDirectories`, `easterEggSkillDirectories`, `skillComponents`, `BuildFilteredCatalogForPacks`)
+  - `pkg/tui/categories.go` (`atvCategoryMapping`)
+  - `pkg/tui/presets.go` (Starter/Pro/Full layer membership)
+  - `pkg/tui/wizard.go` (`defaultSelectedSkillKeys`)
+- Related PRs/commits:
+  - `92b49bd` feat(skills): port /land and /takeoff to Copilot skills
+  - `dfce627` fix(skills): address verified review findings on land + takeoff
+  - `1f30760` feat(installer): add memeIQ Easter Egg scaffolding (#22) — exemplar precedent for end-to-end skill wiring
+  - `f47e6e0` feat: add Karpathy Guidelines skill — exemplar of a template-only skill

--- a/docs/plans/2026-04-24-006-feat-land-ralph-loop-cleanup-plan.md
+++ b/docs/plans/2026-04-24-006-feat-land-ralph-loop-cleanup-plan.md
@@ -1,0 +1,199 @@
+---
+title: "feat: Add ralph-loop state cleanup step to land skill"
+type: feat
+status: active
+date: 2026-04-24
+---
+
+# feat: Add ralph-loop state cleanup step to land skill
+
+## Overview
+
+Add an explicit, idempotent cleanup step to the `land` skill that removes any stale `ralph-loop.local.md` state files anywhere under the repo before the final handoff banner. This prevents the next session from being silently trapped in a replayed ralph-loop prompt when state files are orphaned by session crashes, cwd drift into worktrees, or incomplete completion-promise emission.
+
+## Problem Frame
+
+The ralph-loop skill writes a state file at `.claude/ralph-loop.local.md` (relative to cwd at the time it starts). The plugin's stop-hook reads this file and replays the loop's original prompt verbatim as "Stop hook feedback" until the completion promise is emitted as the final tokens of an assistant turn.
+
+Failure modes observed in this session (PR #26 work):
+
+1. **cwd drift** — work moved into `/tmp/ghcp-wt` (a worktree). If the loop started in the main repo, the hook can read the main-repo state file even from the worktree.
+2. **Promise placement** — `<promise>DONE</promise>` was emitted but not as the trailing content of the assistant message; the hook treated the loop as still running.
+3. **Belt-and-braces cleanup is conditional** — the LFG pipeline's step 10 cleanup only runs *after* DONE is emitted. If the user invokes `/land` without going through LFG (the common path), no cleanup runs and the next session inherits the orphaned state file.
+
+The `land` skill is the natural place to add this cleanup: it is the canonical "I'm finished — close it out" entry point, and Step 7 already cleans up worktrees and stashes. Adding ralph-loop state to that cleanup costs nothing on the happy path (no file → no-op) and prevents the trap on the failure path.
+
+## Requirements Trace
+
+- **R1.** When `land` runs, any `ralph-loop.local.md` files under the current repo (recursively, in any `.claude/` directory) are deleted.
+- **R2.** The cleanup is idempotent — running it on a repo with no ralph-loop state files completes silently and does not fail.
+- **R3.** The cleanup runs in Step 7 (alongside existing worktree/stash cleanup), before Step 8 verification and Step 9 handoff. It must run **regardless of whether the prior session used ralph-loop** — there is no reliable way to detect that retroactively.
+- **R4.** All three copies of the `land` SKILL.md stay in sync: global (`~/.claude/skills/land/SKILL.md`), repo-vendored (`.github/skills/land/SKILL.md`), and scaffold template (`pkg/scaffold/templates/skills/land/SKILL.md`).
+- **R5.** Cleanup output is non-noisy: if files were deleted, mention them in the handoff so the user knows the loop was actively running; if nothing existed, stay silent.
+
+## Scope Boundaries
+
+- Not changing the ralph-loop skill itself or the stop-hook behavior — that's a separate concern.
+- Not adding ralph-loop cleanup to `takeoff` — takeoff is for starting work, and a stale state file there should still trip the safety net (the user should know if a previous session left a loop running).
+- Not adding cleanup to other "completion" skills (`/lfg`, `/ce:work`, etc.) — `land` is the user-facing terminal step. LFG's own step 10 already handles this for the autonomous-pipeline path.
+- Not changing the cleanup pattern used by LFG step 10 — keep the same `find ... -delete` idiom for consistency.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `~/.claude/skills/land/SKILL.md` (Step 7 "Clean up" section) — the insertion point. Currently handles `git stash list` and worktree exit.
+- `~/.claude/rules/common/land-the-plane.md` Step 6 — the user's private global rules echo the same checklist; if updated globally, this should also be updated for parity. (Note: this file is in `~/.claude/rules/common/`, not the skill directory — confirm whether it's authoritative or descriptive before editing.)
+- LFG pipeline step 10 (in user instruction text from this session): `find . -name ralph-loop.local.md -path '*/.claude/*' -delete 2>/dev/null || true` — this is the exact pattern to mirror.
+- `docs/solutions/workflow-issues/ralph-loop-stop-hook-blocking-session-exit-2026-04-17.md` — referenced in user global instructions as the recurrence record. Read it for any prior-art constraints before implementing.
+- `.github/skills/land/SKILL.md` and `pkg/scaffold/templates/skills/land/SKILL.md` — repo-vendored copies; the repo's `templates` flow propagates the scaffold version to new projects.
+
+### Institutional Learnings
+
+- The user's global instinct (95%+ confidence): "Always run a separate cleanup agent that did NOT write the original code" — for this work, the cleanup is a single-line `find` command, so no agent is needed; this instinct mostly informs that the cleanup must be unambiguous and self-contained.
+- The recurrence-history doc explicitly notes: "if the ralph-loop state file is ever orphaned (session crash, cwd drift into a subdirectory with a stale `.claude/ralph-loop.local.md`), the hook replays this string verbatim as Stop hook feedback." This is the failure mode this plan prevents.
+
+### External References
+
+None needed — this is a local convention update.
+
+## Key Technical Decisions
+
+- **Place the cleanup in Step 7, not Step 4 (commit) or Step 5 (push).** Cleanup is a workspace concern, not a code-or-history concern. Step 7 already groups cleanup actions (stashes, worktrees), so ralph-loop fits the section's existing intent.
+- **Run it unconditionally.** Detecting "did this session use ralph-loop?" is unreliable (it might have been started in a prior session, by a different agent, or via a hook). The cost of running the find on every `/land` is microseconds; the cost of a missed cleanup is a trapped next session. Run unconditionally.
+- **Glob restricted to `*/.claude/*`.** Match the LFG step 10 pattern exactly. Prevents accidentally deleting any unrelated `ralph-loop.local.md` someone might have authored as a real document elsewhere.
+- **Capture deleted-file output for the handoff.** If files were deleted, surface them in Step 9 handoff under "blockers / gotchas" so the user knows a loop was active. If none, say nothing.
+- **Update all three skill copies in one commit.** The scaffold template propagates to new projects via `pkg/scaffold/templates/skills/land/`, the repo-vendored copy is used for self-hosting, and the global copy is what runs for the current user. Drift between them creates confusion.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the global rules file (`~/.claude/rules/common/land-the-plane.md`) also be updated?** Yes — the global rules file is the user's private ground-truth for what `land` does. Update it for parity. If the rules file is descriptive (a copy of skill behavior) rather than authoritative, the update is cheap insurance. The plan treats it as in-scope.
+- **Should the cleanup also cover the home directory (`~/.claude/`)?** No — the LFG step 10 pattern is repo-relative (`find .`). A user-level `ralph-loop.local.md` would be the user's own concern, not something `/land` for a project should touch.
+
+### Deferred to Implementation
+
+- **Exact wording of the new step**: implementer chooses concise phrasing consistent with the existing Step 7 voice ("Clean up" → bulleted commands). Do not add a new top-level step.
+- **Whether to print the deleted file path or just a count**: implementer's choice; lean toward path so the user can audit.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add ralph-loop cleanup to global `land` SKILL.md**
+
+**Goal:** Append a ralph-loop state cleanup action inside Step 7 of the global skill.
+
+**Requirements:** R1, R2, R3, R5
+
+**Files:**
+- Modify: `~/.claude/skills/land/SKILL.md` (Step 7 — Clean up section)
+
+**Approach:**
+- After the existing stash/worktree cleanup bullets, add a new sub-bullet describing the ralph-loop state-file cleanup.
+- The shell snippet should match the LFG step 10 pattern: `find . -name ralph-loop.local.md -path '*/.claude/*' -delete 2>/dev/null || true`.
+- Add a one-line note: "If files were deleted, surface them in the Step 9 handoff under blockers/gotchas so the user knows a ralph-loop was active."
+- Include a brief rationale comment in the section describing *why* (cwd-drift orphans, replayed Stop hook feedback) so future maintainers don't strip it out as redundant.
+
+**Patterns to follow:**
+- Existing Step 7 bullet format (terse imperative, short shell snippet, one-line context).
+
+**Test scenarios:**
+- Happy path: running `/land` in a repo with no `ralph-loop.local.md` produces no extra handoff content and no errors.
+- Edge case: running `/land` in a repo with `.claude/ralph-loop.local.md` deletes it and surfaces the deletion in handoff.
+- Edge case: nested ralph-loop file at `subdir/.claude/ralph-loop.local.md` is also deleted.
+- Edge case: a real document literally named `ralph-loop.local.md` outside any `.claude/` directory is **not** deleted (path-glob constraint).
+- Error path: file system permission denied on the find — the `2>/dev/null || true` swallows the error and `/land` continues to Step 8.
+
+**Verification:**
+- `grep -c "ralph-loop" ~/.claude/skills/land/SKILL.md` returns ≥1.
+- The new bullet sits inside the Step 7 section, before Step 8.
+
+- [ ] **Unit 2: Sync repo-vendored `land` SKILL.md**
+
+**Goal:** Apply the same change to the repo's vendored copy at `.github/skills/land/SKILL.md`.
+
+**Requirements:** R4
+
+**Dependencies:** Unit 1 (so the canonical text is settled).
+
+**Files:**
+- Modify: `.github/skills/land/SKILL.md`
+
+**Approach:**
+- Mirror Unit 1's edit verbatim. Avoid drift.
+
+**Test scenarios:**
+- Test expectation: none — pure documentation sync. Verified by `diff <(sed -n '/^### Step 7/,/^### Step 8/p' ~/.claude/skills/land/SKILL.md) <(sed -n '/^### Step 7/,/^### Step 8/p' .github/skills/land/SKILL.md)` showing no functional difference.
+
+**Verification:**
+- The two Step 7 sections are textually equivalent (modulo any intentional repo-specific notes).
+
+- [ ] **Unit 3: Sync scaffold template**
+
+**Goal:** Apply the same change to `pkg/scaffold/templates/skills/land/SKILL.md` so new projects scaffolded after this change inherit the cleanup step.
+
+**Requirements:** R4
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `pkg/scaffold/templates/skills/land/SKILL.md`
+
+**Approach:**
+- Mirror Unit 1's edit verbatim.
+
+**Test scenarios:**
+- Test expectation: none — scaffold template documentation. Verified by diff against Unit 1's text.
+
+**Verification:**
+- A new project scaffolded via the repo's templating flow would get the updated Step 7.
+
+- [ ] **Unit 4: Update global rules file for parity**
+
+**Goal:** Reflect the same step in `~/.claude/rules/common/land-the-plane.md` Step 6 ("Clean up") so the user's private global rules stay aligned with the skill.
+
+**Requirements:** R4
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `~/.claude/rules/common/land-the-plane.md` (Step 6 — Clean up section)
+
+**Approach:**
+- Add a parallel bullet matching Unit 1's wording. Keep the rules-file voice (user-instruction tone) consistent with surrounding bullets.
+
+**Test scenarios:**
+- Test expectation: none — pure documentation. Verified by reading the section.
+
+**Verification:**
+- Section now mentions ralph-loop cleanup alongside stash/worktree cleanup.
+
+## System-Wide Impact
+
+- **Interaction graph:** `/land` invocation → Step 7 cleanup → new `find` invocation. No new cross-skill calls. Independent of `ralph-loop`, `lfg`, or hook code.
+- **Error propagation:** `find ... -delete 2>/dev/null || true` is intentionally tolerant. If file system errors prevent deletion, `/land` continues; the next session may still hit the trap, but `/land` itself is not blocked.
+- **State lifecycle risks:** None — the cleanup deletes only files matching a narrow glob. No data is mutated outside `.claude/` directories.
+- **Unchanged invariants:** The "no merge unless explicitly asked" guardrail, the "push must succeed" rule, and the final banner remain exactly as written.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| User has a legitimate `ralph-loop.local.md` document at a non-`.claude/` path | Path glob `*/.claude/*` excludes such cases by design |
+| `find` invocation fails on Windows / WSL edge cases | The `2>/dev/null \|\| true` swallows errors; documented behavior matches LFG step 10 which has been in use without issue |
+| Three-file sync drifts over time (one copy updated, others not) | Plan calls for all three in one commit; future maintenance should grep for `ralph-loop` across all three before editing any |
+| Scaffold template change breaks downstream projects already using older land template | The change is additive (new bullet); existing scaffolded projects continue to work and benefit from the next pull/regen |
+
+## Documentation / Operational Notes
+
+- No external docs or runbooks reference Step 7 cleanup specifically; no doc updates needed beyond the four files in scope.
+- Optionally, add a note to `docs/solutions/workflow-issues/ralph-loop-stop-hook-blocking-session-exit-2026-04-17.md` (if it exists) recording that the `/land` cleanup was added as a defense-in-depth measure. Treat this as a follow-up, not a blocker.
+
+## Sources & References
+
+- Skill file: `~/.claude/skills/land/SKILL.md`
+- Repo-vendored copy: `.github/skills/land/SKILL.md`
+- Scaffold template: `pkg/scaffold/templates/skills/land/SKILL.md`
+- Global rules echo: `~/.claude/rules/common/land-the-plane.md`
+- Recurrence record (per user global instructions): `docs/solutions/workflow-issues/ralph-loop-stop-hook-blocking-session-exit-2026-04-17.md`
+- Pattern source: LFG pipeline step 10 (user-instruction text, this session)

--- a/docs/plans/2026-04-24-006-feat-land-ralph-loop-cleanup-plan.md
+++ b/docs/plans/2026-04-24-006-feat-land-ralph-loop-cleanup-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Add ralph-loop state cleanup step to land skill"
 type: feat
-status: active
+status: completed
 date: 2026-04-24
 ---
 

--- a/docs/plans/2026-04-25-001-feat-land-skill-session-state-step-plan.md
+++ b/docs/plans/2026-04-25-001-feat-land-skill-session-state-step-plan.md
@@ -1,0 +1,209 @@
+---
+title: "feat: Add session-state capture step to /land skills (Claude + Copilot)"
+type: feat
+status: active
+date: 2026-04-25
+---
+
+# feat: Add session-state capture step to /land skills (Claude + Copilot)
+
+## Overview
+
+The `/land` skill currently ends a session with commit → push → PR → verbal handoff. The verbal handoff is ephemeral — when the next session starts, the new agent has no written record of what was accomplished, what's next, or what tripped us up. Claude Code has a `remember` skill that writes `.remember/now.md` (read by the `SessionStart:clear` hook), but `/land` doesn't invoke it. GitHub Copilot CLI has no `remember` skill at all, but it does read `AGENTS.md` and `.github/copilot-instructions.md` at session start, which means a `.remember/now.md` file becomes durable Copilot context if instructions point Copilot at it.
+
+This plan adds a "Capture session state" step to both the Copilot land skill (`.github/skills/land/SKILL.md`) and the scaffold template (`pkg/scaffold/templates/skills/land/SKILL.md`), and adds a small instruction snippet to `.github/copilot-instructions.md` so Copilot reads `.remember/now.md` on startup. The Claude side has already been updated in `~/.claude/skills/land/SKILL.md` (out of repo) — this plan covers only the in-repo Copilot surfaces.
+
+## Problem Frame
+
+- `/land` ships PRs cleanly but leaves no machine-readable handoff for the next session.
+- Verbal summaries vanish into the transcript; the next agent has to re-derive context from `git log` and PR descriptions.
+- Claude has `remember` + `SessionStart` hook to bridge sessions; Copilot has neither, but does read AGENTS.md / copilot-instructions.md unconditionally on startup.
+- The atv-starterkit ships both Claude and Copilot skills as first-class citizens (see `.github/skills/land/SKILL.md` and `pkg/scaffold/templates/skills/land/SKILL.md`), so the fix needs to land in both.
+
+## Requirements Trace
+
+- R1. The `.github/skills/land/SKILL.md` checklist captures session state to `.remember/now.md` before the verbal handoff, on every land regardless of whether code changed.
+- R2. The scaffold template (`pkg/scaffold/templates/skills/land/SKILL.md`) carries the same step so newly scaffolded repos inherit the behavior.
+- R3. Step renumbering is internally consistent — every cross-reference inside the file points to the right step number after insertion.
+- R4. `.github/copilot-instructions.md` instructs Copilot to read `.remember/now.md` at session start when it exists.
+- R5. The session-state file uses a stable, scannable format (branch, PR, accomplished, next, blockers) so any agent can parse it without an SDK.
+- R6. The step is shell-only — no skill dependency — so it works whether Copilot, Claude, or a human runs the checklist.
+- R7. The final-banner step ("PLANE LANDED") remains the last line of output; the new step sits before the handoff.
+
+## Scope Boundaries
+
+- **Out of scope:** Adding a Copilot-side `remember` skill or chatmode/prompt file. The native `--name`/`--resume` flow is already documented elsewhere; this plan does not wire it into `/land`.
+- **Out of scope:** Modifying the Claude `~/.claude/skills/land/SKILL.md` (already done out-of-repo).
+- **Out of scope:** Adding Stop hooks, SessionStart hooks, or settings.json changes for either tool.
+- **Out of scope:** Changing the `/takeoff` skill to read `.remember/now.md` (Copilot will pick it up via the AGENTS.md instruction; Claude already reads it via the existing SessionStart hook).
+- **Out of scope:** Backfilling existing scaffolded repos.
+- **Out of scope:** Per-session `--share=<path>` transcript export (different concern; tracked separately if pursued).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.github/skills/land/SKILL.md` — Active Copilot land skill in this repo (10 steps, currently no session-state capture). Mirrors structure of the Claude skill.
+- `pkg/scaffold/templates/skills/land/SKILL.md` — Same content shipped as a scaffold template via the `atv` CLI.
+- `.github/copilot-instructions.md` — Repo's instruction file Copilot reads on every session start. Already documents `/land`, `/takeoff`, etc. New "session bookends" guidance fits naturally here.
+- `~/.claude/skills/land/SKILL.md` (out of repo, reference only) — Already patched with the Step 9 `remember:remember` invocation; this plan mirrors its shape, but for Copilot which has no skill equivalent.
+- `.remember/` directory — Already exists in the working tree (untracked). Created by the Claude `remember` skill earlier in the session. The format (`now.md`, `today-*.md`, `recent.md`) is the de facto standard.
+
+### Institutional Learnings
+
+- `/land` has a documented stale-state-file failure mode (ralph-loop replay) — Step 7 already does belt-and-braces cleanup. The new session-state step should follow the same posture: unconditional, idempotent, cheap.
+- The "verbal handoff" pattern was insufficient in practice — this session itself proves the gap (the user had to ask whether session state is captured during land). Writing a file makes the handoff durable.
+
+### External References
+
+- [GitHub Copilot CLI docs — `--continue`, `--resume`, AGENTS.md / copilot-instructions.md auto-loading](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli)
+- [Copilot CLI slash commands — `/compact`, `/context`, `/model`; no `/remember`](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli)
+
+## Key Technical Decisions
+
+- **Shell-only implementation, no skill dependency.** Copilot has no `remember` skill, and we want the step to work identically for any agent (or a human) running the checklist. A heredoc into `.remember/now.md` is universal.
+- **Use `.remember/now.md` as the canonical filename**, matching the Claude `remember` skill's primary buffer. Both ecosystems converge on the same file.
+- **Step 9 placement**, before "Hand off" (Step 10) and "Final banner" (Step 11). The verbal handoff in Step 10 should reference the file. The banner stays the last line of output.
+- **Run unconditionally, including on docs-only / no-commit lands.** A buffer is cheap; a missing handoff is expensive.
+- **Idempotent overwrite.** `.remember/now.md` is replaced on every land (it's a "now" buffer, not an append-only log). Older state lives in `today-*.md` / `recent.md` if/when the Claude `remember` skill runs.
+- **Don't gate on `.remember/` existing** — `mkdir -p .remember` first.
+- **Copilot instruction is opt-in-ish** — phrased as "if `.remember/now.md` exists, read it for prior-session context" so it's a no-op in repos that don't use the workflow.
+- **No frontmatter changes** — both files already have YAML frontmatter; only the body changes.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q: Add a Copilot prompt file (`.github/prompts/land.prompt.md`) too?** — No. Out of scope; current `.github/skills/land/SKILL.md` is the canonical surface.
+- **Q: Wire `copilot --name "<branch>-land"` into the step for native Copilot resume?** — No. Adds a Copilot-only line to a tool-agnostic checklist. Track as future work if the resume pattern proves valuable.
+- **Q: Should the step also call `/remember` on Claude?** — Out of scope (already handled in `~/.claude/skills/land/SKILL.md`). The in-repo Copilot skill has no equivalent skill to call, and shell-writing the file works for both tools, so we keep the in-repo step pure shell.
+
+### Deferred to Implementation
+
+- **Exact wording of the file template** — happy-path content is "branch / PR / accomplished / next / blockers", but the precise heredoc structure is implementation detail. Mirror the Claude `remember` skill's `now.md` shape if it's already on disk in this working tree.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add Step 9 "Capture session state" to `.github/skills/land/SKILL.md`**
+
+  **Goal:** Insert a new Step 9 that writes `.remember/now.md`, renumber Hand off → 10 and Final banner → 11, and update all internal cross-references.
+
+  **Requirements:** R1, R3, R5, R6, R7
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `.github/skills/land/SKILL.md`
+
+  **Approach:**
+  - Insert new `### Step 9: Capture session state` section before the existing `### Step 9: Hand off`.
+  - Body: short rationale + a heredoc shell snippet that creates `.remember/` and writes `now.md` with branch, PR URL, date, accomplished, next-up, blockers.
+  - Renumber existing Step 9 → Step 10, existing Step 10 → Step 11.
+  - Update any in-file references to "Step 9" / "Step 10" that meant the old numbers (Step 7's ralph-loop sweep references "Step 9 handoff"; Step 1's "surface it to the user at Step 9"; Final banner's "Step 5 is skipped" — search and patch).
+  - Keep Step 11 (Final banner) as the last user-visible content; do not add anything after it.
+
+  **Patterns to follow:**
+  - The Claude version `~/.claude/skills/land/SKILL.md` (out-of-repo, reference only) for shape, but use shell instead of `Skill: remember:remember`.
+  - Existing voice/tone of the Copilot `.github/skills/land/SKILL.md` — terse, imperative, no fluff.
+
+  **Test scenarios:**
+  - Edge case: Run `grep -nE "^### Step" .github/skills/land/SKILL.md` and confirm sequential numbering 1–11 with no gaps or duplicates.
+  - Edge case: Run `grep -n "Step [0-9]" .github/skills/land/SKILL.md` and confirm every cross-reference points to a step that still exists with the correct meaning (handoff = 10, banner = 11).
+  - Happy path: Run the embedded shell snippet by hand from a worktree; confirm `.remember/now.md` is created with the expected sections populated.
+  - Happy path: Final banner is still on the last meaningful line of the document body.
+  - Test expectation: none — no executable code, doc-only change. Verification is structural/visual.
+
+  **Verification:**
+  - All step headings renumber cleanly.
+  - All in-body "Step N" references point to the correct (post-renumber) step.
+  - Heredoc snippet is valid bash (no unmatched quotes, no `<<EOF` typos).
+  - Final banner remains the last instruction.
+
+- [ ] **Unit 2: Mirror Step 9 into `pkg/scaffold/templates/skills/land/SKILL.md`**
+
+  **Goal:** Apply the identical change to the scaffold template so `atv`-scaffolded repos inherit the behavior.
+
+  **Requirements:** R2, R3, R5, R6, R7
+
+  **Dependencies:** Unit 1 (use the same wording for consistency)
+
+  **Files:**
+  - Modify: `pkg/scaffold/templates/skills/land/SKILL.md`
+
+  **Approach:**
+  - Diff Unit 1's edit against the template — both files start from the same lineage. Apply the same patch.
+  - If the two files have drifted (which they may have), sync the template to match `.github/skills/land/SKILL.md` only for the new step + renumbering. Don't sweep up unrelated drift in this unit.
+
+  **Patterns to follow:**
+  - Whatever shape Unit 1 ships.
+
+  **Test scenarios:**
+  - Edge case: `diff .github/skills/land/SKILL.md pkg/scaffold/templates/skills/land/SKILL.md` shows only intended divergence (or zero divergence if they were already identical for the affected sections).
+  - Happy path: Step numbering 1–11 sequential and consistent.
+  - Test expectation: none — doc-only change.
+
+  **Verification:**
+  - Same renumbering and cross-reference checks as Unit 1.
+  - The template still scaffolds cleanly (no Go template syntax broken — though this file has no `{{ }}` directives, confirm visually).
+
+- [ ] **Unit 3: Add `.remember/now.md` reading instruction to `.github/copilot-instructions.md`**
+
+  **Goal:** Tell Copilot to read `.remember/now.md` at session start when it exists, so the file written by Step 9 actually gets used.
+
+  **Requirements:** R4
+
+  **Dependencies:** None (independent of Units 1/2 — file consumption can land alongside or after producer)
+
+  **Files:**
+  - Modify: `.github/copilot-instructions.md`
+
+  **Approach:**
+  - Add a small "Session Continuity" section (or extend the existing "Session Bookends" section) with a one-paragraph instruction:
+    > At session start, if `.remember/now.md` exists in the repo, read it before responding — it contains a handoff from the previous session (branch, PR, accomplished, next steps, blockers). Treat it as authoritative context for continuing work.
+  - Keep wording short and durable; don't reference Claude's hook semantics.
+
+  **Patterns to follow:**
+  - Existing voice in `.github/copilot-instructions.md` — short bullets, single source of truth.
+
+  **Test scenarios:**
+  - Happy path: Open the file; the new instruction is present, scannable, and not duplicated.
+  - Edge case: No-op when `.remember/now.md` doesn't exist — the instruction explicitly conditions on existence.
+  - Test expectation: none — doc-only.
+
+  **Verification:**
+  - Instruction is present in `.github/copilot-instructions.md`.
+  - Wording is conditional (`if exists`) so it doesn't break in repos that haven't run `/land` yet.
+
+## System-Wide Impact
+
+- **Interaction graph:** None. No code paths, callbacks, middleware. Doc-only changes.
+- **Error propagation:** N/A.
+- **State lifecycle risks:** `.remember/now.md` is overwritten on every land. If a session crashes mid-land before Step 9, no state is captured — same risk profile as the existing verbal handoff. Acceptable.
+- **API surface parity:** The Claude `~/.claude/skills/land/SKILL.md` already has equivalent Step 9 (out-of-repo). The two surfaces now agree. The `pkg/scaffold/templates/skills/land/SKILL.md` template propagates to new repos.
+- **Integration coverage:** N/A — no automated tests for skill markdown content.
+- **Unchanged invariants:** Step 5 (push to remote) is still mandatory and gates the banner. Step 11 (banner) is still the last line. PR-creation behavior unchanged. No new dependencies introduced.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Renumbering misses a cross-reference | Run `grep -n "Step [0-9]" .github/skills/land/SKILL.md` after edit; eyeball every match. |
+| Template drift between `.github/skills/...` and `pkg/scaffold/templates/...` | Apply the same diff to both in the same PR. Don't expand Unit 2 to fix unrelated drift. |
+| `.remember/` is in `.gitignore` somewhere upstream and `.remember/now.md` never persists for the next session | Check `.gitignore`; if `.remember/` is excluded, that's actually fine — it's session-local state, not source. Document this if it's a gotcha. |
+| Copilot ignores the new instruction | Low — Copilot reads `.github/copilot-instructions.md` reliably per docs. Worst case: instruction is silently no-op, which is the current behavior anyway. |
+| Heredoc shell snippet has subtle bash incompatibility (e.g., user has `sh` not `bash`) | Use POSIX-compatible heredoc syntax; avoid bashisms. The existing land skill already assumes bash, so consistency is fine. |
+
+## Documentation / Operational Notes
+
+- No release notes needed — this is a quality-of-life change to the `/land` workflow itself.
+- The change is self-documenting: the new Step 9 explains what it does and why.
+- Future scaffolds (`atv` CLI) inherit the behavior automatically once Unit 2 lands.
+
+## Sources & References
+
+- This plan: `docs/plans/2026-04-25-001-feat-land-skill-session-state-step-plan.md`
+- Active Copilot skill: `.github/skills/land/SKILL.md`
+- Scaffold template: `pkg/scaffold/templates/skills/land/SKILL.md`
+- Repo-wide Copilot instructions: `.github/copilot-instructions.md`
+- Reference (out of repo): `~/.claude/skills/land/SKILL.md` already has equivalent Step 9.
+- [GitHub Copilot CLI docs](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli)

--- a/pkg/scaffold/catalog.go
+++ b/pkg/scaffold/catalog.go
@@ -186,6 +186,9 @@ var coreSkillDirectories = []string{
 	"unslop",
 	// Behavioral Guidelines
 	"karpathy-guidelines",
+	// Security
+	"atv-security",
+	"cso",
 }
 
 var orchestratorSkillDirectories = []string{

--- a/pkg/scaffold/catalog.go
+++ b/pkg/scaffold/catalog.go
@@ -174,6 +174,9 @@ var coreSkillDirectories = []string{
 	"deepen-plan",
 	"document-review",
 	"setup",
+	// Session lifecycle
+	"takeoff",
+	"land",
 	// ATV Learning Pipeline
 	"learn",
 	"instincts",

--- a/pkg/scaffold/parity_test.go
+++ b/pkg/scaffold/parity_test.go
@@ -141,6 +141,9 @@ func TestDogfoodTemplateParity(t *testing.T) {
 	}
 
 	// Skills intentionally living in only one location.
+	//
+	// templateOnly: skills that ship via the installer but are not used to
+	// dogfood this repo. Small, justified per-entry.
 	templateOnly := map[string]bool{
 		// karpathy-guidelines ships only as a template; there is no
 		// .github/skills/karpathy-guidelines/ in this repo.
@@ -148,13 +151,19 @@ func TestDogfoodTemplateParity(t *testing.T) {
 		// unslop ships only as a template (ATV quality skill).
 		"unslop": true,
 	}
-	dogfoodOnly := map[string]bool{
-		// Historical .github/skills/ entries that were never wired into the
-		// installer template tree. This baseline freezes the current state
-		// so the test catches future drift (a newly-added .github/skills/
-		// entry that someone forgets to mirror into templates/skills/).
-		// To ship one of these via --guided, copy it into
-		// pkg/scaffold/templates/skills/ and remove its entry here.
+
+	// pendingMirror: skills that exist under .github/skills/ but were never
+	// copied into the installer template tree. This list freezes the current
+	// state so future drift fails CI, but every entry here represents real
+	// tech debt: a skill that this repo dogfoods but that --guided users
+	// don't get. Shrink this list over time by either:
+	//   1. Copying the skill into pkg/scaffold/templates/skills/<name>/ and
+	//      registering it in catalog.go (then remove the entry here), or
+	//   2. Removing the unused .github/skills/<name>/ directory entirely.
+	//
+	// Do NOT add entries here without also opening a tracking issue. The
+	// presence of an entry should always be a question, not an answer.
+	pendingMirror := map[string]bool{
 		"agent-browser":             true,
 		"agent-native-architecture": true,
 		"agent-native-audit":        true,
@@ -200,9 +209,43 @@ func TestDogfoodTemplateParity(t *testing.T) {
 		"workflows-work":            true,
 	}
 
+	// Stale-entry check: every name listed in templateOnly must actually
+	// exist under templates/skills/, and every name in pendingMirror must
+	// actually exist under .github/skills/. If a skill is removed or
+	// renamed and the allow-list isn't updated, fail loudly so the list
+	// stays honest instead of silently accumulating dead entries.
+	var staleTemplateOnly []string
+	for name := range templateOnly {
+		if !templateSkills[name] {
+			staleTemplateOnly = append(staleTemplateOnly, name)
+		}
+	}
+	if len(staleTemplateOnly) > 0 {
+		sort.Strings(staleTemplateOnly)
+		t.Errorf(
+			"templateOnly contains entries no longer present under pkg/scaffold/templates/skills/: %v\n"+
+				"Remove each stale entry from this test.",
+			staleTemplateOnly,
+		)
+	}
+	var stalePendingMirror []string
+	for name := range pendingMirror {
+		if !dogfoodSkills[name] {
+			stalePendingMirror = append(stalePendingMirror, name)
+		}
+	}
+	if len(stalePendingMirror) > 0 {
+		sort.Strings(stalePendingMirror)
+		t.Errorf(
+			"pendingMirror contains entries no longer present under .github/skills/: %v\n"+
+				"Remove each stale entry from this test (the underlying tech debt is gone).",
+			stalePendingMirror,
+		)
+	}
+
 	var missingFromTemplates []string
 	for name := range dogfoodSkills {
-		if templateSkills[name] || dogfoodOnly[name] {
+		if templateSkills[name] || pendingMirror[name] {
 			continue
 		}
 		missingFromTemplates = append(missingFromTemplates, name)
@@ -212,7 +255,8 @@ func TestDogfoodTemplateParity(t *testing.T) {
 		t.Fatalf(
 			"skills present in .github/skills/ but missing from pkg/scaffold/templates/skills/: %v\n"+
 				"Copy each skill into pkg/scaffold/templates/skills/<name>/ so --guided installs ship it. "+
-				"If a skill is intentionally dogfood-only, add it to dogfoodOnly in this test.",
+				"If a skill is intentionally dogfood-only and shouldn't ship, add it to pendingMirror in this test "+
+				"(but treat that as recording tech debt, not closing the gap).",
 			missingFromTemplates,
 		)
 	}

--- a/pkg/scaffold/parity_test.go
+++ b/pkg/scaffold/parity_test.go
@@ -150,6 +150,10 @@ func TestDogfoodTemplateParity(t *testing.T) {
 		"karpathy-guidelines": true,
 		// unslop ships only as a template (ATV quality skill).
 		"unslop": true,
+		// atv-security and cso ship only as templates (security skills
+		// added via the installer template tree, not dogfooded yet).
+		"atv-security": true,
+		"cso":          true,
 	}
 
 	// pendingMirror: skills that exist under .github/skills/ but were never
@@ -181,6 +185,7 @@ func TestDogfoodTemplateParity(t *testing.T) {
 		"frontend-design":           true,
 		"gemini-imagegen":           true,
 		"generate_command":          true,
+		"ghcp-review-resolve":       true,
 		"git-clean-gone-branches":   true,
 		"git-commit":                true,
 		"git-commit-push-pr":        true,

--- a/pkg/scaffold/parity_test.go
+++ b/pkg/scaffold/parity_test.go
@@ -1,0 +1,268 @@
+package scaffold
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/All-The-Vibes/ATV-StarterKit/pkg/detect"
+)
+
+// TestCoreLayerShipsLandAndTakeoff verifies that selecting the core-skills
+// layer in --guided mode produces components for both the takeoff and land
+// session-lifecycle skills. Regression guard for the gap this test file
+// was created to close.
+func TestCoreLayerShipsLandAndTakeoff(t *testing.T) {
+	components := BuildFilteredCatalog(detect.StackGeneral, []string{"core-skills"})
+
+	want := map[string]bool{
+		".github/skills/land/SKILL.md":    false,
+		".github/skills/takeoff/SKILL.md": false,
+	}
+	for _, c := range components {
+		// Filepath separator may be OS-specific; normalize.
+		p := filepath.ToSlash(c.Path)
+		if _, ok := want[p]; ok {
+			want[p] = true
+		}
+	}
+	for path, found := range want {
+		if !found {
+			t.Errorf("expected %q in core-skills layer output, not found", path)
+		}
+	}
+
+	// Negative: without core-skills, neither file should appear (proves
+	// they are not smuggled in via another layer such as orchestrators).
+	other := BuildFilteredCatalog(detect.StackGeneral, []string{"orchestrators", "easter-eggs"})
+	for _, c := range other {
+		p := filepath.ToSlash(c.Path)
+		if strings.HasSuffix(p, "/skills/land/SKILL.md") || strings.HasSuffix(p, "/skills/takeoff/SKILL.md") {
+			t.Errorf("did not expect %q without core-skills layer selected", p)
+		}
+	}
+}
+
+// TestSkillDirectoryParity ensures every skill directory under
+// pkg/scaffold/templates/skills/ is registered in exactly one of the three
+// catalog slices (core, orchestrator, easter-egg). This catches the case
+// where a skill template is added but the wiring step is forgotten, which
+// would silently exclude it from --guided installs.
+func TestSkillDirectoryParity(t *testing.T) {
+	templateDirs := readEmbeddedSkillDirs(t)
+
+	registered := make(map[string]string)
+	for _, name := range coreSkillDirectories {
+		if existing, ok := registered[name]; ok {
+			t.Fatalf("skill %q is registered in both %q and core", name, existing)
+		}
+		registered[name] = "core"
+	}
+	for _, name := range orchestratorSkillDirectories {
+		if existing, ok := registered[name]; ok {
+			t.Fatalf("skill %q is registered in both %q and orchestrators", name, existing)
+		}
+		registered[name] = "orchestrators"
+	}
+	for _, name := range easterEggSkillDirectories {
+		if existing, ok := registered[name]; ok {
+			t.Fatalf("skill %q is registered in both %q and easter-eggs", name, existing)
+		}
+		registered[name] = "easter-eggs"
+	}
+
+	var unregistered []string
+	for _, dir := range templateDirs {
+		if _, ok := registered[dir]; !ok {
+			unregistered = append(unregistered, dir)
+		}
+	}
+	if len(unregistered) > 0 {
+		t.Fatalf(
+			"skill template directories not registered in any catalog slice: %v\n"+
+				"Add each name to coreSkillDirectories, orchestratorSkillDirectories, "+
+				"or easterEggSkillDirectories in pkg/scaffold/catalog.go.",
+			unregistered,
+		)
+	}
+
+	templateSet := make(map[string]bool, len(templateDirs))
+	for _, d := range templateDirs {
+		templateSet[d] = true
+	}
+	var orphans []string
+	for name := range registered {
+		if !templateSet[name] {
+			orphans = append(orphans, name)
+		}
+	}
+	if len(orphans) > 0 {
+		sort.Strings(orphans)
+		t.Fatalf(
+			"skill names registered in catalog.go but missing from pkg/scaffold/templates/skills/: %v\n"+
+				"Add the SKILL.md template or remove the catalog entry.",
+			orphans,
+		)
+	}
+}
+
+// TestDogfoodTemplateParity ensures that every skill present in
+// .github/skills/ (the dogfooding source-of-truth used by this repo's own
+// Copilot configuration) is also present under pkg/scaffold/templates/skills/
+// (the embedded copy the installer ships). Without this, a skill added to
+// .github/skills/ would silently miss the --guided install pipeline.
+//
+// This is a presence check only. Content drift between the two copies is
+// accepted: .github/skills/<name>/ is the editable source, and the template
+// is a periodic snapshot.
+func TestDogfoodTemplateParity(t *testing.T) {
+	repoRoot := repoRoot(t)
+
+	dogfoodRoot := filepath.Join(repoRoot, ".github", "skills")
+	dogfoodEntries, err := os.ReadDir(dogfoodRoot)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dogfoodRoot, err)
+	}
+
+	dogfoodSkills := make(map[string]bool)
+	for _, e := range dogfoodEntries {
+		if e.IsDir() {
+			dogfoodSkills[e.Name()] = true
+		}
+	}
+
+	templateSkills := make(map[string]bool)
+	for _, d := range readEmbeddedSkillDirs(t) {
+		templateSkills[d] = true
+	}
+
+	// Skills intentionally living in only one location.
+	templateOnly := map[string]bool{
+		// karpathy-guidelines ships only as a template; there is no
+		// .github/skills/karpathy-guidelines/ in this repo.
+		"karpathy-guidelines": true,
+		// unslop ships only as a template (ATV quality skill).
+		"unslop": true,
+	}
+	dogfoodOnly := map[string]bool{
+		// Historical .github/skills/ entries that were never wired into the
+		// installer template tree. This baseline freezes the current state
+		// so the test catches future drift (a newly-added .github/skills/
+		// entry that someone forgets to mirror into templates/skills/).
+		// To ship one of these via --guided, copy it into
+		// pkg/scaffold/templates/skills/ and remove its entry here.
+		"agent-browser":             true,
+		"agent-native-architecture": true,
+		"agent-native-audit":        true,
+		"andrew-kane-gem-writer":    true,
+		"ce-work-beta":              true,
+		"changelog":                 true,
+		"compound-docs":             true,
+		"create-agent-skill":        true,
+		"create-agent-skills":       true,
+		"deploy-docs":               true,
+		"dhh-rails-style":           true,
+		"dspy-ruby":                 true,
+		"every-style-editor":        true,
+		"file-todos":                true,
+		"frontend-design":           true,
+		"gemini-imagegen":           true,
+		"generate_command":          true,
+		"git-clean-gone-branches":   true,
+		"git-commit":                true,
+		"git-commit-push-pr":        true,
+		"git-worktree":              true,
+		"heal-skill":                true,
+		"onboarding":                true,
+		"orchestrating-swarms":      true,
+		"proof":                     true,
+		"rclone":                    true,
+		"report-bug":                true,
+		"report-bug-ce":             true,
+		"reproduce-bug":             true,
+		"resolve-pr-feedback":       true,
+		"resolve-pr-parallel":       true,
+		"resolve_parallel":          true,
+		"skill-creator":             true,
+		"test-xcode":                true,
+		"todo-create":               true,
+		"todo-resolve":              true,
+		"todo-triage":               true,
+		"triage":                    true,
+		"workflows-brainstorm":      true,
+		"workflows-compound":        true,
+		"workflows-plan":            true,
+		"workflows-review":          true,
+		"workflows-work":            true,
+	}
+
+	var missingFromTemplates []string
+	for name := range dogfoodSkills {
+		if templateSkills[name] || dogfoodOnly[name] {
+			continue
+		}
+		missingFromTemplates = append(missingFromTemplates, name)
+	}
+	if len(missingFromTemplates) > 0 {
+		sort.Strings(missingFromTemplates)
+		t.Fatalf(
+			"skills present in .github/skills/ but missing from pkg/scaffold/templates/skills/: %v\n"+
+				"Copy each skill into pkg/scaffold/templates/skills/<name>/ so --guided installs ship it. "+
+				"If a skill is intentionally dogfood-only, add it to dogfoodOnly in this test.",
+			missingFromTemplates,
+		)
+	}
+
+	var missingFromDogfood []string
+	for name := range templateSkills {
+		if dogfoodSkills[name] || templateOnly[name] {
+			continue
+		}
+		missingFromDogfood = append(missingFromDogfood, name)
+	}
+	if len(missingFromDogfood) > 0 {
+		sort.Strings(missingFromDogfood)
+		t.Fatalf(
+			"skills present in pkg/scaffold/templates/skills/ but missing from .github/skills/: %v\n"+
+				"Either mirror the skill into .github/skills/<name>/, or add it to templateOnly in this test.",
+			missingFromDogfood,
+		)
+	}
+}
+
+// readEmbeddedSkillDirs returns the immediate subdirectory names under
+// templates/skills/ in the embedded template FS.
+func readEmbeddedSkillDirs(t *testing.T) []string {
+	t.Helper()
+
+	entries, err := fs.ReadDir(templateFS, "templates/skills")
+	if err != nil {
+		t.Fatalf("reading embedded templates/skills: %v", err)
+	}
+
+	var dirs []string
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs = append(dirs, e.Name())
+		}
+	}
+	sort.Strings(dirs)
+	return dirs
+}
+
+// repoRoot returns the repository root, derived from this test file's
+// location, so the parity check works regardless of cwd.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// thisFile is .../pkg/scaffold/parity_test.go → climb two levels.
+	return filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+}

--- a/pkg/scaffold/templates/skills/land/SKILL.md
+++ b/pkg/scaffold/templates/skills/land/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: land
+description: Close out a session by committing, pushing, and opening a PR — then handing off. Use when the user says "land", "/land", "land the plane", "land plane", "land it", "let's land", "land this", "bring it in", "wrap it up", "land the plan", "time to land", "ok land", "go ahead and land", or any variation that signals they want to finish, close out, ship, or wrap up the current session's work. Executes the full checklist without asking. Never merges the PR — landing ≠ merging.
+---
+
+# Land the Plane
+
+The session completion counterpart to `/takeoff`. Where `/takeoff` *starts* work by surfacing the backlog, `/land` *finishes* work by running the full commit → push → PR → handoff checklist.
+
+## Trigger
+
+Any variation of: `land`, `/land`, `land the plane`, `land it`, `let's land`, `land this`, `bring it in`, `wrap it up`, `land the plan`, `land plane`, `time to land`, `ok land`, `go ahead and land`.
+
+When the user's message contains "land" in the context of finishing/wrapping up work, invoke this protocol. When in doubt, invoke it.
+
+## Core principle
+
+"Landing" means **commit, push, and create a PR** — it does **not** mean merge. A PR is how humans review agent work; no PR means no review means no trust. **Never merge unless the user explicitly says "merge this PR".**
+
+Work is **not complete until `git push` succeeds**. If push fails, resolve and retry until it works. Do not stop at "ready to push when you are" — you must push.
+
+## Execution
+
+Run the checklist **in order, completely, without asking**. Each step is non-negotiable.
+
+### Step 1: File remaining work
+
+Review what was worked on this session. Capture anything that's unfinished, deferred, or follow-up so it doesn't vanish when the session closes.
+
+- If the repo has Backlog.md tooling (`backlog/` directory at repo root and the `backlog` CLI available), create tasks for unfinished/follow-up work:
+  ```bash
+  if command -v backlog >/dev/null 2>&1 && [ -d backlog ]; then
+    backlog task create "<title>" --description "<context>"
+  fi
+  ```
+- Otherwise, gather remaining work into a short handoff list and surface it at Step 9.
+
+Skip silently if nothing remains.
+
+### Step 2: Run quality gates (only if code changed this session)
+
+Detect the stack from the repo root and run the matching build + test/lint commands. For ATV-starterkit specifically, this means Go at the root plus an optional Node subproject under `npm/`.
+
+```bash
+# Go (repo root) — run when go.mod is present AND Go files changed this session.
+# Quality gates run BEFORE commit, so we cannot rely on HEAD~1; check working tree.
+if [ -f go.mod ]; then
+  if { git diff --name-only;
+       git diff --name-only --cached;
+       git ls-files --others --exclude-standard; } | grep -qE '\.go$|^go\.(mod|sum)$'; then
+    go build ./... && go vet ./...
+  fi
+fi
+
+# Node subproject — run when npm/ files have changed (staged, unstaged, or untracked).
+if [ -f npm/package.json ]; then
+  if { git diff --name-only;
+       git diff --name-only --cached;
+       git ls-files --others --exclude-standard; } | grep -q '^npm/'; then
+    (cd npm && npm run build)
+  fi
+fi
+
+# Generic fallbacks (portable to other repos)
+# pnpm:    [ -f pnpm-workspace.yaml ] && pnpm build && pnpm lint
+# npm:     [ -f package.json ] && npm run build && npm run lint
+# Python:  [ -f pyproject.toml ] && pytest && ruff check .
+# Rust:    [ -f Cargo.toml ] && cargo build && cargo test
+```
+
+If any gate fails (non-zero exit), **halt the routine, fix the failure, and re-run from Step 2 before proceeding to Step 4**. Do not append `|| true` to swallow failures — a broken build does not ship, and a swallowed failure would falsely emit the success banner at Step 10.
+
+If no code changed (docs-only, config-only, planning-only sessions), skip quality gates and note that in the handoff.
+
+### Step 3: Update task status (if the repo has task tracking)
+
+- Mark completed tasks as `Done`.
+- Update in-progress tasks with short implementation notes so the next session has context.
+- If the repo uses `backlog_task_id` in plan frontmatter, ensure status reflects reality.
+
+### Step 4: Commit all changes
+
+Stage specific files — **never** `git add -A` or `git add .`. That risks pulling in `.env`, credentials, or large binaries.
+
+```bash
+git status                         # see what's outstanding
+git add <specific-files>           # stage deliberately
+git commit -m "<type>: <summary>"  # conventional commits (feat, fix, refactor, docs, test, chore, perf, ci)
+```
+
+If there are no changes, skip. Do not create empty commits.
+
+### Step 5: PUSH TO REMOTE (MANDATORY)
+
+Work is not complete until this step succeeds.
+
+```bash
+branch=$(git branch --show-current)
+if [ -z "$branch" ]; then
+  echo "ERROR: detached HEAD — refusing to push. Check out a branch first." >&2
+  exit 1
+fi
+# only rebase if this branch already tracks a remote — new branches have no upstream yet
+if git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
+  git pull --rebase origin "$branch"
+fi
+git push -u origin "$branch"
+git status                         # must show "up to date with origin"
+```
+
+If push fails (conflicts, hook rejection, branch protection), **resolve and retry** until it works. Do not hand off with unpushed commits.
+
+### Step 6: Create or update the PR
+
+A PR is the review artifact. Agent work without a PR has no trust surface.
+
+Check first whether a PR already exists on this branch, capturing the exit code so "no PR yet" is handled as normal workflow state rather than an error:
+
+```bash
+if PR_VIEW_OUTPUT=$(gh pr view --json url,title,state 2>&1); then
+  PR_VIEW_EXIT=0
+else
+  PR_VIEW_EXIT=$?
+fi
+printf '%s\n__GH_PR_VIEW_EXIT__=%s\n' "$PR_VIEW_OUTPUT" "$PR_VIEW_EXIT"
+```
+
+If no PR exists, create one. **For PR body construction, follow the conventions in [`git-commit-push-pr`](../git-commit-push-pr/SKILL.md)** — value-first, intent-forward, scaled to the complexity of the change. Do not re-implement that logic here.
+
+Resolve the default branch dynamically — it's not always `main`:
+
+```bash
+default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+if [ -z "$default_branch" ]; then
+  default_branch=$(git rev-parse --verify origin/main >/dev/null 2>&1 && echo "main" || echo "master")
+fi
+git log "origin/$default_branch..HEAD" --oneline
+git diff "origin/$default_branch...HEAD" --stat
+```
+
+Summarize the **full branch** diff (not just the latest commit) when authoring the body. Include a test plan checklist. Share the PR URL at handoff.
+
+**Never merge the PR** unless the user explicitly says "merge this PR". Landing ≠ merging.
+
+### Step 7: Clean up
+
+```bash
+git stash list                     # check for session-era stashes
+# drop only stashes from this session; leave older ones alone
+```
+
+**If working inside a git worktree:** leave the worktree in place while the PR is open. Remove it manually with `git worktree remove <path>` only after the PR is merged or abandoned. Do not attempt to tear down worktrees from this skill.
+
+### Step 8: Verify
+
+Confirm a clean state:
+
+```bash
+git status                                          # working tree clean (or only untracked)
+branch=$(git branch --show-current)
+if [ -n "$branch" ] && git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
+  git log "origin/$branch..HEAD"                    # must be empty — all pushed
+else
+  echo "WARNING: no upstream tracking ref for '$branch' — cannot verify pushed state"
+fi
+```
+
+If either check fails, loop back and fix. Do not hand off a dirty or unpushed tree.
+
+### Step 9: Hand off
+
+Provide a concise summary for the next session:
+
+- **Accomplished** — what shipped (with task IDs if applicable)
+- **Next up** — what's queued (with task IDs if applicable)
+- **Blockers / gotchas** — anything that tripped you up or is waiting on a decision
+- **Branch** — current branch name
+- **PR** — PR URL from Step 6
+
+Keep it scannable. The next session (human or agent) should be able to take off from this handoff without re-reading the whole transcript.
+
+### Step 10: Final banner
+
+After the handoff summary, emit a single final line:
+
+```
+🛬 PLANE LANDED — NICE WORK
+```
+
+This **must** be the last line of output — no content after it, no code fence, no trailing heading. The banner is a **completion** marker, not a "we tried" marker: emit it only when the routine completes successfully (including the clean-tree / nothing-to-commit path where Step 5 is skipped because there's nothing to push). If `git push` never succeeds, a quality gate fails and halts the routine, or the PR step errors out and cannot be resolved, do **not** emit the banner.
+
+## Critical rules
+
+These are non-negotiable when `/land` is invoked:
+
+- **NEVER stop before pushing.** Unpushed work is stranded work.
+- **NEVER say "ready to push when you are."** You push. That is the job.
+- **NEVER skip quality gates.** Broken code does not ship.
+- **NEVER merge the PR** unless the user explicitly says "merge this PR".
+- **NEVER use `git add -A` or `git add .`.** Stage specific files.
+- **NEVER bypass hooks** (`--no-verify`, `--no-gpg-sign`) unless the user explicitly asks. If a hook fails, investigate and fix the root cause.
+- If push fails, **resolve and retry** until it succeeds.
+- **Always end successful landing output with the `🛬 PLANE LANDED — NICE WORK` banner line.** Do not emit the banner on failure paths (push failed, quality gate halted the routine, PR step errored out with no resolution).
+
+## Project-specific considerations
+
+Some repos have local conventions layered on top of this protocol — read `.github/copilot-instructions.md` (and any `AGENTS.md` or `CLAUDE.md` at the repo root, when present) for project-specific rules (e.g., branch protection, PR comment workflows, backlog linkage requirements). Project rules override these defaults where they conflict.

--- a/pkg/scaffold/templates/skills/land/SKILL.md
+++ b/pkg/scaffold/templates/skills/land/SKILL.md
@@ -154,7 +154,7 @@ git stash list                     # check for session-era stashes
 **Sweep stale ralph-loop state files.** If a previous session ran `ralph-loop` and the state file was orphaned (session crash, cwd drift into a worktree, completion promise emitted but not as the trailing tokens of the assistant message), the plugin's stop-hook will replay the loop's prompt verbatim in the next session as "Stop hook feedback." Run unconditionally — the cost is microseconds and detecting "did this session use ralph-loop?" is unreliable:
 
 ```bash
-DELETED_RL=$(find . -name ralph-loop.local.md -path '*/.claude/*' -print -delete 2>/dev/null)
+DELETED_RL=$(find . -name ralph-loop.local.md -path '*/.claude/*' -print -delete 2>/dev/null || true)
 if [ -n "$DELETED_RL" ]; then
   echo "ralph-loop state files removed (surface in Step 9 handoff under blockers/gotchas):"
   echo "$DELETED_RL"

--- a/pkg/scaffold/templates/skills/land/SKILL.md
+++ b/pkg/scaffold/templates/skills/land/SKILL.md
@@ -33,7 +33,7 @@ Review what was worked on this session. Capture anything that's unfinished, defe
     backlog task create "<title>" --description "<context>"
   fi
   ```
-- Otherwise, gather remaining work into a short handoff list and surface it at Step 9.
+- Otherwise, gather remaining work into a short handoff list and surface it at Step 10.
 
 Skip silently if nothing remains.
 
@@ -68,7 +68,7 @@ fi
 # Rust:    [ -f Cargo.toml ] && cargo build && cargo test
 ```
 
-If any gate fails (non-zero exit), **halt the routine, fix the failure, and re-run from Step 2 before proceeding to Step 4**. Do not append `|| true` to swallow failures — a broken build does not ship, and a swallowed failure would falsely emit the success banner at Step 10.
+If any gate fails (non-zero exit), **halt the routine, fix the failure, and re-run from Step 2 before proceeding to Step 4**. Do not append `|| true` to swallow failures — a broken build does not ship, and a swallowed failure would falsely emit the success banner at Step 11.
 
 If no code changed (docs-only, config-only, planning-only sessions), skip quality gates and note that in the handoff.
 
@@ -156,7 +156,7 @@ git stash list                     # check for session-era stashes
 ```bash
 DELETED_RL=$(find . -name ralph-loop.local.md -path '*/.claude/*' -print -delete 2>/dev/null || true)
 if [ -n "$DELETED_RL" ]; then
-  echo "ralph-loop state files removed (surface in Step 9 handoff under blockers/gotchas):"
+  echo "ralph-loop state files removed (surface in Step 10 handoff under blockers/gotchas):"
   echo "$DELETED_RL"
 fi
 ```
@@ -179,7 +179,36 @@ fi
 
 If either check fails, loop back and fix. Do not hand off a dirty or unpushed tree.
 
-### Step 9: Hand off
+### Step 9: Capture session state
+
+Persist a written handoff to `.remember/now.md` so the next session (Copilot, Claude, or human) can resume with full context — not just the verbal summary in Step 10. GitHub Copilot CLI reads `.github/copilot-instructions.md` on every session start, and the project-level instruction tells it to read `.remember/now.md` when it exists. This makes the handoff durable across sessions without requiring any tool-specific skill.
+
+Run unconditionally — even on docs-only or planning-only sessions. The buffer is cheap and the recovery value is high. Idempotent: overwrites the previous `now.md` each time.
+
+```bash
+mkdir -p .remember
+branch=$(git branch --show-current 2>/dev/null || echo "(unknown)")
+pr_url=$(gh pr view --json url -q .url 2>/dev/null || echo "(no PR)")
+cat > .remember/now.md <<EOF
+# Session handoff — $(date +%Y-%m-%d)
+
+**Branch:** $branch
+**PR:** $pr_url
+
+## Accomplished
+- (fill in: what shipped this session)
+
+## Next up
+- (fill in: what's queued for the next session)
+
+## Blockers / gotchas
+- (fill in: anything waiting on a decision or that tripped us up)
+EOF
+```
+
+After writing the file, replace the `(fill in: ...)` placeholders with the actual session content before moving on. The shell snippet creates the structure; the agent fills the substance.
+
+### Step 10: Hand off
 
 Provide a concise summary for the next session:
 
@@ -191,7 +220,7 @@ Provide a concise summary for the next session:
 
 Keep it scannable. The next session (human or agent) should be able to take off from this handoff without re-reading the whole transcript.
 
-### Step 10: Final banner
+### Step 11: Final banner
 
 After the handoff summary, emit a single final line:
 

--- a/pkg/scaffold/templates/skills/land/SKILL.md
+++ b/pkg/scaffold/templates/skills/land/SKILL.md
@@ -151,6 +151,18 @@ git stash list                     # check for session-era stashes
 
 **If working inside a git worktree:** leave the worktree in place while the PR is open. Remove it manually with `git worktree remove <path>` only after the PR is merged or abandoned. Do not attempt to tear down worktrees from this skill.
 
+**Sweep stale ralph-loop state files.** If a previous session ran `ralph-loop` and the state file was orphaned (session crash, cwd drift into a worktree, completion promise emitted but not as the trailing tokens of the assistant message), the plugin's stop-hook will replay the loop's prompt verbatim in the next session as "Stop hook feedback." Run unconditionally — the cost is microseconds and detecting "did this session use ralph-loop?" is unreliable:
+
+```bash
+DELETED_RL=$(find . -name ralph-loop.local.md -path '*/.claude/*' -print -delete 2>/dev/null)
+if [ -n "$DELETED_RL" ]; then
+  echo "ralph-loop state files removed (surface in Step 9 handoff under blockers/gotchas):"
+  echo "$DELETED_RL"
+fi
+```
+
+The path glob `*/.claude/*` ensures only state files inside `.claude/` directories are deleted — a legitimately named `ralph-loop.local.md` document elsewhere is left alone.
+
 ### Step 8: Verify
 
 Confirm a clean state:

--- a/pkg/scaffold/templates/skills/takeoff/SKILL.md
+++ b/pkg/scaffold/templates/skills/takeoff/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: takeoff
+description: Start a session with a prioritized backlog briefing. Use when the user says "takeoff", "take off", "/takeoff", "starting a new session", "what should I work on", "kickoff", "what's next", or wants a prioritized view of the backlog at the start of work. Surfaces the top-priority actionable tasks as bullet groups with status, dependencies, and blockers pulled from Backlog.md when available, or falls back to active plans under `docs/plans/`.
+---
+
+# Take Off
+
+The session kickoff counterpart to `/land`. Where `/land` closes out work, `/takeoff` *starts* work by giving a crisp, prioritized picture of what to pick up.
+
+## Trigger
+
+Any variation of:
+- `/takeoff`, `takeoff`, `take off`, `let's take off`, `time to take off`, `ready to take off`
+- `what should I work on`, `what's next`, `kickoff`, `start a new session`, `show me the backlog`
+
+When in doubt and the user is at the *start* of work (not finishing), invoke this protocol.
+
+## What this skill produces
+
+A short, scannable briefing with four sections:
+
+1. **Top Priority** — the N highest-priority actionable tasks
+2. **Blocked / Dependent** — tasks that exist but cannot be started
+3. **In Progress** — tasks already underway (not to be double-claimed)
+4. **Recommendation** — one sentence: "Start with `X` because …"
+
+Keep it terse. The user wants to pick a task and go, not read a report.
+
+## Execution
+
+### Step 1: Verify backlog tooling is present
+
+Check that the current repo has a `backlog/` directory. If not, fall back to reading plan files in `docs/plans/` and summarizing those instead (Step 2b).
+
+```bash
+test -d backlog && echo "backlog present" || echo "no backlog — will fall back to docs/plans/"
+```
+
+### Step 2: Pull the backlog (preferred path)
+
+Shell out to the backlog CLI only when both the CLI and `backlog/` directory are present. Otherwise fall through to Step 2b:
+
+```bash
+if command -v backlog >/dev/null 2>&1 && [ -d backlog ]; then
+  backlog task list --plain --sort priority
+  backlog sequence list --plain
+fi
+```
+
+Parse both outputs. Extract: id, title, priority, status, assignee, dependencies, blocked-by.
+
+If the `backlog` CLI is absent but the `backlog/` directory is present, read the task markdown files directly and parse frontmatter for the same fields.
+
+### Step 2b: Fallback — read `docs/plans/`
+
+When no `backlog/` directory exists (the default in ATV-starterkit today), scan `docs/plans/` for plans with `status: active` in the YAML frontmatter:
+
+```bash
+for plan in docs/plans/*.md; do
+  [ -f "$plan" ] || continue
+  # Only consider plans whose frontmatter has `status: active`.
+  # awk pulls the first YAML block; grep checks for the active marker.
+  if awk '/^---$/{c++; next} c==1' "$plan" | grep -qE '^status:[[:space:]]*active$'; then
+    title=$(awk '/^---$/{c++; next} c==1' "$plan" | grep -E '^title:' | sed 's/^title:[[:space:]]*//; s/^"//; s/"$//')
+    echo "- $(basename "$plan") — ${title:-(untitled)}"
+  fi
+done
+```
+
+Skip plans with `status: done`, `status: archived`, or missing frontmatter. Mention explicitly in the output that this is a `docs/plans/` fallback because the repo has no `backlog/` directory. If the fallback also yields zero active plans, drop into the empty-list edge case (congratulate + suggest `/ce-ideate` or `/ce-plan`).
+
+### Step 3: Classify each task
+
+For every task returned, bucket it:
+
+| Bucket | Criteria |
+|---|---|
+| **Actionable** | status = "To Do", no unresolved dependencies, not assigned to someone else |
+| **Blocked** | status = "To Do" but has a `blocked_by` / unresolved dependency |
+| **In Progress** | status = "In Progress" or "Doing" |
+| **Done** | status = "Done" — skip, don't surface |
+
+If a task has a dependency, note *which* task blocks it by ID.
+
+### Step 4: Render as bulleted groups
+
+Sort actionable tasks by priority (HIGH → MEDIUM → LOW), then by ID. By default show the top 5 in the top-priority group. If the user passed `--top N`, honor that. If they passed `--mine`, filter to their assignee.
+
+**Format: flat bullet lists grouped by category, with an emoji header on each secondary group.** Tables wrap poorly in narrow terminals. A plain `- ID — Title` bullet reads cleanly at any width.
+
+Use `—` (em-dash) as the separator between ID and title. For tasks with dependencies, append `(blocked by X, Y)` or `(depends on X)` at the end of the line.
+
+Group headers use these emojis:
+- 🛫 Top-priority actionable group (the main recommendation pool)
+- 🔵 Epic subtasks, or clusters of related follow-ups
+- 🟢 In Progress
+- ⚪ LOW / Housekeeping
+- 🔴 Blocked / Dependent (only when all blockers are hard blockers)
+
+Emit the output directly as markdown in your final response — no code fences, no custom rendering scripts.
+
+**Shape:**
+
+```markdown
+## 🛫 Takeoff — <repo-name>
+
+### Top Priority (actionable)
+
+- AGENTSAPI-1 — Orchestrator admin-agents client + manifest types
+- AGENTSAPI-2 — Admin Agents list page + row actions (depends on AGENTSAPI-1)
+- NEBULA-42 — PR comment three-step enforcement hook
+
+🔵 DOCREVIEW epic subtasks (children of DOCREVIEW-1)
+
+- DOCREVIEW-1.1 — strip Recommendations strip from final chain message
+- DOCREVIEW-1.2 — generalize Review Document button via ChainConfig
+
+🟢 In Progress
+
+- AGENTSAPI-7 — something currently being worked on (@sam)
+
+⚪ LOW / Housekeeping
+
+- NEBULA-35 — Enforce backlog.md usage via MCP server and hooks
+
+### Recommendation
+Start with **AGENTSAPI-1**. It's the next unblocked HIGH-priority item and clears the path for 2 more.
+```
+
+**Formatting rules:**
+- One task per line. Do not wrap a task across multiple lines.
+- Group headers use H3 (`###`) for top-priority only; secondary groups use a bold-emoji line (e.g., `🔵 DOCREVIEW epic subtasks`), not an H-level heading.
+- Omit groups that have zero tasks. If In Progress is empty, skip the section.
+- Never emit a table. No pipes, no box-drawing characters.
+- Do not truncate titles; rely on bullets to wrap cleanly at any width.
+
+### Step 5: Offer a next step
+
+End with a single question: "Want me to open the plan for `<ID>` and start `/ce-work` on it?" — do not auto-start. Takeoff is for orientation, not execution.
+
+### Step 6: Final banner
+
+After the recommendation question, emit a single final line:
+
+```
+✈️ TAKE OFF — NOW AT 30,000 FEET
+```
+
+This **must** be the last line of output — no content after it, no code fence, no trailing heading. It fires on every successful completion path, including the no-backlog fallback and the empty-task-list edge case. Do not emit the banner if the routine aborts before producing a briefing.
+
+## Formatting rules
+
+- **Bullets, not tables.** Tables break at narrow widths; bullets flow cleanly.
+- **Group with emoji headers.** 🛫 top-priority, 🔵 related clusters / epics, 🟢 in progress, ⚪ housekeeping, 🔴 hard-blocked.
+- **Never hide blockers.** Annotate dependencies inline with `(blocked by X)` — don't silently drop the task.
+- **Show dependency IDs explicitly.** `(blocked by AGENTSAPI-1)` is useful; `(has dependencies)` is not.
+- **Be honest about emptiness.** If there are zero actionable tasks, say so and suggest creating one or picking up in-progress work.
+- **Always end with the takeoff banner.** The final line of every successful invocation must be `✈️ TAKE OFF — NOW AT 30,000 FEET`.
+
+## Why this shape
+
+Takeoff's job is one concentrated briefing that answers *"what am I about to do and why"* in under 15 seconds of reading. Bullets + a one-line recommendation beat a paragraph because the user is scanning, not reading.
+
+Dependencies matter more than priority on their own — a HIGH task that's blocked is worse than a MEDIUM task that's ready. The recommendation should factor in unblocking power, not just raw priority.
+
+## Arguments
+
+- `--top N` — show N tasks in the top-priority group (default 5)
+- `--mine` — filter to tasks assigned to the current user (resolve via `git config user.email` or `git config user.name`)
+- `--all` — also include LOW priority actionable tasks
+- `--tag <tag>` — filter by a backlog tag/label
+
+If no arguments are given, use defaults.
+
+## Edge cases
+
+- **No `backlog/` directory** → fall back to `docs/plans/` summaries (Step 2b); tell the user.
+- **`backlog/` present but CLI missing** → parse task markdown files directly.
+- **`backlog` CLI returns non-zero** → report the error honestly, fall back to `docs/plans/`, still emit banner.
+- **Everything is blocked** → surface the root blockers and ask whether to create a task to unblock them.
+- **Task list is empty** → congratulate the user and suggest `/ce-ideate` or `/ce-plan` to generate new work.
+- **Tasks without priority set** → treat as MEDIUM.

--- a/pkg/tui/categories.go
+++ b/pkg/tui/categories.go
@@ -35,6 +35,10 @@ var atvCategoryMapping = map[string][]CategorySkill{
 	gstack.CategoryReview: {
 		{Label: "CE Review — multi-agent code review", Key: "core-skills:ce-review", Source: "atv"},
 	},
+	gstack.CategorySecurity: {
+		{Label: "ATV Security — agentic config security audit", Key: "core-skills:atv-security", Source: "atv"},
+		{Label: "CSO — OWASP Top 10 + STRIDE source-code review", Key: "core-skills:cso", Source: "atv"},
+	},
 	gstack.CategoryShipping: {
 		{Label: "Takeoff — backlog briefing at session start", Key: "core-skills:takeoff", Source: "atv"},
 		{Label: "CE Work — execute plans with quality checks", Key: "core-skills:ce-work", Source: "atv"},

--- a/pkg/tui/categories.go
+++ b/pkg/tui/categories.go
@@ -36,12 +36,14 @@ var atvCategoryMapping = map[string][]CategorySkill{
 		{Label: "CE Review — multi-agent code review", Key: "core-skills:ce-review", Source: "atv"},
 	},
 	gstack.CategoryShipping: {
+		{Label: "Takeoff — backlog briefing at session start", Key: "core-skills:takeoff", Source: "atv"},
 		{Label: "CE Work — execute plans with quality checks", Key: "core-skills:ce-work", Source: "atv"},
 		{Label: "LFG — full autonomous pipeline", Key: "orchestrators:lfg", Source: "atv"},
 		{Label: "SLFG — swarm mode parallel execution", Key: "orchestrators:slfg", Source: "atv"},
 		{Label: "CE Compound — document solutions", Key: "core-skills:ce-compound", Source: "atv"},
 		{Label: "CE Compound Refresh — refresh documented solutions", Key: "core-skills:ce-compound-refresh", Source: "atv"},
 		{Label: "Claude Permissions Optimizer — optimize tool permissions", Key: "orchestrators:claude-permissions-optimizer", Source: "atv"},
+		{Label: "Land — commit, push, and open a PR at session end", Key: "core-skills:land", Source: "atv"},
 	},
 	gstack.CategoryQATesting: {
 		{Label: "agent-browser — real browser automation with screenshots and form fills", Key: "agent-browser", Source: "atv"},

--- a/pkg/tui/categories_test.go
+++ b/pkg/tui/categories_test.go
@@ -77,3 +77,43 @@ func TestBuildCategoryGroupsWarnsWhenQARuntimeUnavailable(t *testing.T) {
 	}
 	t.Fatal("expected QA category group")
 }
+
+// TestShippingCategoryIncludesLandAndTakeoff is the customize-mode counterpart
+// to TestCoreLayerShipsLandAndTakeoff in pkg/scaffold. It guards against a
+// regression where Land or Takeoff are dropped from the Shipping category in
+// the customize-mode TUI even if they remain wired in the catalog.
+func TestShippingCategoryIncludesLandAndTakeoff(t *testing.T) {
+	groups := BuildCategoryGroups(gstack.Prerequisites{})
+
+	var shipping *CategoryGroup
+	for i, group := range groups {
+		if group.Category == gstack.CategoryShipping {
+			shipping = &groups[i]
+			break
+		}
+	}
+	if shipping == nil {
+		t.Fatal("expected shipping category group in BuildCategoryGroups output")
+	}
+
+	want := map[string]bool{
+		"core-skills:takeoff": false,
+		"core-skills:land":    false,
+	}
+	for _, skill := range shipping.Skills {
+		if _, ok := want[skill.Key]; ok {
+			want[skill.Key] = true
+			if skill.Source != "atv" {
+				t.Errorf("%s should have source=atv, got %q", skill.Key, skill.Source)
+			}
+			if skill.IsGstack {
+				t.Errorf("%s should not be marked as a gstack skill", skill.Key)
+			}
+		}
+	}
+	for key, found := range want {
+		if !found {
+			t.Errorf("shipping category missing required skill: %s", key)
+		}
+	}
+}

--- a/pkg/tui/categories_test.go
+++ b/pkg/tui/categories_test.go
@@ -78,6 +78,43 @@ func TestBuildCategoryGroupsWarnsWhenQARuntimeUnavailable(t *testing.T) {
 	t.Fatal("expected QA category group")
 }
 
+// TestSecurityCategoryIncludesAtvSecurityAndCso ensures the customize-mode
+// TUI surfaces atv-security and cso as toggleable options. Both ship via
+// LayerCoreSkills, so without TUI entries users would receive them
+// silently with no way to opt out.
+func TestSecurityCategoryIncludesAtvSecurityAndCso(t *testing.T) {
+	groups := BuildCategoryGroups(gstack.Prerequisites{})
+
+	var security *CategoryGroup
+	for i, group := range groups {
+		if group.Category == gstack.CategorySecurity {
+			security = &groups[i]
+			break
+		}
+	}
+	if security == nil {
+		t.Fatal("expected security category group in BuildCategoryGroups output")
+	}
+
+	want := map[string]bool{
+		"core-skills:atv-security": false,
+		"core-skills:cso":          false,
+	}
+	for _, skill := range security.Skills {
+		if _, ok := want[skill.Key]; ok {
+			want[skill.Key] = true
+			if skill.Source != "atv" {
+				t.Errorf("%s should have source=atv, got %q", skill.Key, skill.Source)
+			}
+		}
+	}
+	for key, found := range want {
+		if !found {
+			t.Errorf("security category missing required skill: %s", key)
+		}
+	}
+}
+
 // TestShippingCategoryIncludesLandAndTakeoff is the customize-mode counterpart
 // to TestCoreLayerShipsLandAndTakeoff in pkg/scaffold. It guards against a
 // regression where Land or Takeoff are dropped from the Shipping category in


### PR DESCRIPTION
## Summary

Adds an unconditional sweep of stale `ralph-loop.local.md` state files inside `.claude/` directories to the Step 7 cleanup section of the `land` skill — both the repo-vendored copy (`.github/skills/land/SKILL.md`) and the scaffold template (`pkg/scaffold/templates/skills/land/SKILL.md`).

## Why

ralph-loop's stop-hook replays the loop's prompt verbatim as 'Stop hook feedback' if the state file is orphaned. Failure modes observed in PR #26 work earlier this session:

- **cwd drift** — work moved into a worktree; the hook reads the main-repo state file from the worktree's parent context
- **Promise placement** — `<promise>DONE</promise>` was emitted but not as the trailing tokens of the assistant turn, so the hook treated the loop as still running
- **No automatic cleanup** — LFG's step 10 runs the same `find -delete` but only after DONE is emitted; users invoking `/land` directly never benefit

Result: next session inherits the orphan and gets trapped in a replayed loop prompt.

## What changes

```bash
DELETED_RL=$(find . -name ralph-loop.local.md -path '*/.claude/*' -print -delete 2>/dev/null)
if [ -n "$DELETED_RL" ]; then
  echo "ralph-loop state files removed (surface in Step 9 handoff under blockers/gotchas):"
  echo "$DELETED_RL"
fi
```

Same idiom used by LFG step 10. Path glob `*/.claude/*` keeps the sweep narrow.

## Test plan

- [x] Smoke test: created `.claude/ralph-loop.local.md`, `sub/.claude/ralph-loop.local.md`, and `unrelated/ralph-loop.local.md` in a tmp dir; confirmed only the two inside `.claude/` were deleted, the unrelated file preserved
- [x] Idempotency: ran the snippet a second time on the empty state — silent, no errors
- [ ] Manual: invoke `/land` in a session that previously ran ralph-loop and confirm cleanup output appears

## Files

- `.github/skills/land/SKILL.md` — repo-vendored copy
- `pkg/scaffold/templates/skills/land/SKILL.md` — scaffold template (new projects inherit)
- `docs/plans/2026-04-24-006-feat-land-ralph-loop-cleanup-plan.md` — implementation plan

## Out of scope

Parallel edits applied to `~/.claude/skills/land/SKILL.md` and `~/.claude/rules/common/land-the-plane.md` (user's private global config) are mentioned in the plan but are not part of this repo's diff.