### PR TITLE
feat(plugin): add VS Code source-install lifecycle

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,30 @@
+{
+  "name": "atv-starter-kit",
+  "owner": {
+    "name": "All The Vibes",
+    "url": "https://github.com/All-The-Vibes"
+  },
+  "metadata": {
+    "description": "Curated VS Code source-install catalog for ATV Starter Kit.",
+    "version": "2.6.3"
+  },
+  "plugins": [
+    {
+      "name": "atv-starter-kit",
+      "description": "ATV Starter Kit for VS Code: all ATV skills and reviewer/specialist agents in one personal install.",
+      "author": {
+        "name": "All The Vibes",
+        "url": "https://github.com/All-The-Vibes"
+      },
+      "homepage": "https://github.com/All-The-Vibes/ATV-StarterKit",
+      "tags": [
+        "atv",
+        "starter-kit",
+        "vscode",
+        "skills",
+        "agents"
+      ],
+      "source": "./plugins/atv-everything"
+    }
+  ]
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+README.md whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -11,18 +11,6 @@
   },
   "plugins": [
     {
-      "name": "atv-agents",
-      "source": "atv-agents",
-      "description": "All ATV reviewer and specialist agents (universal + stack-specific).",
-      "version": "2.6.3",
-      "keywords": [
-        "atv",
-        "agents",
-        "reviewers"
-      ],
-      "category": "agents"
-    },
-    {
       "name": "atv-everything",
       "source": "atv-everything",
       "description": "ATV Starter Kit — install everything in one shot: all skills + all reviewer/specialist agents.",
@@ -33,6 +21,18 @@
         "everything"
       ],
       "category": "starter-kit"
+    },
+    {
+      "name": "atv-agents",
+      "source": "atv-agents",
+      "description": "All ATV reviewer and specialist agents (universal + stack-specific).",
+      "version": "2.6.3",
+      "keywords": [
+        "atv",
+        "agents",
+        "reviewers"
+      ],
+      "category": "agents"
     },
     {
       "name": "atv-pack-easter-eggs",
@@ -153,7 +153,7 @@
     {
       "name": "atv-skill-atv-doctor",
       "source": "atv-skill-atv-doctor",
-      "description": "ATV `atv-doctor` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `atv-doctor` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -165,7 +165,7 @@
     {
       "name": "atv-skill-atv-security",
       "source": "atv-skill-atv-security",
-      "description": "ATV `atv-security` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `atv-security` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -177,7 +177,7 @@
     {
       "name": "atv-skill-atv-update",
       "source": "atv-skill-atv-update",
-      "description": "ATV `atv-update` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `atv-update` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -189,7 +189,7 @@
     {
       "name": "atv-skill-autoresearch",
       "source": "atv-skill-autoresearch",
-      "description": "ATV `autoresearch` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `autoresearch` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -201,7 +201,7 @@
     {
       "name": "atv-skill-brainstorming",
       "source": "atv-skill-brainstorming",
-      "description": "ATV `brainstorming` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `brainstorming` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -213,7 +213,7 @@
     {
       "name": "atv-skill-ce-brainstorm",
       "source": "atv-skill-ce-brainstorm",
-      "description": "ATV `ce-brainstorm` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `ce-brainstorm` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -225,7 +225,7 @@
     {
       "name": "atv-skill-ce-compound",
       "source": "atv-skill-ce-compound",
-      "description": "ATV `ce-compound` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `ce-compound` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -237,7 +237,7 @@
     {
       "name": "atv-skill-ce-compound-refresh",
       "source": "atv-skill-ce-compound-refresh",
-      "description": "ATV `ce-compound-refresh` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `ce-compound-refresh` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -249,7 +249,7 @@
     {
       "name": "atv-skill-ce-ideate",
       "source": "atv-skill-ce-ideate",
-      "description": "ATV `ce-ideate` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `ce-ideate` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -261,7 +261,7 @@
     {
       "name": "atv-skill-ce-plan",
       "source": "atv-skill-ce-plan",
-      "description": "ATV `ce-plan` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `ce-plan` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -273,7 +273,7 @@
     {
       "name": "atv-skill-ce-review",
       "source": "atv-skill-ce-review",
-      "description": "ATV `ce-review` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `ce-review` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -285,7 +285,7 @@
     {
       "name": "atv-skill-ce-work",
       "source": "atv-skill-ce-work",
-      "description": "ATV `ce-work` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `ce-work` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -297,7 +297,7 @@
     {
       "name": "atv-skill-deepen-plan",
       "source": "atv-skill-deepen-plan",
-      "description": "ATV `deepen-plan` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `deepen-plan` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -309,7 +309,7 @@
     {
       "name": "atv-skill-document-review",
       "source": "atv-skill-document-review",
-      "description": "ATV `document-review` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `document-review` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -321,7 +321,7 @@
     {
       "name": "atv-skill-evolve",
       "source": "atv-skill-evolve",
-      "description": "ATV `evolve` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `evolve` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -333,7 +333,7 @@
     {
       "name": "atv-skill-feature-video",
       "source": "atv-skill-feature-video",
-      "description": "ATV `feature-video` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `feature-video` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -345,7 +345,7 @@
     {
       "name": "atv-skill-instincts",
       "source": "atv-skill-instincts",
-      "description": "ATV `instincts` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `instincts` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -357,7 +357,7 @@
     {
       "name": "atv-skill-karpathy-guidelines",
       "source": "atv-skill-karpathy-guidelines",
-      "description": "ATV `karpathy-guidelines` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `karpathy-guidelines` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -369,7 +369,7 @@
     {
       "name": "atv-skill-land",
       "source": "atv-skill-land",
-      "description": "ATV `land` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `land` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -381,7 +381,7 @@
     {
       "name": "atv-skill-learn",
       "source": "atv-skill-learn",
-      "description": "ATV `learn` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `learn` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -393,7 +393,7 @@
     {
       "name": "atv-skill-lfg",
       "source": "atv-skill-lfg",
-      "description": "ATV `lfg` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `lfg` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -405,7 +405,7 @@
     {
       "name": "atv-skill-meme-iq",
       "source": "atv-skill-meme-iq",
-      "description": "ATV `meme-iq` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `meme-iq` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -417,7 +417,7 @@
     {
       "name": "atv-skill-observe",
       "source": "atv-skill-observe",
-      "description": "ATV `observe` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `observe` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -429,7 +429,7 @@
     {
       "name": "atv-skill-ralph-loop",
       "source": "atv-skill-ralph-loop",
-      "description": "ATV `ralph-loop` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `ralph-loop` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -441,7 +441,7 @@
     {
       "name": "atv-skill-resolve-todo-parallel",
       "source": "atv-skill-resolve-todo-parallel",
-      "description": "ATV `resolve_todo_parallel` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `resolve_todo_parallel` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -453,7 +453,7 @@
     {
       "name": "atv-skill-setup",
       "source": "atv-skill-setup",
-      "description": "ATV `setup` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `setup` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -465,7 +465,7 @@
     {
       "name": "atv-skill-slfg",
       "source": "atv-skill-slfg",
-      "description": "ATV `slfg` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `slfg` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -477,7 +477,7 @@
     {
       "name": "atv-skill-takeoff",
       "source": "atv-skill-takeoff",
-      "description": "ATV `takeoff` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `takeoff` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -489,7 +489,7 @@
     {
       "name": "atv-skill-test-browser",
       "source": "atv-skill-test-browser",
-      "description": "ATV `test-browser` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `test-browser` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",
@@ -501,7 +501,7 @@
     {
       "name": "atv-skill-unslop",
       "source": "atv-skill-unslop",
-      "description": "ATV `unslop` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+      "description": "ATV `unslop` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
       "version": "2.6.3",
       "keywords": [
         "atv",

--- a/README.md
+++ b/README.md
@@ -50,14 +50,23 @@ npx atv-starterkit@latest init --guided  # interactive TUI with multi-stack sele
 npx atv-starterkit@latest uninstall      # cleanly remove everything ATV installed
 ```
 
-**Personal install** (Copilot CLI plugin marketplace, follows you across projects):
+**Personal install** (VS Code source install or Copilot CLI marketplace, follows you across projects):
+
+VS Code / VS Code Insiders:
+
+1. Open the Command Palette.
+2. Run `Chat: Install Plugin from source`.
+3. Enter `All-The-Vibes/ATV-StarterKit`.
+4. Choose `atv-starter-kit`.
+
+Copilot CLI:
 
 ```bash
 copilot plugin marketplace add All-The-Vibes/ATV-StarterKit
 copilot plugin install atv-everything@atv-starter-kit
 ```
 
-Both paths can coexist. See [Installation](#installation) for the decision matrix and [docs/marketplace.md](docs/marketplace.md) for category bundles and per-skill plugins.
+The VS Code source-install path gives one complete ATV option. The Copilot CLI marketplace keeps category bundles and per-skill plugins for CLI users. Both personal paths can coexist with the project scaffold. See [Installation](#installation) for the decision matrix and [docs/marketplace.md](docs/marketplace.md) for CLI bundles and per-skill plugins.
 
 Then open **Copilot Chat** (⌃⌘I / Ctrl+Shift+I) and go:
 
@@ -69,20 +78,23 @@ Then open **Copilot Chat** (⌃⌘I / Ctrl+Shift+I) and go:
 /ce-compound     →  Document what you learned for future sessions
 
 /lfg             →  Run the full pipeline in one shot
+
+/atv-doctor      →  Diagnose ATV install health
+/atv-update      →  Update ATV marketplace plugins and safe source-installed AgentPlugins
 ```
 
 ---
 
 ## Installation
 
-ATV ships in **two flavours** — pick whichever matches your need (or use both):
+ATV ships in **three flavours** — pick whichever matches your need:
 
-| | `npx atv-starterkit init` | Copilot CLI marketplace |
-|---|---|---|
-| **Files land in** | Your project's `.github/`, `.vscode/`, `docs/` | `~/.copilot/installed-plugins/` |
-| **Scope** | Project-level, committed, team-shared | Personal, follows you across projects |
-| **What ships** | Skills + agents + MCP + hooks + instructions + setup-steps + docs | Skills + agents only |
-| **Best for** | Bootstrapping a new repo, codifying team workflow | Personal cross-project skills |
+| | `npx atv-starterkit init` | VS Code source install | Copilot CLI marketplace |
+|---|---|---|---|
+| **Files land in** | Your project's `.github/`, `.vscode/`, `docs/` | VS Code AgentPlugin directory | `~/.copilot/installed-plugins/` |
+| **Scope** | Project-level, committed, team-shared | Personal/editor-level | Personal, follows you across CLI projects |
+| **What ships** | Skills + agents + MCP + hooks + instructions + setup-steps + docs | One complete ATV skills + agents bundle | Skills + agents only |
+| **Best for** | Bootstrapping a new repo, codifying team workflow | VS Code Copilot users who want one obvious install choice | CLI users who want bundles or granular skills |
 
 ### Path 1 — npm scaffold (project-level, recommended for teams)
 
@@ -105,7 +117,18 @@ git clone https://github.com/All-The-Vibes/ATV-StarterKit.git
 cd ATV-StarterKit && go build -o atv-installer .
 ```
 
-### Path 2 — Copilot CLI marketplace (personal, cross-project)
+### Path 2 — VS Code source install (personal, editor-level)
+
+In VS Code or VS Code Insiders:
+
+1. Open the Command Palette.
+2. Run `Chat: Install Plugin from source`.
+3. Enter `All-The-Vibes/ATV-StarterKit`.
+4. Choose `atv-starter-kit`.
+
+This installs the complete recommended ATV personal bundle: all ATV skills and all reviewer/specialist agents. It does not install MCP config, hooks, instructions templates, setup steps, or project docs; use Path 1 for those.
+
+### Path 3 — Copilot CLI marketplace (personal, cross-project)
 
 ```bash
 copilot plugin marketplace add All-The-Vibes/ATV-StarterKit
@@ -119,7 +142,7 @@ copilot plugin install atv-pack-planning@atv-starter-kit    # one category
 copilot plugin install atv-skill-autoresearch@atv-starter-kit  # one skill
 ```
 
-The marketplace ships skills + agents only. For MCP config, hooks, instructions templates, and docs scaffolding use Path 1.
+The CLI marketplace ships skills + agents only. For MCP config, hooks, instructions templates, and docs scaffolding use Path 1. For the cleanest VS Code picker, use Path 2.
 
 ### Prerequisites
 
@@ -129,7 +152,7 @@ The marketplace ships skills + agents only. For MCP config, hooks, instructions 
 - **Bun** — for gstack browser skills (`/gstack-qa`, `/gstack-browse`, `/gstack-benchmark`)
 - **GitHub PAT** — for GitHub MCP server
 - **Azure CLI** — for Azure MCP server
-- **Copilot CLI** — for Path 2 (`copilot` command)
+- **Copilot CLI** — for Path 3 (`copilot` command)
 
 Without Bun, text-based gstack skills still work. `agent-browser` works independently of Bun.
 

--- a/docs/brainstorms/2026-04-28-vscode-source-install-clean-plugin-requirements.md
+++ b/docs/brainstorms/2026-04-28-vscode-source-install-clean-plugin-requirements.md
@@ -1,0 +1,163 @@
+---
+date: 2026-04-28
+topic: vscode-source-install-clean-plugin
+---
+
+# VS Code Source Install Clean Plugin
+
+## Summary
+
+ATV should present one clear default install choice on each personal-plugin surface: `atv-starter-kit` for VS Code source install and `atv-everything` for Copilot CLI. Granular CLI packs, single-skill plugins, and agents-only installs remain available as advanced options, but they must not leak into the default VS Code picker.
+
+---
+
+## Problem Frame
+
+VS Code Insiders can now install agent plugins directly from a GitHub repository through `Chat: Install Plugin from source`. When users install `All-The-Vibes/ATV-StarterKit`, the selector shows the full ATV Copilot CLI marketplace catalog: category packs, agents-only bundles, and many individual skill plugins. This makes ATV feel noisy and harder to trust at the exact moment a user is deciding what to install.
+
+The Copilot CLI catalog already has a general full-bundle plugin, `atv-everything`. The product problem is not that granular CLI plugins exist; it is that the default user journey is not clearly hierarchical. VS Code should show one productized choice backed by the complete bundle, while CLI users should be guided first to `atv-everything` and only then to advanced pack or single-skill installs.
+
+The same lifecycle should also be easy after install: users should be able to see which source-installed AgentPlugin version is active, update it, and reload VS Code without manually deleting plugin folders.
+
+---
+
+## Actors
+
+- A1. VS Code Copilot user: Installs ATV from a GitHub repository inside VS Code and expects one clear decision.
+- A2. ATV maintainer: Publishes and validates plugin metadata without breaking the existing starter kit experience.
+- A3. Copilot CLI user: Uses `atv-everything` as the recommended full install, with packs, single skills, and agents-only installs available as advanced granular options.
+- A4. Source-installed plugin user: Has ATV, CE, or another AgentPlugin installed under VS Code's agent plugin directory and needs a reliable update path.
+
+---
+
+## Key Flows
+
+- F1. Clean VS Code source install
+  - **Trigger:** A VS Code user runs `Chat: Install Plugin from source` and enters `All-The-Vibes/ATV-StarterKit` or a fork such as `datorresb/ATV-StarterKit`.
+  - **Actors:** A1
+  - **Steps:** VS Code resolves the repository, reads the plugin metadata, shows a single ATV install option, the user selects it, and ATV skills/agents become available.
+  - **Outcome:** The user sees ATV as one coherent product rather than 40+ install fragments.
+  - **Covered by:** R1, R2, R3, R4
+
+- F2. Maintainer validation
+  - **Trigger:** ATV plugin metadata, templates, or generated plugin folders change.
+  - **Actors:** A2
+  - **Steps:** The maintainer regenerates or updates plugin metadata, validates the generated output, confirms the source-install catalog remains one entry, confirms the CLI catalog still has a clear flagship default, and performs a VS Code source-install smoke test.
+  - **Outcome:** The clean selector remains stable across releases and CLI users still have a coherent recommended default.
+  - **Covered by:** R5, R6, R7, R10
+
+- F3. Source-installed plugin update
+  - **Trigger:** A user suspects their installed AgentPlugin is stale after a VS Code uninstall, reload, reinstall, or upstream release.
+  - **Actors:** A1, A4
+  - **Steps:** The user runs an ATV health/update workflow, sees each installed source plugin's current version and git state, confirms any update, and receives clear reload guidance after the update.
+  - **Outcome:** The user can update source-installed plugins without manually finding, deleting, or recloning plugin folders.
+  - **Covered by:** R11, R12, R13, R14, R15
+
+---
+
+## Requirements
+
+**User-facing install surface**
+
+- R1. VS Code source install must show one primary ATV option, named clearly enough that a first-time user can select it without reading ATV's marketplace docs.
+- R2. The primary option description must be short, user-facing, and fit comfortably in VS Code's Quick Pick row without relying on long warnings, URLs, or implementation notes.
+- R3. The option should represent the complete recommended ATV personal plugin experience for VS Code, not a partial skill, hidden dependency, or expert-only bundle.
+- R4. Individual skill plugins and category packs must not appear in the VS Code source-install picker for the default ATV repository install flow.
+
+**Compatibility and positioning**
+
+- R5. The project-level `npx atv-starterkit init` flow remains separate and continues to be documented as the team/shared repo bootstrap path.
+- R6. Copilot CLI marketplace support may remain granular, but it must position `atv-everything` as the recommended full install and must not force the VS Code source-install picker to expose every granular ATV package.
+- R7. If VS Code and Copilot CLI cannot use separate catalogs cleanly, prioritize the one-option VS Code source-install experience for this change and defer granular CLI preservation to a follow-up.
+
+**Documentation and validation**
+
+- R8. ATV documentation must include the VS Code source-install flow using the current command palette wording: `Chat: Install Plugin from source`.
+- R9. Documentation must explain the difference between VS Code source install, Copilot CLI plugin install, and `npx atv-starterkit init` without making users choose from a large matrix before the quick start; Copilot CLI docs must lead with `atv-everything` before advanced granular installs.
+- R10. A release or validation check must catch drift where the VS Code source-install surface grows beyond the intended single primary option.
+
+**VS Code AgentPlugin lifecycle**
+
+- R11. ATV health/update workflows must detect source-installed AgentPlugins under the VS Code and VS Code Insiders agent plugin roots, including repositories installed from GitHub source.
+- R12. The workflow must report a source-installed plugin's repository owner/name, current branch, current commit, version metadata when available, and whether the local checkout differs from its remote tracking branch.
+- R13. Updating a source-installed plugin must be opt-in and must avoid overwriting local changes silently; dirty or diverged worktrees require an explicit remediation choice.
+- R14. If a clean in-place update is not possible, the workflow may offer a reinstall/removal path only after showing the exact plugin folder that would be removed and receiving explicit confirmation.
+- R15. After any successful update, the workflow must tell the user how to make VS Code load the new plugin content, including reload/restart guidance when needed.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R4.** Given the ATV repository is installed through `Chat: Install Plugin from source`, when VS Code shows the plugin picker, then the picker contains one ATV install option with a concise description instead of the current 42-entry list.
+- AE2. **Covers R3.** Given a user installs the single ATV option, when they open Copilot Chat, then the recommended ATV skills and agents needed for the normal personal workflow are available without separately installing `atv-agents` or a category pack.
+- AE3. **Covers R5, R6, R9.** Given a user reads the README, when they compare install paths, then they can quickly tell that VS Code source install is personal/editor-level, `npx atv-starterkit init` is project/team-level, and Copilot CLI's recommended full install is `atv-everything`.
+- AE4. **Covers R10.** Given generated plugin metadata changes, when validation runs, then it fails or warns if the VS Code source-install catalog would expose granular skill or pack entries again, or if regeneration would replace the curated root source-install catalog with the granular CLI catalog.
+- AE5. **Covers R11, R12.** Given CE is installed under VS Code Insiders AgentPlugins, when the health workflow runs, then it reports the installed path, current package version, current commit, git tag/description when available, and whether it is behind `origin/main`.
+- AE6. **Covers R13, R14, R15.** Given a source-installed plugin is stale and its worktree is clean, when the user confirms an update, then ATV updates it safely and tells the user to reload VS Code; if the worktree is dirty or update fails, ATV explains the exact state and does not delete or overwrite anything without explicit confirmation.
+
+---
+
+## Success Criteria
+
+- A first-time VS Code user sees ATV as one polished product, not a long list of internal packages.
+- The install picker for ATV visually resembles the clean `EveryInc/compound-engineering-plugin` experience: one obvious flagship option rather than many granular options.
+- A Copilot CLI user can identify `atv-everything` as the default full install before encountering pack-level or single-skill advanced choices.
+- Source-installed plugin updates no longer require users to manually inspect `.vscode-insiders/agent-plugins`, delete folders, and reinstall by hand.
+- Planning can proceed without inventing the product shape: the chosen v1 UX is a single source-install entry.
+- Maintainers have a repeatable way to verify that ATV's source-install surface has not regressed.
+
+---
+
+## Scope Boundaries
+
+- Do not build a full VS Code extension, VSIX package, chat participant, or Visual Studio Marketplace listing in this v1.
+- Do not change the behavior of ATV skills or agents as part of this cleanup unless required for packaging correctness.
+- Do not remove or redesign the `npx atv-starterkit init` project bootstrap flow.
+- Do not remove Copilot CLI pack, single-skill, or agents-only plugins in this v1; preserve them as advanced/granular options.
+- Do not rename the Copilot CLI full bundle from `atv-everything` as part of this change.
+- Do not expose single-skill plugins, category packs, or agent-only bundles in the VS Code source-install picker.
+- Do not require users to understand Copilot CLI marketplace mechanics before installing ATV in VS Code.
+- Do not silently update, reset, delete, or reinstall source-installed plugin folders.
+- Do not attempt to solve generic VS Code extension auto-update or Visual Studio Marketplace publishing in this v1.
+
+---
+
+## Key Decisions
+
+- One-option source install: The desired VS Code experience is a single clean ATV option.
+- CLI flagship plus advanced granularity: `atv-everything` is the Copilot CLI default full install; granular packs, single skills, and agents-only installs remain available for advanced users.
+- VS Code UX over catalog granularity: Granular packs are useful for CLI/power users, but they should not appear in the default VS Code source-install picker.
+- Documentation should follow the current VS Code flow: The relevant user path is `Chat: Install Plugin from source`, not manual copying into `.github/skills/`.
+- Update belongs in the ATV maintenance workflow: Source-installed AgentPlugin health/update should extend `/atv-doctor` and `/atv-update` rather than becoming another visible install option.
+
+---
+
+## Dependencies / Assumptions
+
+- ATV's Copilot CLI metadata exposes 42 plugin entries from `.github/plugin/marketplace.json`. That catalog includes `atv-everything` as the full-bundle default plus advanced pack, single-skill, and agents-only options.
+- `EveryInc/compound-engineering-plugin` exposes only `compound-engineering` and `coding-tutor` in its plugin marketplace metadata, which matches the clean picker shown in VS Code.
+- VS Code's source-install resolver consumes root `marketplace.json` before `.github/plugin/marketplace.json`; generated metadata must preserve that split so regeneration does not replace the curated root catalog with the 42-entry CLI catalog.
+- GitHub issue `EveryInc/compound-engineering-plugin#637` confirms the current recommended source-install path for VS Code users.
+- On Windows with VS Code Insiders, source-installed AgentPlugins are present under `%USERPROFILE%/.vscode-insiders/agent-plugins/github.com/<owner>/<repo>` and are git worktrees.
+- Locally observed examples include `EveryInc/compound-engineering-plugin` with version metadata in `package.json` and `All-The-Vibes/ATV-StarterKit` with version metadata in `VERSION`.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- None.
+
+### Deferred to Planning
+
+- [Affects R6, R9][Technical] Confirm whether Copilot CLI marketplace browsing honors catalog order; if it does, keep `atv-everything` first, and if it does not, make documentation and install commands lead with `atv-everything`.
+- [Affects R10][Technical] Decide whether validation belongs in `cmd/plugingen`, CI, or a focused metadata smoke test.
+- [Affects R11-R15][Needs research] Confirm whether VS Code provides an official AgentPlugin update/reload command, or whether ATV should treat source-installed plugins as git checkouts and guide users to reload VS Code after update.
+- [Affects R11, R12][Technical] Decide whether ATV should update only `All-The-Vibes/ATV-StarterKit` by default or also offer generic diagnostics for other source-installed plugins such as `EveryInc/compound-engineering-plugin`.
+
+---
+
+## Next Steps
+
+-> /ce-plan for structured implementation planning

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -1,32 +1,45 @@
-# ATV Starter Kit — Copilot CLI plugin marketplace
+# ATV Starter Kit — source install and Copilot CLI marketplace
 
-The ATV Starter Kit is available as a [GitHub Copilot CLI plugin marketplace](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-marketplace) in addition to the project-scaffolding `npx atv-starterkit init` flow.
+The ATV Starter Kit is available through VS Code source install and as a [GitHub Copilot CLI plugin marketplace](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-marketplace) in addition to the project-scaffolding `npx atv-starterkit init` flow.
 
-## Two install paths — pick whichever matches your need
+## Three install paths — pick whichever matches your need
 
-| | `npx atv-starterkit init` | `copilot plugin install …@atv-starter-kit` |
-|---|---|---|
-| **Where files land** | Your project's `.github/`, `.vscode/`, `docs/` | `~/.copilot/installed-plugins/` |
-| **Scope** | Project-level, committed to git, shared with the team | Personal, follows you across projects |
-| **What ships** | Skills + agents + MCP config + hooks + instructions + setup-steps + docs scaffolding | Skills + agents only |
-| **Stack-aware** | Yes — Python/Rails/TypeScript instructions and reviewer agents | No — install plugins manually per project |
-| **Best for** | Bootstrapping a new repo, codifying team-wide AI workflow | Personal/cross-project skills you want everywhere |
+| | `npx atv-starterkit init` | VS Code source install | `copilot plugin install …@atv-starter-kit` |
+|---|---|---|---|
+| **Where files land** | Your project's `.github/`, `.vscode/`, `docs/` | VS Code AgentPlugin directory | `~/.copilot/installed-plugins/` |
+| **Scope** | Project-level, committed to git, shared with the team | Personal/editor-level | Personal, follows you across CLI projects |
+| **What ships** | Skills + agents + MCP config + hooks + instructions + setup-steps + docs scaffolding | One complete ATV skills + agents bundle | Skills + agents only |
+| **Stack-aware** | Yes — Python/Rails/TypeScript instructions and reviewer agents | No — complete personal bundle | No — install plugins manually per project |
+| **Best for** | Bootstrapping a new repo, codifying team-wide AI workflow | VS Code Copilot users who want one obvious install choice | CLI users who want bundles or granular skills |
 
-You can use both. They write to different locations and Copilot CLI's loading precedence (project skills > user skills > plugin skills) means project-level ATV files always win when there's overlap.
+You can use these paths together. They write to different locations and Copilot CLI's loading precedence (project skills > user skills > plugin skills) means project-level ATV files always win when there's overlap.
 
-## Add the marketplace
+## VS Code source install
+
+In VS Code or VS Code Insiders:
+
+1. Open the Command Palette.
+2. Run `Chat: Install Plugin from source`.
+3. Enter `All-The-Vibes/ATV-StarterKit`.
+4. Choose `atv-starter-kit`.
+
+The source-install catalog is intentionally curated to one option. That option points at the complete `atv-everything` bundle so VS Code users get all ATV skills and all reviewer/specialist agents without choosing from category packs or single-skill plugins.
+
+Maintainer validation for releases: the VS Code source-install picker should show one ATV option with a concise description. If it shows `atv-pack-*`, `atv-skill-*`, or `atv-agents`, the source-install catalog has regressed.
+
+## Add the Copilot CLI marketplace
 
 ```bash
 copilot plugin marketplace add All-The-Vibes/ATV-StarterKit
 ```
 
-Browse the catalog:
+Browse the CLI catalog:
 
 ```bash
 copilot plugin marketplace browse atv-starter-kit
 ```
 
-## Three install tiers
+## Copilot CLI install tiers
 
 ### 1. Flagship — install everything
 
@@ -34,12 +47,12 @@ copilot plugin marketplace browse atv-starter-kit
 copilot plugin install atv-everything@atv-starter-kit
 ```
 
-Bundles **every** ATV skill (29) + **every** reviewer/specialist agent (51). Equivalent in coverage to the Full preset of `atv init` (scoped to skills + agents — no MCP servers, hooks, or instructions templates).
+Bundles **every** ATV skill (31) + **every** reviewer/specialist agent (51). Equivalent in coverage to the Full preset of `atv init` (scoped to skills + agents — no MCP servers, hooks, or instructions templates).
 
-You probably also want:
+Advanced standalone agents-only install:
 
 ```bash
-copilot plugin install atv-agents@atv-starter-kit   # already included in atv-everything; install standalone if you only want the agents
+copilot plugin install atv-agents@atv-starter-kit   # agents for category-pack or single-skill installs
 ```
 
 ### 2. Category packs — bundle related skills
@@ -71,7 +84,7 @@ copilot plugin install atv-skill-atv-security@atv-starter-kit
 copilot plugin install atv-skill-ce-plan@atv-starter-kit
 ```
 
-> **Heads up:** per-skill plugins are NOT standalone for all skills. Several skills (`ce-plan`, `ce-ideate`, `deepen-plan`, `ce-review`, `document-review`) dispatch reviewer/research agents that are bundled separately in `atv-agents`. For the most predictable experience, install `atv-pack-*` (which includes the relevant agents through the marketplace's recommended bundling) or `atv-everything`.
+> **Heads up:** category-pack and per-skill plugins include skills only. Several skills (`ce-plan`, `ce-ideate`, `deepen-plan`, `ce-review`, `document-review`) dispatch reviewer/research agents that are bundled separately in `atv-agents`. For the most predictable experience, install `atv-everything`. If you choose a category pack or single skill that dispatches agents, also install `atv-agents`.
 
 ## Skill dependencies (subset)
 
@@ -109,16 +122,24 @@ All ATV plugins share the kit's release cadence — e.g. `atv-skill-autoresearch
 copilot plugin install ./   # from a local clone checked out at the desired tag
 ```
 
-## How the marketplace is generated
+## How the catalogs are generated
 
-`plugins/` and `.github/plugin/marketplace.json` are generated from `pkg/scaffold/templates/` by `pkg/plugingen/` and the `cmd/plugingen` CLI. Run:
+`plugins/`, root `marketplace.json`, `.github/plugin/marketplace.json`, and `.claude-plugin/marketplace.json` are generated from `pkg/scaffold/templates/` by `pkg/plugingen/` and the `cmd/plugingen` CLI. Run:
 
 ```bash
 go run ./cmd/plugingen        # regenerate after editing any template
 go run ./cmd/plugingen -check # CI dry-run mode (exits 1 on drift)
 ```
 
-CI runs the `-check` mode automatically. If templates change without a regeneration, CI fails with a clear "plugin tree out of sync" error.
+CI runs the `-check` mode automatically. If templates or generated catalog metadata change without a regeneration, CI fails with a clear "plugin tree out of sync" error.
+
+Catalog intent:
+
+- `marketplace.json` — VS Code source install, one curated `atv-starter-kit` option. VS Code checks this before `.github/plugin/marketplace.json`.
+- `.claude-plugin/marketplace.json` — mirrored curated source-install catalog for Claude-format compatibility.
+- `.github/plugin/marketplace.json` — Copilot CLI marketplace, granular bundles and per-skill plugins.
+
+If VS Code source install ever ignores root `marketplace.json` and reads `.github/plugin/marketplace.json` instead, prioritize the clean one-option VS Code experience and make the CLI granularity tradeoff explicit before release.
 
 ## Further reading
 

--- a/docs/plans/2026-04-28-001-feat-vscode-source-install-agentplugin-update-plan.md
+++ b/docs/plans/2026-04-28-001-feat-vscode-source-install-agentplugin-update-plan.md
@@ -1,0 +1,455 @@
+---
+title: "feat: Clean VS Code source install and AgentPlugin updates"
+type: feat
+status: active
+date: 2026-04-28
+origin: docs/brainstorms/2026-04-28-vscode-source-install-clean-plugin-requirements.md
+---
+
+# feat: Clean VS Code source install and AgentPlugin updates
+
+## Summary
+
+This plan keeps ATV's generator as the source of truth, adds a curated VS Code source-install AgentPlugin surface, and extends the generated maintenance skills so source-installed plugins can be diagnosed and updated safely. The implementation validates the picker surface early, preserves the project scaffold path, and keeps Copilot CLI granular while positioning `atv-everything` as the CLI flagship default.
+
+---
+
+## Problem Frame
+
+ATV currently projects its full Copilot CLI plugin marketplace into the metadata VS Code reads during `Chat: Install Plugin from source`, so first-time VS Code users see dozens of internal packs and single-skill plugins instead of one coherent ATV product. The same source-installed plugin lifecycle is also opaque after install: users have to inspect plugin folders, git state, and versions manually to know whether a VS Code AgentPlugin is stale.
+
+The Copilot CLI catalog already contains the right full-bundle default, `atv-everything`. The implementation should not remove the granular CLI catalog in v1; it should preserve those advanced choices while ensuring VS Code sees only the curated source-install entry and CLI docs/tests keep `atv-everything` in the flagship position.
+
+---
+
+## Assumptions
+
+*This plan was authored without another synchronous confirmation after research. The items below are plan-time bets that should be validated in the first implementation unit and reviewed before merge.*
+
+- VS Code source install reads marketplace definition files in this order: `marketplace.json`, `.plugin/marketplace.json`, `.github/plugin/marketplace.json`, `.claude-plugin/marketplace.json`. Because `.github/plugin` wins over `.claude-plugin`, ATV needs a curated root `marketplace.json` for the VS Code source-install surface while preserving `.github/plugin/marketplace.json` for Copilot CLI.
+- The `.claude-plugin/marketplace.json` catalog can still be generated as Claude-format metadata, but it is not sufficient by itself while ATV also carries a granular `.github/plugin/marketplace.json`.
+- Review found two implementation blockers to address before further validation: `compareFile` must be a package-level helper so Go compiles, and the generator must not write the granular CLI catalog to root `marketplace.json`.
+- Source-installed AgentPlugin updates should treat plugin directories as git checkouts. No official VS Code AgentPlugin update command was found in the current VS Code extension and AI extensibility docs.
+- `/atv-doctor` should report all GitHub-source AgentPlugins under VS Code roots, while `/atv-update` should default to updating ATV and require an explicit plugin/repo selection before updating non-ATV plugins.
+
+---
+
+## Requirements
+
+- R1. VS Code source install must show one primary ATV option, named clearly enough that a first-time user can select it without reading ATV's marketplace docs.
+- R2. The primary option description must be short, user-facing, and fit comfortably in VS Code's Quick Pick row without relying on long warnings, URLs, or implementation notes.
+- R3. The option should represent the complete recommended ATV personal plugin experience for VS Code, not a partial skill, hidden dependency, or expert-only bundle.
+- R4. Individual skill plugins and category packs must not appear in the VS Code source-install picker for the default ATV repository install flow.
+- R5. The project-level `npx atv-starterkit init` flow remains separate and continues to be documented as the team/shared repo bootstrap path.
+- R6. Copilot CLI marketplace support may remain granular, but it must position `atv-everything` as the recommended full install and must not force the VS Code source-install picker to expose every granular ATV package.
+- R7. If VS Code and Copilot CLI cannot use separate catalogs cleanly, prioritize the one-option VS Code source-install experience for this change and defer granular CLI preservation to a follow-up.
+- R8. ATV documentation must include the VS Code source-install flow using the current command palette wording: `Chat: Install Plugin from source`.
+- R9. Documentation must explain the difference between VS Code source install, Copilot CLI plugin install, and `npx atv-starterkit init` without making users choose from a large matrix before the quick start; Copilot CLI docs must lead with `atv-everything` before advanced granular installs.
+- R10. A release or validation check must catch drift where the VS Code source-install surface grows beyond the intended single primary option.
+- R11. ATV health/update workflows must detect source-installed AgentPlugins under the VS Code and VS Code Insiders agent plugin roots, including repositories installed from GitHub source.
+- R12. The workflow must report a source-installed plugin's repository owner/name, current branch, current commit, version metadata when available, and whether the local checkout differs from its remote tracking branch.
+- R13. Updating a source-installed plugin must be opt-in and must avoid overwriting local changes silently; dirty or diverged worktrees require an explicit remediation choice.
+- R14. If a clean in-place update is not possible, the workflow may offer a reinstall/removal path only after showing the exact plugin folder that would be removed and receiving explicit confirmation.
+- R15. After any successful update, the workflow must tell the user how to make VS Code load the new plugin content, including reload/restart guidance when needed.
+
+**Origin actors:** A1 VS Code Copilot user, A2 ATV maintainer, A3 Copilot CLI user, A4 source-installed plugin user.
+
+**Origin flows:** F1 Clean VS Code source install, F2 Maintainer validation, F3 Source-installed plugin update.
+
+**Origin acceptance examples:** AE1 covers R1/R2/R4, AE2 covers R3, AE3 covers R5/R9, AE4 covers R10, AE5 covers R11/R12, AE6 covers R13/R14/R15.
+
+---
+
+## Scope Boundaries
+
+- Do not build a full VS Code extension, VSIX package, chat participant, language model tool, or Visual Studio Marketplace listing in this v1.
+- Do not change ATV skill or agent behavior except for generated packaging metadata and the `atv-doctor` / `atv-update` maintenance instructions.
+- Do not redesign `npx atv-starterkit init`, its templates, MCP config, hooks, or project scaffold installer behavior.
+- Do not require VS Code users to understand Copilot CLI marketplace mechanics before installing ATV from source.
+- Do not remove Copilot CLI pack, single-skill, or agents-only plugins in this v1; preserve them as advanced/granular options.
+- Do not rename the Copilot CLI full bundle from `atv-everything` as part of this change.
+- Do not silently update, reset, delete, or reinstall any source-installed plugin folder.
+- Do not treat generated `plugins/` files as canonical source; template and generator changes remain authoritative.
+
+### Deferred to Follow-Up Work
+
+- Removing or collapsing Copilot CLI granularity: defer unless user demand or maintenance cost proves the advanced catalog is harmful. For v1, keep granularity but make `atv-everything` the obvious default.
+- Full VS Code extension publishing: evaluate only after the source-install path is clean and maintainers know whether a Marketplace extension is worth the extra release surface.
+- Project scaffold refresh support: leave the additive-only `atv init` limitation unchanged.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `pkg/plugingen/generate.go` generates every plugin directory and catalog metadata from `pkg/scaffold/templates/`. The intended split is that `writeMarketplace` emits the granular Copilot CLI catalog under `.github/plugin/marketplace.json`, while the source-install generator emits a curated root `marketplace.json` plus `.claude-plugin/marketplace.json`. The current branch needs a corrective fix because review found the generator still writes the CLI catalog to the root path.
+- `pkg/plugingen/generate_test.go` already mirrors templates into a temp repo and validates deterministic generation. It contains the current noisy-regression test, `TestGenerate_MarketplaceListsEveryPlugin`, which should remain useful for the Copilot CLI catalog if a separate VS Code catalog is added.
+- `pkg/plugingen/manifest.go` models both the Copilot CLI marketplace shape and the curated source-install marketplace shape.
+- `cmd/plugingen/main.go` reads `VERSION` and runs `Generate` or `CheckClean`; the drift check is already wired into CI through `.github/workflows/ci.yml`.
+- `pkg/scaffold/templates/skills/atv-doctor/SKILL.md` and `pkg/scaffold/templates/skills/atv-update/SKILL.md` are the canonical maintenance skill sources. Generated copies under `plugins/` should be updated only by regeneration.
+- CE's installed source plugin informed the `.claude-plugin/plugin.json` per-plugin metadata shape. VS Code's current marketplace-definition order requires ATV's curated source-install picker to be exposed through root `marketplace.json` as well.
+
+### Institutional Learnings
+
+- `docs/solutions/developer-experience/validate-ce-agent-plugin-installation-2026-04-28.md` shows the reliable validation path for source-installed CE plugins: inspect the actual installed AgentPlugin directory under the VS Code Insiders root, read package/version metadata from that directory, inspect git status/log/describe there, and treat manual folder removal as destructive with exact-path confirmation.
+
+### External References
+
+- `EveryInc/compound-engineering-plugin#637` documents the current VS Code source-install flow: run `Chat: Install Plugin from source`, enter `EveryInc/compound-engineering-plugin`, and select the curated plugin entry.
+- VS Code extension docs describe Marketplace/VSIX distribution as the automatic update path for extensions, but this plan intentionally stays on source-installed AgentPlugins rather than building a VSIX.
+- VS Code AI extensibility docs warn that too many chat participants can degrade UX; that supports keeping ATV as one source-install product surface rather than many install choices.
+
+---
+
+## Key Technical Decisions
+
+- Add a curated AgentPlugin catalog instead of hand-editing generated output: the generator remains the single place that defines plugin projections and drift checks.
+- Generate a root `marketplace.json` for VS Code source install while preserving `.github/plugin/marketplace.json` for the Copilot CLI catalog. Also emit `.claude-plugin/marketplace.json` with the same curated entry for Claude-format compatibility.
+- Represent the VS Code option as `atv-starter-kit` backed by the existing complete `atv-everything` bundle. This gives first-time users a product name while keeping the complete skills-plus-agents payload already tested by the generator.
+- Keep granular pack and single-skill plugin folders generated for now, but do not expose them in the VS Code source-install picker. In Copilot CLI, keep `atv-everything` as the full-bundle flagship and treat packs, single skills, and `atv-agents` as advanced/granular choices.
+- Extend maintenance workflows in markdown templates, not generated copies. The generated `plugins/atv-everything` and `plugins/atv-skill-*` copies are regenerated after template edits.
+- Use git safety states for updates: clean behind-only worktrees can be fast-forwarded after user confirmation; dirty, ahead, detached, missing remote, or diverged worktrees report state and stop before destructive remediation.
+- Make AgentPlugin diagnostics generic and update behavior conservative: `/atv-doctor` reports ATV, CE, and other GitHub-source plugins; `/atv-update` defaults to ATV and only touches another plugin when the user explicitly targets it.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should v1 build a VS Code extension? No. The origin explicitly excludes VSIX/Marketplace work, and source install already exists.
+- Should ATV update generated plugin files directly? No. `pkg/scaffold/templates/` and `pkg/plugingen` remain canonical.
+- Should the maintenance skills cover CE and other source plugins? Diagnostics should, because the user pain came from CE and the origin names other AgentPlugins. Updates should default to ATV and require an explicit target for non-ATV plugins.
+- Should CLI granularity be preserved? Yes for v1. The CLI already has `atv-everything` as the full-bundle default; keep the 42-entry granular catalog for compatibility, but make the flagship/default hierarchy explicit in docs and tests. If the catalog split ever stops working, R7 makes the clean VS Code picker the priority.
+
+### Deferred to Implementation
+
+- Exact AgentPlugin metadata field shape for `.claude-plugin/plugin.json`: choose the minimal CE-compatible fields after confirming what VS Code accepts.
+- Exact root detection list beyond Windows paths: implementation should cover VS Code and Insiders on Windows, macOS, and Linux, but any unexpected product-root variants discovered during smoke testing should be added then.
+- Exact wording of reload guidance: keep it aligned with the VS Code command palette wording observed during the smoke test.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TD
+    Templates[pkg/scaffold/templates]
+    Generator[pkg/plugingen]
+    PluginDirs[plugins/*]
+    CliCatalog[.github/plugin/marketplace.json]
+    SourceCatalog[marketplace.json + .claude-plugin/marketplace.json]
+    SourceManifest[plugins/atv-everything/.claude-plugin/plugin.json]
+    Doctor[atv-doctor generated skills]
+    Update[atv-update generated skills]
+
+    Templates --> Generator
+    Generator --> PluginDirs
+    Generator --> CliCatalog
+    Generator --> SourceCatalog
+    Generator --> SourceManifest
+    Templates --> Doctor
+    Templates --> Update
+```
+
+The important separation is catalog intent: `.github/plugin/marketplace.json` remains the Copilot CLI catalog, while root `marketplace.json` is the first-match curated VS Code source-install surface. `.claude-plugin/marketplace.json` mirrors the same curated entry for Claude-format compatibility. All generated catalogs are checked for drift by the same toolchain.
+
+---
+
+## Implementation Units
+
+- U1. **Generate a curated VS Code source-install catalog**
+
+**Goal:** Make the source-install picker expose one ATV option while keeping the complete skills-plus-agents payload.
+
+**Requirements:** R1, R2, R3, R4, R6, R7, R10; F1, F2; AE1, AE2, AE4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `pkg/plugingen/generate.go`
+- Modify: `pkg/plugingen/manifest.go`
+- Modify: `pkg/plugingen/generate_test.go`
+- Create: `marketplace.json`
+- Create: `.claude-plugin/marketplace.json`
+- Create: `plugins/atv-everything/.claude-plugin/plugin.json`
+- Modify: generated files under `plugins/atv-everything/` as produced by the generator
+
+**Approach:**
+- Add or correct generator support for a curated source-install marketplace emitted at root `marketplace.json` and mirrored to `.claude-plugin/marketplace.json`.
+- Fix the review-discovered generator bug so the granular Copilot CLI catalog is no longer written to root `marketplace.json`; it belongs only under `.github/plugin/marketplace.json`.
+- Fix the review-discovered compile blocker by keeping shared comparison helpers at package scope.
+- Emit exactly one source-install entry named `atv-starter-kit`, with source pointing at the complete `plugins/atv-everything` bundle.
+- Add per-plugin AgentPlugin metadata under `plugins/atv-everything/.claude-plugin/plugin.json` so the source path has local metadata even though the Copilot CLI `plugin.json` stays in place.
+- Keep the existing `plugins/atv-everything/plugin.json` manifest and generated skills/agents unchanged except for the added AgentPlugin metadata.
+- Keep `.github/plugin/marketplace.json` granular because VS Code reads the root `marketplace.json` before `.github/plugin/marketplace.json`.
+
+**Execution note:** Start with generator tests that fail on the current noisy source-install surface before changing generator output.
+
+**Patterns to follow:**
+- `pkg/plugingen/generate.go` deterministic output helpers (`marshalJSON`, sorted output, LF normalization).
+- `pkg/plugingen/generate_test.go` temp-repo generation pattern.
+- VS Code marketplace definition precedence: root `marketplace.json` first, then `.plugin/marketplace.json`, then `.github/plugin/marketplace.json`, then `.claude-plugin/marketplace.json`.
+- CE's per-plugin `.claude-plugin/plugin.json` structure.
+
+**Test scenarios:**
+- Covers AE1. Happy path: generated root `marketplace.json` and `.claude-plugin/marketplace.json` each contain exactly one plugin entry named `atv-starter-kit` and no names starting with `atv-skill-`, `atv-pack-`, or `atv-agents`.
+- Covers AE4. Regression: regeneration must not replace root `marketplace.json` with the 42-entry Copilot CLI catalog.
+- Covers AE1 / AE2. Happy path: the sole source-install entry resolves to an existing generated directory that contains both `skills/` and `agents/` plus AgentPlugin metadata.
+- Covers R2. Edge case: the source-install description remains concise enough for Quick Pick use by enforcing a small maximum length and rejecting URLs or long warning text.
+- Covers AE4. Regression: adding another source-install entry causes the generator test to fail with a message that names the unexpected entry count.
+- Integration: `CheckClean` compares the curated source-install catalog and per-plugin metadata, so changing templates without regeneration reports drift.
+
+**Verification:**
+- Generator tests for curated source-install metadata pass.
+- The generated source-install catalog contains one ATV option and the generated complete bundle still includes all skills and agents.
+- The plugin drift check covers root `marketplace.json` and `.claude-plugin` output in addition to `plugins/` and `.github/plugin`.
+
+---
+
+- U2. **Preserve and hierarchy-guard the Copilot CLI catalog**
+
+**Goal:** Keep existing Copilot CLI marketplace behavior intact, while making `atv-everything` the obvious CLI default and keeping root `marketplace.json` reserved for VS Code's curated source-install catalog.
+
+**Requirements:** R5, R6, R7, R10; F2; AE3, AE4
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `pkg/plugingen/generate.go`
+- Modify: `pkg/plugingen/generate_test.go`
+- Modify: generated `.github/plugin/marketplace.json` if the catalog order can and should put `atv-everything` first.
+
+**Approach:**
+- Keep `writeMarketplace` as the Copilot CLI catalog generator for `.github/plugin/marketplace.json`.
+- Keep `atv-everything` as the first conceptual CLI install path. If Copilot CLI honors catalog order, emit it first before packs, agents-only, and single-skill entries; if the CLI sorts independently, keep the generated catalog deterministic and make docs/install commands lead with `atv-everything`.
+- Rename the existing noisy test to make its scope explicit, for example from "marketplace lists every plugin" to "CLI marketplace lists every plugin".
+- Add a separate test that proves source-install and CLI catalogs have intentionally different entry counts and purposes.
+- Add a test or documented assertion that `atv-everything` remains the CLI flagship/default, even though granular entries remain available.
+- Keep source-install assertions focused on the root `marketplace.json` and `.claude-plugin/marketplace.json` catalogs.
+
+**Patterns to follow:**
+- Existing `TestGenerate_MarketplaceListsEveryPlugin` assertions for sorting and source/name relationships.
+- Existing CI plugin drift check in `.github/workflows/ci.yml`.
+
+**Test scenarios:**
+- Happy path: the CLI catalog still includes `atv-everything`, `atv-agents`, all packs, and all per-skill entries when separate source-install metadata is honored.
+- Covers R6. Happy path: CLI docs and, where supported by catalog order, generated metadata present `atv-everything` before advanced granular options.
+- Covers AE4. Integration: source-install catalog has one entry while CLI catalog has the expected granular count, proving the two surfaces do not drift into each other.
+- Future fallback path: if VS Code precedence changes and the root catalog no longer wins, revisit the `.github/plugin` tradeoff explicitly rather than allowing a noisy picker.
+- Edge case: every marketplace entry source still resolves to an existing generated plugin directory.
+
+**Verification:**
+- Tests make the intended catalog split and CLI flagship hierarchy observable.
+- Maintainers can tell from a failing test whether the regression is source-install noise, CLI catalog drift, or a missing generated directory.
+
+---
+
+- U6. **Validate source-install picker precedence**
+
+**Goal:** Prove the actual VS Code source-install picker uses the intended catalog before docs and maintenance workflows are written around that path.
+
+**Requirements:** R1, R2, R3, R4, R6, R7, R8, R10; F1, F2; AE1, AE2, AE4
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: source-install metadata/tests only if the actual picker does not honor the root `marketplace.json` first-match behavior.
+
+**Approach:**
+- Install ATV from source in VS Code or VS Code Insiders from a branch or fork containing the generated metadata.
+- Verify the picker shows exactly one ATV option with concise copy before proceeding to documentation and maintenance-skill edits.
+- Verify installing that option makes normal ATV skills and agents available without a separate `atv-agents` install.
+- Verify the installed plugin lands under the expected AgentPlugin root and has readable version/git metadata for later doctor/update validation.
+- If the picker still shows the granular `.github/plugin` catalog despite root `marketplace.json`, stop and reassess before changing the CLI catalog.
+
+**Patterns to follow:**
+- CE source-install validation from `EveryInc/compound-engineering-plugin#637`.
+- WorkIQ learning for validating installed AgentPlugin version and git state from the actual VS Code AgentPlugin directory.
+
+**Test scenarios:**
+- Covers AE1. Manual smoke: source-install picker shows one ATV option, not pack or per-skill entries.
+- Covers AE2. Manual smoke: after install, representative planning, review, shipping, maintenance skills and reviewer agents are available from the installed source plugin.
+- Covers AE4. Regression check: generated metadata tests fail if source-install entries grow beyond one.
+- Failure path: if VS Code ignores root `marketplace.json`, the implementation should stop for a focused compatibility decision before docs are finalized.
+
+**Verification:**
+- The implementation has a proven catalog path before U3-U5 proceed: root `marketplace.json` produces the clean VS Code picker and CLI granularity remains under `.github/plugin`.
+- Generated metadata tests and the manual picker smoke agree on the one-option source-install surface.
+
+---
+
+- U3. **Document the three install paths and maintainer validation**
+
+**Goal:** Give users one clean VS Code source-install path and give maintainers a repeatable validation checklist that catches picker regressions.
+
+**Requirements:** R5, R8, R9, R10; F1, F2; AE1, AE3, AE4
+
+**Dependencies:** U1, U2, U6
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/marketplace.md`
+- Optional modify: `CHANGELOG.md` if the repo's release process expects user-visible changes there before tagging
+
+**Approach:**
+- Add VS Code source install as the first personal/editor-level path: command palette `Chat: Install Plugin from source`, repo `All-The-Vibes/ATV-StarterKit`, plugin `atv-starter-kit`.
+- Keep `npx atv-starterkit init` positioned as project/team bootstrap and Copilot CLI marketplace as the CLI/power-user path, with `atv-everything` as the first recommended CLI command.
+- Correct stale generated counts in docs, such as the full bundle's skill count.
+- Avoid a large decision matrix in the quick start. Put deeper comparisons in `docs/marketplace.md`.
+- Add a maintainer validation note: source-install picker should show one ATV option; generator tests and drift checks should fail if that surface grows.
+- Document the fallback decision if U6 forces `.github/plugin` to one-entry and granular CLI support becomes deferred.
+
+**Patterns to follow:**
+- Existing README sections: Quick Start, Installation, and Path 2.
+- Existing `docs/marketplace.md` explanation of generated marketplace output.
+
+**Test scenarios:**
+- Covers AE3. Documentation review: README clearly distinguishes VS Code source install, project scaffold, and Copilot CLI without requiring users to read a large matrix first, and CLI instructions lead with `atv-everything`.
+- Covers AE1 / AE4. Documentation review: maintainer validation explicitly states the expected one-option picker result.
+- Error path: docs do not instruct users to manually delete AgentPlugin folders as the normal update path.
+
+**Verification:**
+- README quick start contains the exact `Chat: Install Plugin from source` wording.
+- `docs/marketplace.md` explains which catalog is for VS Code source install and which is for Copilot CLI, or explains the R7 fallback if separate catalogs do not work.
+
+---
+
+- U4. **Extend `/atv-doctor` for VS Code AgentPlugin diagnostics**
+
+**Goal:** Let users see actual installed source-plugin state from VS Code and VS Code Insiders roots, including version, git, and remote divergence details.
+
+**Requirements:** R11, R12; F3; AE5
+
+**Dependencies:** U1, U6
+
+**Files:**
+- Modify: `pkg/scaffold/templates/skills/atv-doctor/SKILL.md`
+- Modify: generated `plugins/atv-everything/skills/atv-doctor/SKILL.md`
+- Modify: generated `plugins/atv-skill-atv-doctor/skills/atv-doctor/SKILL.md`
+- Modify: generated `plugins/atv-pack-maintenance/skills/atv-doctor/SKILL.md`
+- Modify: `pkg/plugingen/generate_test.go` or add a focused template-content test under `pkg/plugingen/`
+
+**Approach:**
+- Add a source-installed AgentPlugin detection phase to the doctor template after marketplace detection.
+- Detect VS Code Stable and Insiders roots on Windows, macOS, and Linux, scoped to `agent-plugins/github.com/<owner>/<repo>` directory layout.
+- For each discovered git checkout, report owner/repo, path, branch, commit, upstream remote, ahead/behind or diverged state, dirty state, and version metadata from known files when present (`package.json`, `VERSION`, or plugin metadata files).
+- Keep path handling cross-platform: Windows Stable/Insiders profile roots, macOS profile roots, and Linux profile roots should be described without assuming POSIX separators.
+- Grade findings conservatively: stale clean checkouts are warnings, dirty/diverged checkouts are warnings with no automatic action, missing metadata is informational.
+- Keep project scaffold, Copilot CLI marketplace, hooks, MCP prereqs, and optional dependency sections intact.
+
+**Execution note:** Add content-level regression tests before editing the generated skill template so the new diagnostic requirements cannot disappear in a later regeneration.
+
+**Patterns to follow:**
+- Existing `/atv-doctor` phase structure and graded report skeleton.
+- WorkIQ learning for CE plugin validation: inspect installed AgentPlugin path, version metadata, and git status in the actual plugin directory.
+
+**Test scenarios:**
+- Covers AE5. Happy path: generated `atv-doctor` instructions mention VS Code and VS Code Insiders AgentPlugin roots, owner/repo reporting, version metadata, current commit, and git divergence state.
+- Edge case: generated instructions cover plugins with `package.json`, plugins with `VERSION`, and plugins with only plugin metadata.
+- Edge case: generated instructions mention both Windows and POSIX-style AgentPlugin roots and avoid a single hardcoded path shape.
+- Error path: generated instructions say dirty or diverged source plugin checkouts are reported without overwrite/reset/delete.
+- Integration: after regeneration, `atv-doctor` content is present in `atv-everything`, `atv-pack-maintenance`, and `atv-skill-atv-doctor` outputs.
+
+**Verification:**
+- Generated maintenance skill content includes a dedicated source-installed AgentPlugin diagnostic phase.
+- Plugingen drift check passes after template regeneration.
+
+---
+
+- U5. **Extend `/atv-update` for safe source-installed AgentPlugin updates**
+
+**Goal:** Give users an opt-in, non-destructive update path for clean source-installed ATV checkouts, with clear stop states for dirty, diverged, or untrackable plugins.
+
+**Requirements:** R11, R12, R13, R14, R15; F3; AE6
+
+**Dependencies:** U4
+
+**Files:**
+- Modify: `pkg/scaffold/templates/skills/atv-update/SKILL.md`
+- Modify: generated `plugins/atv-everything/skills/atv-update/SKILL.md`
+- Modify: generated `plugins/atv-skill-atv-update/skills/atv-update/SKILL.md`
+- Modify: generated `plugins/atv-pack-maintenance/skills/atv-update/SKILL.md`
+- Modify: `pkg/plugingen/generate_test.go` or add a focused template-content test under `pkg/plugingen/`
+
+**Approach:**
+- Add source-installed AgentPlugins as a third update scope beside project scaffold and Copilot CLI marketplace.
+- Default target is ATV's source-installed repo; allow an explicit owner/repo or plugin path only when the user asks for another source plugin.
+- Use git inspection first: fetch remote metadata, read tracking branch state, report dirty/ahead/behind/diverged/detached/missing-upstream states, and require confirmation before any update.
+- Permit automatic update only for clean behind-only worktrees where a fast-forward update is possible.
+- For dirty, ahead, diverged, detached, or missing-upstream states, stop with remediation choices; do not reset, stash, delete, or reclone automatically.
+- Offer reinstall/removal only as an explicit destructive remediation path that prints the exact folder and requires confirmation before removal.
+- After any successful update, instruct the user to reload or restart VS Code so the AgentPlugin content is reloaded.
+- Keep commands and path examples cross-platform enough for Windows and POSIX users, with Windows examples using profile-aware paths rather than literal machine-specific paths.
+
+**Execution note:** Keep the destructive-action language close to the project's AGENTS guidance: exact data loss, explicit confirmation, then verify.
+
+**Patterns to follow:**
+- Existing `/atv-update` dry-run/apply mode structure.
+- Existing per-plugin confirmation approach for Copilot CLI marketplace updates.
+- WorkIQ CE plugin validation learning for exact-path destructive confirmation.
+
+**Test scenarios:**
+- Covers AE6. Happy path: generated `atv-update` instructions allow a clean behind-only source plugin update only after user confirmation and include reload guidance.
+- Error path: generated instructions explicitly stop on dirty worktrees and do not suggest silent overwrite, reset, stash, or delete.
+- Error path: generated instructions stop on diverged or ahead checkouts and require a remediation choice rather than applying an update.
+- Covers R14. Destructive path: generated instructions require exact plugin folder display and explicit confirmation before reinstall/removal.
+- Edge case: generated instructions include reload guidance after source-plugin update without implying the reload itself validates file-system changes.
+- Integration: after regeneration, update guidance is present in `atv-everything`, `atv-pack-maintenance`, and `atv-skill-atv-update` outputs.
+
+**Verification:**
+- Generated update skill contains source-installed AgentPlugin update phases, safety states, confirmation language, and reload guidance.
+- Plugingen drift check passes after template regeneration.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `pkg/scaffold/templates/` feeds `pkg/plugingen`, which feeds generated plugin directories, Copilot CLI metadata, and new VS Code source-install metadata. Maintenance skill template edits also propagate into multiple generated plugin bundles.
+- **Error propagation:** Generator failures should remain loud and deterministic. Doctor/update runtime failures are instructions for the agent to report state and stop, not to mask failures with destructive fallback.
+- **State lifecycle risks:** Source-installed AgentPlugins are git worktrees under user profile directories; dirty, ahead, diverged, detached, or missing-upstream states must never be treated as safe to overwrite.
+- **API surface parity:** `npx atv-starterkit init` remains unchanged. Copilot CLI marketplace behavior remains unchanged only if VS Code honors the curated catalog split.
+- **Integration coverage:** Unit tests prove generated metadata shape; manual VS Code source-install smoke proves the actual picker behavior that local tests cannot simulate.
+- **Unchanged invariants:** `plugins/` remains generated, templates remain canonical, `atv-everything` continues bundling all skills and agents, and `go run ./cmd/plugingen -check` remains the release drift gate.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| VS Code ignores `.claude-plugin/marketplace.json` when `.github/plugin/marketplace.json` exists. | U6 validates the actual picker and activates the R7 fallback to one-entry `.github/plugin` if needed. |
+| Preserving CLI granularity conflicts with a clean VS Code picker. | Make the tradeoff explicit and prioritize VS Code one-option v1 per origin R7. |
+| Generated files drift from templates or new metadata. | Extend `CheckClean` to compare the new source-install metadata and add tests that enforce one source-install entry. |
+| Maintenance skills accidentally recommend destructive git operations. | Content tests assert dirty/diverged states stop safely and destructive removal requires exact path plus confirmation. |
+| AgentPlugin root paths vary across OS or VS Code product. | Doctor/update instructions enumerate Stable and Insiders roots across Windows, macOS, and Linux, and U6 validates at least the observed Windows Insiders path. |
+| Users expect updated source plugin content to load immediately. | Update flow always ends with reload/restart guidance after a successful source-plugin update. |
+
+---
+
+## Documentation / Operational Notes
+
+- README should lead with a simple personal install path for VS Code users before showing deeper marketplace options.
+- `docs/marketplace.md` should explain that generated catalogs have different audiences if the split works: VS Code source install versus Copilot CLI marketplace.
+- Release validation should include one human smoke check of `Chat: Install Plugin from source` because local generator tests cannot prove VS Code's catalog precedence.
+- Destructive reinstall/removal guidance in `/atv-update` must remain opt-in and exact-path-confirmed to comply with project safety rules.
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-04-28-vscode-source-install-clean-plugin-requirements.md`
+- Related code: `pkg/plugingen/generate.go`
+- Related code: `pkg/plugingen/generate_test.go`
+- Related code: `pkg/plugingen/manifest.go`
+- Related code: `pkg/scaffold/templates/skills/atv-doctor/SKILL.md`
+- Related code: `pkg/scaffold/templates/skills/atv-update/SKILL.md`
+- Related docs: `README.md`
+- Related docs: `docs/marketplace.md`
+- Institutional learning: `docs/solutions/developer-experience/validate-ce-agent-plugin-installation-2026-04-28.md`
+- Related issue: `https://github.com/EveryInc/compound-engineering-plugin/issues/637`
+- External docs: `https://code.visualstudio.com/api/working-with-extensions/publishing-extension`
+- External docs: `https://code.visualstudio.com/api/extension-guides/ai/ai-extensibility-overview`

--- a/docs/solutions/developer-experience/split-agentplugin-catalogs-by-consumer-2026-04-28.md
+++ b/docs/solutions/developer-experience/split-agentplugin-catalogs-by-consumer-2026-04-28.md
@@ -1,0 +1,99 @@
+---
+title: Split AgentPlugin Catalogs by Consumer
+date: 2026-04-28
+category: developer-experience
+module: ATV plugin generation
+problem_type: developer_experience
+component: tooling
+severity: medium
+applies_when:
+  - "A source-installed AgentPlugin repository also exposes a granular CLI marketplace"
+  - "VS Code install UX should show one product option while CLI users keep advanced packages"
+  - "A generator drift check runs on Windows checkouts with Git autocrlf enabled"
+tags: [vscode, agentplugin, marketplace, plugingen, autocrlf]
+---
+
+# Split AgentPlugin Catalogs by Consumer
+
+## Context
+
+ATV needed one clean VS Code `Chat: Install Plugin from source` option without removing its advanced Copilot CLI plugin catalog. The confusing state was that VS Code could fall through to the granular `.github/plugin/marketplace.json` catalog and show dozens of packs and single-skill plugins to a first-time user.
+
+The repo also needed generator validation to work on Windows. Git may check generated JSON and Markdown out with CRLF line endings even though `plugingen` emits LF, so a byte-only drift check can report false positives on an otherwise in-sync tree.
+
+## Guidance
+
+Use separate generated catalog surfaces for separate consumers:
+
+- Root `marketplace.json`: curated VS Code source-install catalog. It should expose exactly one product entry, `atv-starter-kit`, with `source` pointing to `./plugins/atv-everything`.
+- `.claude-plugin/marketplace.json`: byte-identical mirror of the root source-install catalog for Claude-format compatibility.
+- `.github/plugin/marketplace.json`: Copilot CLI catalog. It can keep every granular package, but should put the full `atv-everything` bundle first.
+
+Keep the generator as the source of truth. Do not hand-maintain the catalogs independently. `Generate` should write all three surfaces, and `CheckClean` should compare them all.
+
+When checking generated output, normalize line endings during comparison:
+
+```go
+func equalGeneratedContent(a, b []byte) bool {
+    if bytes.Equal(a, b) {
+        return true
+    }
+    return normalizeLineEndings(string(a)) == normalizeLineEndings(string(b))
+}
+```
+
+Also prefix drift paths by output root before reporting them. Without prefixes, failures from root `marketplace.json`, `.claude-plugin/marketplace.json`, and `.github/plugin/marketplace.json` can all appear as repeated `marketplace.json`, which slows review.
+
+## Why This Matters
+
+The same repository can serve different install surfaces, but the UX contract is different for each one. VS Code source install is a product-selection moment, so it should present one coherent ATV option. Copilot CLI users may still need granular packs, single-skill installs, or agents-only installs, so the CLI catalog can remain broad.
+
+Separating the catalogs lets ATV improve the VS Code first-run experience without breaking CLI compatibility. Keeping all catalogs generated prevents drift between the product decision and the checked-in metadata.
+
+Line-ending tolerant comparisons make the generator check portable. The check still catches real content drift, missing files, stale files, and missing trailing newlines, but it does not fail just because the working tree is CRLF on Windows.
+
+## When to Apply
+
+- A repo has one internal/plugin packaging graph but multiple consumer-facing installers.
+- VS Code or another source-install flow reads catalog files in precedence order and can accidentally pick up an expert-oriented catalog.
+- Generated docs or metadata are checked on both Unix-like and Windows developer machines.
+
+## Examples
+
+The intended catalog invariant is:
+
+```text
+marketplace.json                         -> 1 entry: atv-starter-kit -> ./plugins/atv-everything
+.claude-plugin/marketplace.json          -> byte-identical mirror of root marketplace.json
+.github/plugin/marketplace.json          -> 42 CLI entries, atv-everything first
+plugins/atv-everything/.claude-plugin/   -> per-plugin source-install metadata
+```
+
+The regression tests should make those invariants explicit:
+
+```go
+if len(mp.Plugins) != 1 {
+    t.Fatalf("source-install marketplace should expose exactly one plugin, got %d", len(mp.Plugins))
+}
+if entry.Source != "./plugins/atv-everything" {
+    t.Errorf("source-install entry source: got %q want ./plugins/atv-everything", entry.Source)
+}
+```
+
+And the CLI test should continue to protect the granular catalog:
+
+```go
+if len(mp.Plugins) != len(wantNames) {
+    t.Errorf("marketplace.json plugin count: got %d want %d", len(mp.Plugins), len(wantNames))
+}
+if len(mp.Plugins) == 0 || mp.Plugins[0].Name != "atv-everything" {
+    t.Fatalf("CLI marketplace should put atv-everything first, got %+v", mp.Plugins)
+}
+```
+
+## Related
+
+- `pkg/plugingen/generate.go`
+- `pkg/plugingen/generate_test.go`
+- `docs/marketplace.md`
+- `docs/plans/2026-04-28-001-feat-vscode-source-install-agentplugin-update-plan.md`

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,0 +1,30 @@
+{
+  "name": "atv-starter-kit",
+  "owner": {
+    "name": "All The Vibes",
+    "url": "https://github.com/All-The-Vibes"
+  },
+  "metadata": {
+    "description": "Curated VS Code source-install catalog for ATV Starter Kit.",
+    "version": "2.6.3"
+  },
+  "plugins": [
+    {
+      "name": "atv-starter-kit",
+      "description": "ATV Starter Kit for VS Code: all ATV skills and reviewer/specialist agents in one personal install.",
+      "author": {
+        "name": "All The Vibes",
+        "url": "https://github.com/All-The-Vibes"
+      },
+      "homepage": "https://github.com/All-The-Vibes/ATV-StarterKit",
+      "tags": [
+        "atv",
+        "starter-kit",
+        "vscode",
+        "skills",
+        "agents"
+      ],
+      "source": "./plugins/atv-everything"
+    }
+  ]
+}

--- a/pkg/plugingen/generate.go
+++ b/pkg/plugingen/generate.go
@@ -38,9 +38,11 @@ type Config struct {
 	KitVersion string
 }
 
-// Generate produces the plugins/ tree and .github/plugin/marketplace.json
-// from pkg/scaffold/templates/. It always writes a deterministic byte
-// sequence: sorted lists, slash-normalized paths, LF line endings,
+// Generate produces the plugins/ tree, marketplace.json,
+// .github/plugin/marketplace.json, and .claude-plugin/marketplace.json
+// from pkg/scaffold/templates/.
+// It always writes a deterministic byte sequence: sorted lists,
+// slash-normalized paths, LF line endings,
 // indented JSON with a trailing newline.
 //
 // Generate first runs Audit and returns an error containing every
@@ -243,12 +245,19 @@ func Generate(cfg Config) error {
 	if err := writeManifest(everythingDir, everythingManifest); err != nil {
 		return err
 	}
+	if err := writeSourceInstallPluginManifest(everythingDir, cfg); err != nil {
+		return err
+	}
 	if err := writePluginReadme(everythingDir, everythingManifest); err != nil {
 		return err
 	}
 
-	// 5. marketplace.json — top-level manifest enumerating every plugin.
+	// 5. .github/plugin/marketplace.json — Copilot CLI manifest enumerating every plugin.
 	if err := writeMarketplace(cfg, skillNames, packs); err != nil {
+		return err
+	}
+	// 6. marketplace.json + .claude-plugin/marketplace.json — curated source-install surface.
+	if err := writeSourceInstallMarketplace(cfg); err != nil {
 		return err
 	}
 
@@ -258,9 +267,11 @@ func Generate(cfg Config) error {
 // CheckClean returns nil if running Generate would not change any
 // committed file, or an error listing the changed paths otherwise.
 //
-// The check generates into a temporary directory, then byte-compares
-// every output file against the corresponding committed file. This is
-// safer than mutating the working tree and diffing.
+// The check generates into a temporary directory, then compares every
+// output file against the corresponding committed file. Line endings are
+// normalized during comparison so Windows autocrlf checkouts do not create
+// false drift reports. This is safer than mutating the working tree and
+// diffing.
 func CheckClean(cfg Config) error {
 	if cfg.RepoRoot == "" {
 		return fmt.Errorf("plugingen: RepoRoot is required")
@@ -283,15 +294,20 @@ func CheckClean(cfg Config) error {
 	}
 
 	var diffs []string
-	for _, sub := range []string{"plugins", filepath.Join(".github", "plugin")} {
+	for _, sub := range []string{"plugins", filepath.Join(".github", "plugin"), ".claude-plugin"} {
 		gotRoot := filepath.Join(tmp, sub)
 		wantRoot := filepath.Join(cfg.RepoRoot, sub)
 		more, err := compareTrees(gotRoot, wantRoot)
 		if err != nil {
 			return err
 		}
-		diffs = append(diffs, more...)
+		diffs = append(diffs, prefixDiffs(filepath.ToSlash(sub), more)...)
 	}
+	more, err := compareFile(filepath.Join(tmp, "marketplace.json"), filepath.Join(cfg.RepoRoot, "marketplace.json"), "marketplace.json")
+	if err != nil {
+		return err
+	}
+	diffs = append(diffs, more...)
 	if len(diffs) > 0 {
 		sort.Strings(diffs)
 		return fmt.Errorf("plugin tree out of sync with templates. Run `go run ./cmd/plugingen` and commit the result. Differences:\n  - %s",
@@ -380,6 +396,28 @@ func writePluginReadme(pluginDir string, m PluginManifest) error {
 	return os.WriteFile(filepath.Join(pluginDir, "README.md"), []byte(b.String()), 0o644)
 }
 
+func writeSourceInstallPluginManifest(pluginDir string, cfg Config) error {
+	manifestDir := filepath.Join(pluginDir, ".claude-plugin")
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		return err
+	}
+	manifest := PluginManifest{
+		Name:        "atv-starter-kit",
+		Description: sourceInstallDescription(),
+		Version:     cfg.KitVersion,
+		Author:      defaultAuthor(),
+		Homepage:    defaultRepository(),
+		Repository:  defaultRepository(),
+		License:     "MIT",
+		Keywords:    []string{"atv", "starter-kit", "vscode", "agent-plugin"},
+	}
+	data, err := marshalJSON(manifest)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(manifestDir, "plugin.json"), data, 0o644)
+}
+
 func writeMarketplace(cfg Config, skillNames []string, packs []Pack) error {
 	mpDir := filepath.Join(cfg.RepoRoot, ".github", "plugin")
 	if err := os.MkdirAll(mpDir, 0o755); err != nil {
@@ -425,6 +463,11 @@ func writeMarketplace(cfg Config, skillNames []string, packs []Pack) error {
 		})
 	}
 	sort.Slice(entries, func(i, j int) bool {
+		leftRank := cliMarketplaceRank(entries[i].Name)
+		rightRank := cliMarketplaceRank(entries[j].Name)
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
 		return entries[i].Name < entries[j].Name
 	})
 
@@ -445,8 +488,53 @@ func writeMarketplace(cfg Config, skillNames []string, packs []Pack) error {
 	return os.WriteFile(filepath.Join(mpDir, "marketplace.json"), data, 0o644)
 }
 
+func cliMarketplaceRank(name string) int {
+	if name == "atv-everything" {
+		return 0
+	}
+	return 1
+}
+
+func writeSourceInstallMarketplace(cfg Config) error {
+	mpDir := filepath.Join(cfg.RepoRoot, ".claude-plugin")
+	if err := os.MkdirAll(mpDir, 0o755); err != nil {
+		return err
+	}
+
+	mp := SourceInstallMarketplace{
+		Name:  "atv-starter-kit",
+		Owner: defaultMarketplaceOwner(),
+		Metadata: SourceInstallMarketplaceMeta{
+			Description: "Curated VS Code source-install catalog for ATV Starter Kit.",
+			Version:     cfg.KitVersion,
+		},
+		Plugins: []SourceInstallEntry{
+			{
+				Name:        "atv-starter-kit",
+				Description: sourceInstallDescription(),
+				Author:      defaultAuthor(),
+				Homepage:    defaultRepository(),
+				Tags:        []string{"atv", "starter-kit", "vscode", "skills", "agents"},
+				Source:      "./plugins/atv-everything",
+			},
+		},
+	}
+	data, err := marshalJSON(mp)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(cfg.RepoRoot, "marketplace.json"), data, 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(mpDir, "marketplace.json"), data, 0o644)
+}
+
+func sourceInstallDescription() string {
+	return "ATV Starter Kit for VS Code: all ATV skills and reviewer/specialist agents in one personal install."
+}
+
 func skillPluginDescription(name string) string {
-	return fmt.Sprintf("ATV `%s` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.", name)
+	return fmt.Sprintf("ATV `%s` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.", name)
 }
 
 func defaultAuthor() *Author {
@@ -483,10 +571,39 @@ func marshalJSON(v interface{}) ([]byte, error) {
 	return out, nil
 }
 
-// normalizeLineEndings converts CRLF to LF so generated files are
-// byte-identical regardless of the host OS git autocrlf setting.
+// normalizeLineEndings converts CRLF to LF for text comparisons across
+// Git autocrlf checkouts.
 func normalizeLineEndings(s string) string {
 	return strings.ReplaceAll(s, "\r\n", "\n")
+}
+
+func equalGeneratedContent(a, b []byte) bool {
+	if bytes.Equal(a, b) {
+		return true
+	}
+	return normalizeLineEndings(string(a)) == normalizeLineEndings(string(b))
+}
+
+func prefixDiffs(prefix string, diffs []string) []string {
+	out := make([]string, 0, len(diffs))
+	for _, diff := range diffs {
+		out = append(out, prefixDiff(prefix, diff))
+	}
+	return out
+}
+
+func prefixDiff(prefix, diff string) string {
+	for _, marker := range []string{
+		"missing on disk: ",
+		"stale on disk (not produced by generator): ",
+		"content differs: ",
+	} {
+		if strings.HasPrefix(diff, marker) {
+			rel := strings.TrimPrefix(diff, marker)
+			return marker + filepath.ToSlash(filepath.Join(prefix, rel))
+		}
+	}
+	return diff
 }
 
 // resetDir removes dir entirely if it exists, then recreates it empty.
@@ -549,12 +666,33 @@ func compareTrees(gotRoot, wantRoot string) ([]string, error) {
 		default:
 			a, _ := os.ReadFile(gp)
 			b, _ := os.ReadFile(wp)
-			if !bytes.Equal(a, b) {
+			if !equalGeneratedContent(a, b) {
 				diffs = append(diffs, "content differs: "+rel)
 			}
 		}
 	}
 	return diffs, nil
+}
+
+func compareFile(gotPath, wantPath, rel string) ([]string, error) {
+	got, err := os.ReadFile(gotPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{"missing generated file: " + rel}, nil
+		}
+		return nil, err
+	}
+	want, err := os.ReadFile(wantPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{"missing on disk: " + rel}, nil
+		}
+		return nil, err
+	}
+	if !equalGeneratedContent(got, want) {
+		return []string{"content differs: " + rel}, nil
+	}
+	return nil, nil
 }
 
 // walkFiles returns a map from forward-slash relative path to absolute

--- a/pkg/plugingen/generate_test.go
+++ b/pkg/plugingen/generate_test.go
@@ -144,7 +144,7 @@ func TestGenerate_AtvAgentsBundlesAllAgents(t *testing.T) {
 	}
 }
 
-func TestGenerate_MarketplaceListsEveryPlugin(t *testing.T) {
+func TestGenerate_CliMarketplaceListsEveryPlugin(t *testing.T) {
 	tmp := regenerateInto(t)
 	var mp Marketplace
 	readJSON(t, filepath.Join(tmp, ".github", "plugin", "marketplace.json"), &mp)
@@ -179,13 +179,121 @@ func TestGenerate_MarketplaceListsEveryPlugin(t *testing.T) {
 			t.Errorf("marketplace.json missing entry %q", n)
 		}
 	}
+	if len(mp.Plugins) != len(wantNames) {
+		t.Errorf("marketplace.json plugin count: got %d want %d", len(mp.Plugins), len(wantNames))
+	}
 
-	// Entries must be sorted alphabetically for deterministic output.
-	for i := 1; i < len(mp.Plugins); i++ {
+	if len(mp.Plugins) == 0 || mp.Plugins[0].Name != "atv-everything" {
+		t.Fatalf("CLI marketplace should put atv-everything first, got %+v", mp.Plugins)
+	}
+
+	// After the flagship entry, entries remain sorted alphabetically for deterministic output.
+	for i := 2; i < len(mp.Plugins); i++ {
 		if mp.Plugins[i-1].Name > mp.Plugins[i].Name {
 			t.Errorf("marketplace.json plugins not sorted: %q > %q",
 				mp.Plugins[i-1].Name, mp.Plugins[i].Name)
 		}
+	}
+}
+
+func TestGenerate_SourceInstallMarketplaceHasOneFlagshipPlugin(t *testing.T) {
+	tmp := regenerateInto(t)
+	for _, rel := range []string{"marketplace.json", filepath.Join(".claude-plugin", "marketplace.json")} {
+		assertSourceInstallMarketplaceHasOneFlagshipPlugin(t, filepath.Join(tmp, rel))
+	}
+	assertFilesEqual(t, filepath.Join(tmp, "marketplace.json"), filepath.Join(tmp, ".claude-plugin", "marketplace.json"))
+
+	sourceDir := filepath.Join(tmp, "plugins", "atv-everything")
+	for _, path := range []string{
+		filepath.Join(sourceDir, "skills"),
+		filepath.Join(sourceDir, "agents"),
+		filepath.Join(sourceDir, ".claude-plugin", "plugin.json"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("source-install entry points at incomplete plugin dir, missing %s: %v", path, err)
+		}
+	}
+
+	var manifest PluginManifest
+	readJSON(t, filepath.Join(sourceDir, ".claude-plugin", "plugin.json"), &manifest)
+	if manifest.Name != "atv-starter-kit" {
+		t.Errorf("source-install plugin manifest name: got %q want atv-starter-kit", manifest.Name)
+	}
+}
+
+func TestGenerate_GranularSkillDescriptionsMentionAgentCompanion(t *testing.T) {
+	tmp := regenerateInto(t)
+	var manifest PluginManifest
+	readJSON(t, filepath.Join(tmp, "plugins", "atv-skill-ce-review", "plugin.json"), &manifest)
+
+	if !strings.Contains(manifest.Description, "installs may need `atv-agents` alongside them") {
+		t.Errorf("granular skill description should tell users when atv-agents is needed, got %q", manifest.Description)
+	}
+	if strings.Contains(manifest.Description, "includes the relevant agents") {
+		t.Errorf("granular skill description should not imply category packs include agents, got %q", manifest.Description)
+	}
+}
+
+func assertSourceInstallMarketplaceHasOneFlagshipPlugin(t *testing.T, path string) {
+	t.Helper()
+	var mp SourceInstallMarketplace
+	readJSON(t, path, &mp)
+
+	if mp.Name != "atv-starter-kit" {
+		t.Errorf("source-install marketplace name: got %q want atv-starter-kit", mp.Name)
+	}
+	if len(mp.Plugins) != 1 {
+		t.Fatalf("source-install marketplace should expose exactly one plugin, got %d", len(mp.Plugins))
+	}
+
+	entry := mp.Plugins[0]
+	if entry.Name != "atv-starter-kit" {
+		t.Errorf("source-install entry name: got %q want atv-starter-kit", entry.Name)
+	}
+	if entry.Source != "./plugins/atv-everything" {
+		t.Errorf("source-install entry source: got %q want ./plugins/atv-everything", entry.Source)
+	}
+	if len(entry.Description) > 120 {
+		t.Errorf("source-install description should fit in a picker row, got %d chars", len(entry.Description))
+	}
+	if strings.Contains(entry.Description, "http") {
+		t.Errorf("source-install description should not include URLs, got %q", entry.Description)
+	}
+	for _, noisyPrefix := range []string{"atv-skill-", "atv-pack-"} {
+		if strings.HasPrefix(entry.Name, noisyPrefix) {
+			t.Errorf("source-install entry should be the flagship plugin, got %q", entry.Name)
+		}
+	}
+	if entry.Name == "atv-agents" {
+		t.Errorf("source-install entry should not expose agents-only plugin")
+	}
+}
+
+func TestGenerate_MaintenanceSkillsCoverSourceAgentPlugins(t *testing.T) {
+	tmp := regenerateInto(t)
+
+	doctorSnippets := []string{
+		"VS Code source-installed AgentPlugins",
+		"hasSourceAgentPlugins",
+		"owner/repo",
+		"ahead/behind",
+		"Never update, reset, delete, or reinstall VS Code AgentPlugin folders from `/atv-doctor`",
+	}
+	updateSnippets := []string{
+		"VS Code source-installed AgentPlugins",
+		"clean and behind-only",
+		"Do not run `git reset`, `git stash`",
+		"Reload or restart VS Code",
+		"Never remove an entire `agent-plugins`",
+	}
+
+	for _, plugin := range []string{"atv-everything", "atv-pack-maintenance", "atv-skill-atv-doctor"} {
+		path := filepath.Join(tmp, "plugins", plugin, "skills", "atv-doctor", "SKILL.md")
+		assertFileContainsAll(t, path, doctorSnippets)
+	}
+	for _, plugin := range []string{"atv-everything", "atv-pack-maintenance", "atv-skill-atv-update"} {
+		path := filepath.Join(tmp, "plugins", plugin, "skills", "atv-update", "SKILL.md")
+		assertFileContainsAll(t, path, updateSnippets)
 	}
 }
 
@@ -202,12 +310,83 @@ func TestGenerate_DeterministicAcrossRuns(t *testing.T) {
 			t.Fatalf("generate: %v", err)
 		}
 	}
-	diffs, err := compareTrees(filepath.Join(tmpA, "plugins"), filepath.Join(tmpB, "plugins"))
+	for _, sub := range []string{"plugins", filepath.Join(".github", "plugin"), ".claude-plugin"} {
+		diffs, err := compareTrees(filepath.Join(tmpA, sub), filepath.Join(tmpB, sub))
+		if err != nil {
+			t.Fatalf("compareTrees %s: %v", sub, err)
+		}
+		if len(diffs) > 0 {
+			t.Errorf("non-deterministic generation in %s, diffs: %v", sub, diffs)
+		}
+	}
+	assertFilesEqual(t, filepath.Join(tmpA, "marketplace.json"), filepath.Join(tmpB, "marketplace.json"))
+}
+
+func TestCompareGeneratedContentIgnoresLineEndingDifferences(t *testing.T) {
+	gotRoot := t.TempDir()
+	wantRoot := t.TempDir()
+	gotPath := filepath.Join(gotRoot, "plugin", "README.md")
+	wantPath := filepath.Join(wantRoot, "plugin", "README.md")
+	if err := os.MkdirAll(filepath.Dir(gotPath), 0o755); err != nil {
+		t.Fatalf("mkdir got: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(wantPath), 0o755); err != nil {
+		t.Fatalf("mkdir want: %v", err)
+	}
+	if err := os.WriteFile(gotPath, []byte("# plugin\n\nbody\n"), 0o644); err != nil {
+		t.Fatalf("write got: %v", err)
+	}
+	if err := os.WriteFile(wantPath, []byte("# plugin\r\n\r\nbody\r\n"), 0o644); err != nil {
+		t.Fatalf("write want: %v", err)
+	}
+
+	diffs, err := compareTrees(gotRoot, wantRoot)
 	if err != nil {
 		t.Fatalf("compareTrees: %v", err)
 	}
-	if len(diffs) > 0 {
-		t.Errorf("non-deterministic generation, diffs: %v", diffs)
+	if len(diffs) != 0 {
+		t.Fatalf("line-ending-only differences should not be reported, got %v", diffs)
+	}
+
+	diffs, err = compareFile(gotPath, wantPath, "plugin/README.md")
+	if err != nil {
+		t.Fatalf("compareFile: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Fatalf("line-ending-only file differences should not be reported, got %v", diffs)
+	}
+}
+
+func TestCheckCleanReportsPrefixedCatalogDrift(t *testing.T) {
+	tmp := regenerateInto(t)
+	for _, rel := range []string{
+		"marketplace.json",
+		filepath.Join(".claude-plugin", "marketplace.json"),
+		filepath.Join(".github", "plugin", "marketplace.json"),
+	} {
+		path := filepath.Join(tmp, rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, append(data, []byte("\n")...), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	err := CheckClean(Config{RepoRoot: tmp, KitVersion: "test-1.2.3"})
+	if err == nil {
+		t.Fatal("expected CheckClean to report drift")
+	}
+	message := err.Error()
+	for _, want := range []string{
+		"content differs: marketplace.json",
+		"content differs: .claude-plugin/marketplace.json",
+		"content differs: .github/plugin/marketplace.json",
+	} {
+		if !strings.Contains(message, want) {
+			t.Errorf("CheckClean error missing %q:\n%s", want, message)
+		}
 	}
 }
 
@@ -269,5 +448,34 @@ func readJSON(t *testing.T, path string, v interface{}) {
 	}
 	if err := json.NewDecoder(bytes.NewReader(data)).Decode(v); err != nil {
 		t.Fatalf("decode %s: %v", path, err)
+	}
+}
+
+func assertFileContainsAll(t *testing.T, path string, snippets []string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	body := string(data)
+	for _, snippet := range snippets {
+		if !strings.Contains(body, snippet) {
+			t.Errorf("%s missing snippet %q", path, snippet)
+		}
+	}
+}
+
+func assertFilesEqual(t *testing.T, leftPath, rightPath string) {
+	t.Helper()
+	left, err := os.ReadFile(leftPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", leftPath, err)
+	}
+	right, err := os.ReadFile(rightPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", rightPath, err)
+	}
+	if !bytes.Equal(left, right) {
+		t.Errorf("files differ: %s and %s", leftPath, rightPath)
 	}
 }

--- a/pkg/plugingen/manifest.go
+++ b/pkg/plugingen/manifest.go
@@ -1,11 +1,12 @@
 // Package plugingen generates a GitHub Copilot CLI plugin marketplace
 // from the ATV Starter Kit's scaffold templates.
 //
-// The generator is the single source of truth for the plugins/ tree
-// and .github/plugin/marketplace.json. Templates under
-// pkg/scaffold/templates/ remain authoritative for both the atv init
-// scaffold path and the marketplace path; this package projects them
-// into the plugin format Copilot CLI expects.
+// The generator is the single source of truth for the plugins/ tree,
+// marketplace.json, .github/plugin/marketplace.json, and
+// .claude-plugin/marketplace.json.
+// Templates under pkg/scaffold/templates/ remain authoritative for both
+// the atv init scaffold path and the marketplace/source-install paths;
+// this package projects them into the plugin formats Copilot expects.
 //
 // All output is deterministic: lists are sorted, paths are slash-
 // normalized, line endings are LF. Re-running the generator on a
@@ -77,4 +78,32 @@ type MarketplaceEntry struct {
 	Version     string   `json:"version,omitempty"`
 	Keywords    []string `json:"keywords,omitempty"`
 	Category    string   `json:"category,omitempty"`
+}
+
+// SourceInstallMarketplace models the marketplace.json file consumed by
+// VS Code's source-install AgentPlugin flow. It intentionally stays separate
+// from the Copilot CLI marketplace model because the source-install catalog
+// has a curated UX surface and CE-style metadata fields.
+type SourceInstallMarketplace struct {
+	Name     string                       `json:"name"`
+	Owner    Author                       `json:"owner"`
+	Metadata SourceInstallMarketplaceMeta `json:"metadata"`
+	Plugins  []SourceInstallEntry         `json:"plugins"`
+}
+
+// SourceInstallMarketplaceMeta is the top-level metadata object for the
+// curated source-install catalog.
+type SourceInstallMarketplaceMeta struct {
+	Description string `json:"description,omitempty"`
+	Version     string `json:"version,omitempty"`
+}
+
+// SourceInstallEntry is one plugin entry in the curated source-install catalog.
+type SourceInstallEntry struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Author      *Author  `json:"author,omitempty"`
+	Homepage    string   `json:"homepage,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Source      string   `json:"source"`
 }

--- a/pkg/scaffold/templates/skills/atv-doctor/SKILL.md
+++ b/pkg/scaffold/templates/skills/atv-doctor/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: atv-doctor
-description: "Diagnose ATV Starter Kit installation health across both install paths (project scaffold from `atv init` and Copilot CLI marketplace plugins). Detects install scope, version drift, file integrity (checksums vs install manifest), hook validity, MCP prereqs, and optional dependency status. Triggers on 'atv doctor', 'atv health', 'check atv', 'diagnose atv', 'atv status', 'atv check', 'atv healthcheck', 'is atv ok'."
+description: "Diagnose ATV Starter Kit installation health across project scaffold, Copilot CLI marketplace plugins, and VS Code source-installed AgentPlugins. Detects install scope, version drift, AgentPlugin git state, file integrity, hook validity, MCP prereqs, and optional dependency status. Triggers on 'atv doctor', 'atv health', 'check atv', 'diagnose atv', 'atv status', 'atv check', 'atv healthcheck', 'is atv ok'."
 argument-hint: "[mode: report (default) | fix]"
 ---
 
 # /atv-doctor — ATV installation health check
 
-Diagnose your ATV Starter Kit installation. Checks both install paths (project scaffold via `atv init` and Copilot CLI marketplace plugins via `copilot plugin install`), version drift, file integrity, hook validity, MCP prereqs, and optional dependency status.
+Diagnose your ATV Starter Kit installation. Checks project scaffold via `atv init`, Copilot CLI marketplace plugins via `copilot plugin install`, and VS Code source-installed AgentPlugins via `Chat: Install Plugin from source`. Reports version drift, AgentPlugin git state, file integrity, hook validity, MCP prereqs, and optional dependency status.
 
 ## Arguments
 
@@ -17,14 +17,15 @@ Diagnose your ATV Starter Kit installation. Checks both install paths (project s
 ## Execution Flow
 
 ```
-Phase 1: Detect install scope        → repo-artifact + ~/.copilot/installed-plugins/ walk
-Phase 2: Version check               → installed vs latest npm
-Phase 3: File integrity (project)    → manifest checksum verification (when manifest exists)
-Phase 4: Hook validity (project)     → JSON parse + script existence
-Phase 5: MCP prereqs (project)       → parse inputs[] from MCP config
-Phase 6: Optional dep gating         → only warn for deps the user opted into
-Phase 7: Output graded report
-Phase 8: Fix mode (opt-in, marketplace plugins only)
+Phase 1: Detect install scope        → repo-artifact + marketplace + VS Code AgentPlugin roots
+Phase 2: Version check               → installed vs latest npm / source git state
+Phase 3: Source AgentPlugin health   → owner/repo, path, commit, version metadata, divergence
+Phase 4: File integrity (project)    → manifest checksum verification (when manifest exists)
+Phase 5: Hook validity (project)     → JSON parse + script existence
+Phase 6: MCP prereqs (project)       → parse inputs[] from MCP config
+Phase 7: Optional dep gating         → only warn for deps the user opted into
+Phase 8: Output graded report
+Phase 9: Fix mode (opt-in, marketplace plugins only)
 ```
 
 ---
@@ -40,8 +41,16 @@ Set these flags from the working directory's repo root (or `~/.copilot/` for mar
 | `hasProject` | true if **any** of these exist: `.github/skills/` (directory), `.github/copilot-instructions.md`, `.github/copilot-mcp-config.json`, `.github/hooks/copilot-hooks.json` |
 | `hasManifest` | true if `.atv/install-manifest.json` exists (used to enable Phases 3 & 5; not gating) |
 | `hasMarketplace` | true if `~/.copilot/installed-plugins/atv-starter-kit/` exists OR `copilot plugin marketplace list` mentions `atv-starter-kit` |
+| `hasSourceAgentPlugins` | true if any git checkout exists under a VS Code AgentPlugin root such as `$HOME/.vscode/agent-plugins/github.com/<owner>/<repo>` or `$HOME/.vscode-insiders/agent-plugins/github.com/<owner>/<repo>` |
 
-If `!hasProject && !hasMarketplace`: print "No ATV install detected. To install: `npx atv-starterkit init` (project scaffold) or `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit && copilot plugin install atv-everything@atv-starter-kit` (marketplace)." and stop.
+On Windows, `$HOME` may resolve through Git Bash and `%USERPROFILE%` may be clearer in PowerShell. Probe both Stable and Insiders roots without hardcoding a machine-specific username:
+
+| Product | Root examples |
+|---------|---------------|
+| VS Code Stable | `$HOME/.vscode/agent-plugins/github.com`, `%USERPROFILE%\.vscode\agent-plugins\github.com` |
+| VS Code Insiders | `$HOME/.vscode-insiders/agent-plugins/github.com`, `%USERPROFILE%\.vscode-insiders\agent-plugins\github.com` |
+
+If `!hasProject && !hasMarketplace && !hasSourceAgentPlugins`: print "No ATV install detected. To install: `npx atv-starterkit init` (project scaffold), `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit && copilot plugin install atv-everything@atv-starter-kit` (marketplace), or VS Code `Chat: Install Plugin from source` with `All-The-Vibes/ATV-StarterKit`." and stop.
 
 Record what was detected for the report header.
 
@@ -85,9 +94,66 @@ done
 
 For each installed version, compare to latest. Use semver-aware comparison if possible; otherwise string compare and flag any difference as 🟡 with the suggestion to run `/atv-update`.
 
+### 2e. Source-installed AgentPlugin versions
+
+If `hasSourceAgentPlugins`, inspect each discovered checkout under the VS Code AgentPlugin roots. Include ATV and other GitHub-source AgentPlugins such as Compound Engineering in the report, because stale source installs are easiest to diagnose when the actual installed directory is inspected.
+
+For each plugin directory:
+
+1. Derive `owner/repo` from the `github.com/<owner>/<repo>` path segments.
+2. Read version metadata from the first available source:
+   - `package.json` `version`
+   - `VERSION`
+   - `.claude-plugin/plugin.json` `version`
+   - `plugin.json` `version`
+3. Read git state from inside that directory:
+   - current branch or detached HEAD
+   - current commit
+   - `git describe --tags --always` when available
+   - `origin` URL when available
+   - dirty state from `git status --short`
+   - upstream tracking branch and ahead/behind counts when available
+4. Best-effort fetch remote state before ahead/behind comparison. If fetch fails because the user is offline or the remote is unavailable, report remote drift as unknown and keep going.
+
+Do not mutate source AgentPlugin checkouts in `/atv-doctor`. This phase is read-only except for best-effort git remote metadata fetch.
+
 ---
 
-## Phase 3: File integrity (project scaffold, manifest required)
+## Phase 3: Source AgentPlugin health
+
+Summarize source-installed AgentPlugins separately from Copilot CLI marketplace plugins.
+
+Suggested report shape:
+
+```markdown
+**VS Code source-installed AgentPlugins:**
+- All-The-Vibes/ATV-StarterKit
+  - Path: <exact installed path>
+  - Version: 2.6.3 (from VERSION)
+  - Git: main @ b2a2d11 (v2.6.3)
+  - Remote: origin/main, clean, behind by 0 / ahead by 0 🟢
+- EveryInc/compound-engineering-plugin
+  - Path: <exact installed path>
+  - Version: 3.2.0 (from package.json)
+  - Git: main @ <commit> (<describe>)
+  - Remote: origin/main, behind by N 🟡 update available
+```
+
+Severity rules:
+
+| State | Severity | Meaning |
+|-------|----------|---------|
+| clean and aligned with upstream | 🟢 ok | Source plugin checkout appears current |
+| clean and behind upstream | 🟡 warn | Update available; run `/atv-update` |
+| dirty worktree | 🟡 warn | Local edits present; update must not overwrite silently |
+| ahead of upstream | 🟡 warn | Local commits present; update needs manual review |
+| diverged from upstream | 🔴 critical | Both local and remote changed; do not auto-update |
+| detached HEAD or no upstream | ⚪ info | Version can be reported, but update path is manual |
+| missing version metadata | ⚪ info | Git state is still useful; version is unknown |
+
+---
+
+## Phase 4: File integrity (project scaffold, manifest required)
 
 Skip this phase entirely when `!hasManifest` and emit:
 
@@ -110,7 +176,7 @@ Group findings by severity in the final report (don't print one line per file un
 
 ---
 
-## Phase 4: Hook validity (project scaffold only)
+## Phase 5: Hook validity (project scaffold only)
 
 Skip when `!hasProject` or `.github/hooks/copilot-hooks.json` is absent.
 
@@ -120,7 +186,7 @@ Skip when `!hasProject` or `.github/hooks/copilot-hooks.json` is absent.
 
 ---
 
-## Phase 5: MCP prereqs (project scaffold only)
+## Phase 6: MCP prereqs (project scaffold only)
 
 Skip when `!hasProject` or `.github/copilot-mcp-config.json` is absent.
 
@@ -142,7 +208,7 @@ MCP servers configured:
 
 ---
 
-## Phase 6: Optional dep gating
+## Phase 7: Optional dep gating
 
 For each optional tool, only warn when there's evidence the user wants it. **Never warn unconditionally.**
 
@@ -158,7 +224,7 @@ When `!hasManifest`, fall back to ⚪ informational status for everything option
 
 ---
 
-## Phase 7: Output
+## Phase 8: Output
 
 Print a graded report. Use this skeleton:
 
@@ -168,6 +234,7 @@ Print a graded report. Use this skeleton:
 **Detected:**
 - Project scaffold: ✓ (manifest: yes/no)
 - Marketplace plugins: ✓ (N installed)
+- Source AgentPlugins: ✓ (N detected)
 
 **Versions:**
 - Latest on npm: 2.6.3
@@ -188,7 +255,7 @@ Print a graded report. Use this skeleton:
 - ...
 
 **Next steps:**
-- Run `/atv-update` to update marketplace plugins.
+- Run `/atv-update` to update marketplace plugins or clean source-installed ATV checkouts.
 - Project scaffold updates require manual review (today's installer is additive-only).
 ```
 
@@ -196,9 +263,9 @@ If zero non-info findings: "Your ATV install looks healthy! 🩺"
 
 ---
 
-## Phase 8: Fix mode (opt-in)
+## Phase 9: Fix mode (opt-in)
 
-Only runs when `mode=fix`. **Limited scope today** — only marketplace plugin updates are auto-fixable. Project scaffold "fixes" require the user to manually re-run the installer because today's `atv init` is additive-only and would not refresh existing files.
+Only runs when `mode=fix`. **Limited scope today** — only Copilot CLI marketplace plugin updates are auto-fixable from doctor mode. Project scaffold "fixes" require the user to manually re-run the installer because today's `atv init` is additive-only and would not refresh existing files. Source AgentPlugin updates belong in `/atv-update`, where the workflow can inspect git state and ask for explicit confirmation before changing a checkout.
 
 For each stale marketplace plugin:
 
@@ -212,6 +279,7 @@ After all fixes, print a summary: "Updated N plugins, skipped M."
 **Constraints:**
 - Never auto-rerun `atv init` (today's installer is additive-only — would not actually refresh files).
 - Never modify scaffold files directly.
+- Never update, reset, delete, or reinstall VS Code AgentPlugin folders from `/atv-doctor`.
 - Always confirm before running anything.
 
 ---
@@ -219,6 +287,7 @@ After all fixes, print a summary: "Updated N plugins, skipped M."
 ## What this skill does NOT do
 
 - Refresh project scaffold files (installer is additive-only today; tracked as future work).
+- Update VS Code source-installed AgentPlugins directly (use `/atv-update`).
 - Validate MCP server connectivity (would require network calls to each server).
 - Run JSON-schema validation on configs (just parse + key presence).
 - Auto-install missing optional dependencies (Bun, agent-browser, gh, az).

--- a/pkg/scaffold/templates/skills/atv-update/SKILL.md
+++ b/pkg/scaffold/templates/skills/atv-update/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: atv-update
-description: "Update ATV Starter Kit to the latest version. For Copilot CLI marketplace plugins (`atv-skill-*`, `atv-pack-*`, `atv-everything`, `atv-agents`): runs `copilot plugin update` per installed ATV plugin with per-step confirmation. For project scaffold (`atv init`): reports the version delta and prints the exact commands you can run — does NOT auto-rerun the installer because today's installer is additive-only and would not refresh existing files. Triggers on 'atv update', 'update atv', 'upgrade atv', 'atv upgrade', 'refresh atv', 'atv latest'."
+description: "Update ATV Starter Kit to the latest version. Handles Copilot CLI marketplace plugins, VS Code source-installed AgentPlugins, and project scaffold advisory status. Marketplace plugins use `copilot plugin update` with confirmation. Clean source AgentPlugins can fast-forward with confirmation. Project scaffold remains advisory because today's installer is additive-only. Triggers on 'atv update', 'update atv', 'upgrade atv', 'atv upgrade', 'refresh atv', 'atv latest'."
 argument-hint: "[mode: dry-run | apply (default)]"
 ---
 
 # /atv-update — Update ATV Starter Kit
 
-Bring your ATV install up to the latest version. Handles both install paths:
+Bring your ATV install up to the latest version. Handles three install paths:
 
 - **Marketplace plugins** — auto-updated via `copilot plugin update` (with per-plugin confirmation).
+- **VS Code source-installed AgentPlugins** — updated only when the checkout is clean and can fast-forward safely (with confirmation and reload guidance).
 - **Project scaffold** — advisory only. Today's installer is `additive-only` and `npx atv-starterkit@latest init` will NOT refresh existing scaffold files. This skill prints the version delta and the exact commands you can run yourself.
 
 > **Future:** Once the installer gains a `--refresh` flag (read manifest → overwrite checksum-clean files → preserve drifted files), this skill will gain auto-update for project scaffold too. Tracked as a known gap.
@@ -23,12 +24,13 @@ Bring your ATV install up to the latest version. Handles both install paths:
 
 ```
 Phase 1: Detect install scope         → same as /atv-doctor Phase 1
-Phase 2: Read installed versions      → manifest (project) + plugin.json files (marketplace)
+Phase 2: Read installed versions      → project + marketplace + source AgentPlugins
 Phase 3: Fetch latest npm version     → npm view
 Phase 4: Show changelog (best-effort) → fetch + parse, fall back to link
 Phase 5: Plan update                  → structured table of components + commands
-Phase 6: Apply (marketplace only)     → copilot plugin update with confirmation
-Phase 7: Verify (suggest /atv-doctor)
+Phase 6: Apply marketplace updates    → copilot plugin update with confirmation
+Phase 7: Apply source plugin updates  → clean fast-forward only, with confirmation
+Phase 8: Verify and reload guidance   → suggest /atv-doctor + VS Code reload/restart
 ```
 
 ---
@@ -42,8 +44,11 @@ Same detection logic as `/atv-doctor` Phase 1 — repo-artifact-based, not manif
 | `hasProject` | any of `.github/skills/`, `.github/copilot-instructions.md`, `.github/copilot-mcp-config.json` exists |
 | `hasManifest` | `.atv/install-manifest.json` exists |
 | `hasMarketplace` | `~/.copilot/installed-plugins/atv-starter-kit/` exists |
+| `hasSourceAgentPlugins` | any git checkout exists under a VS Code AgentPlugin root such as `$HOME/.vscode/agent-plugins/github.com/<owner>/<repo>` or `$HOME/.vscode-insiders/agent-plugins/github.com/<owner>/<repo>` |
 
-If `!hasProject && !hasMarketplace`: print "No ATV install detected. Nothing to update. Run `npx atv-starterkit init` to scaffold, or `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit` to register the marketplace." and stop.
+Probe both Stable and Insiders roots. On Windows, prefer profile-aware paths such as `%USERPROFILE%\.vscode-insiders\agent-plugins\github.com` in PowerShell and `$HOME/.vscode-insiders/agent-plugins/github.com` in Bash; never hardcode a machine-specific user directory.
+
+If `!hasProject && !hasMarketplace && !hasSourceAgentPlugins`: print "No ATV install detected. Nothing to update. Run `npx atv-starterkit init` to scaffold, `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit` to register the marketplace, or VS Code `Chat: Install Plugin from source` with `All-The-Vibes/ATV-StarterKit`." and stop.
 
 ---
 
@@ -70,6 +75,35 @@ done
 ```
 
 Build a list `{name, currentVersion}` for each ATV plugin.
+
+### VS Code source-installed AgentPlugins
+
+Walk VS Code Stable and Insiders AgentPlugin roots under `agent-plugins/github.com/<owner>/<repo>`. By default, target only `All-The-Vibes/ATV-StarterKit` and `datorresb/ATV-StarterKit` source installs. If the user explicitly named another owner/repo or exact plugin path in the arguments, inspect that target too.
+
+For each target checkout, collect:
+
+- exact path
+- owner/repo from the path
+- version metadata from `package.json`, `VERSION`, `.claude-plugin/plugin.json`, or `plugin.json`
+- current branch or detached HEAD
+- current commit and `git describe --tags --always` when available
+- origin URL
+- dirty state from `git status --short`
+- upstream tracking branch and ahead/behind counts after best-effort fetch
+
+Classify source plugin update state:
+
+| State | Update action |
+|-------|---------------|
+| clean, tracking branch, behind remote only | eligible for fast-forward after confirmation |
+| clean and aligned | no update needed |
+| dirty worktree | stop; explain local edits must be reviewed first |
+| ahead of remote | stop; explain local commits must be reviewed first |
+| diverged | stop; explain both local and remote changed |
+| detached HEAD or no upstream | stop; manual update path only |
+| fetch failed | stop; remote state unknown |
+
+Do not run `git reset`, `git stash`, branch checkout, folder deletion, or reclone as part of normal update.
 
 ---
 
@@ -151,13 +185,37 @@ For each plugin from Phase 2 that's behind `LATEST`, list it as:
 
 If all plugins are up to date: print "All marketplace plugins are up to date."
 
+### VS Code source-installed AgentPlugins (auto only when safe)
+
+For each detected ATV source plugin:
+
+```
+🔄 Source AgentPlugin updates
+  • All-The-Vibes/ATV-StarterKit
+    Path: <exact path>
+    State: clean, main behind origin/main by N commits
+    Action: eligible for fast-forward in Phase 7
+```
+
+For blocked states, print the exact reason and do not include an automatic command in the apply plan:
+
+```
+⚠️ Source AgentPlugin requires manual review
+  • EveryInc/compound-engineering-plugin
+    Path: <exact path>
+    State: dirty worktree
+    Action: skipped — local edits would be overwritten by an update
+```
+
+If a reinstall/removal is the only practical remediation, present it as a separate destructive option, not as the default update path. It must show the exact folder that would be removed and require explicit confirmation before removal.
+
 ---
 
-## Phase 6: Apply (marketplace only)
+## Phase 6: Apply marketplace updates
 
 **Skip this phase entirely in `dry-run` mode.**
 
-Project scaffold updates are NEVER auto-applied — see Phase 5 rationale.
+Project scaffold updates are NEVER auto-applied — see Phase 5 rationale. Source AgentPlugin updates are handled in Phase 7.
 
 For each marketplace plugin from Phase 5 that's behind:
 
@@ -177,19 +235,61 @@ Errored on X (see above for details).
 
 ---
 
-## Phase 7: Verify
+## Phase 7: Apply source plugin updates
+
+**Skip this phase entirely in `dry-run` mode.**
+
+For each source AgentPlugin classified as clean and behind-only:
+
+1. Show the exact owner/repo, installed path, current commit, upstream branch, and behind count.
+2. Use `AskUserQuestion`:
+  > Fast-forward source AgentPlugin `<owner>/<repo>` at `<exact path>` now? (y/n)
+3. On `y`: run a fast-forward-only update in that plugin directory.
+4. On `n`: skip and continue.
+5. On error: report the failure clearly and do not try destructive remediation automatically.
+
+For blocked states:
+
+- **Dirty worktree:** print the changed-file summary and stop. Do not stash, reset, or overwrite.
+- **Ahead or diverged:** print ahead/behind counts and stop. The user must review local commits before update.
+- **Detached HEAD or no upstream:** print that no safe automatic update target exists.
+- **Fetch failed:** print that remote state is unknown and stop.
+
+### Destructive reinstall/removal fallback
+
+Only offer this after a clean in-place update is impossible or has failed, and only when the user asks to remediate.
+
+Before removal:
+
+1. Print exactly what would be lost: the full plugin folder path and all files inside it.
+2. Ask for explicit confirmation naming that exact folder.
+3. Remove only that plugin folder after confirmation.
+4. Verify the folder and its metadata file are gone.
+5. Tell the user to reinstall through VS Code `Chat: Install Plugin from source`.
+
+Never remove an entire `agent-plugins`, `github.com`, `.vscode`, or `.vscode-insiders` directory.
+
+---
+
+## Phase 8: Verify and reload guidance
 
 After applying any changes, suggest:
 
 > Run `/atv-doctor` to verify the post-update install state.
 
-Don't run it automatically — let the user choose.
+If any source AgentPlugin was updated or reinstalled, also print:
+
+> Reload or restart VS Code / VS Code Insiders so the AgentPlugin content is reloaded. If the old skills still appear, close all VS Code windows and reopen the workspace before re-running `/atv-doctor`.
+
+Don't run `/atv-doctor` or reload VS Code automatically — let the user choose.
 
 ---
 
 ## What this skill does NOT do
 
 - Auto-refresh project scaffold files (installer limitation; tracked as future work).
+- Force-update dirty, ahead, diverged, detached, or untracked source AgentPlugin checkouts.
+- Silently delete or reinstall VS Code AgentPlugin folders.
 - Update gstack — that's `gstack`'s own responsibility (gstack syncs from its source repo).
 - Update agent-browser — `npm install -g agent-browser` is manual.
 - Pin specific versions — `copilot plugin install plugin@marketplace` doesn't accept a version. All ATV plugins share the kit version.

--- a/plugins/atv-everything/.claude-plugin/plugin.json
+++ b/plugins/atv-everything/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "atv-starter-kit",
+  "description": "ATV Starter Kit for VS Code: all ATV skills and reviewer/specialist agents in one personal install.",
+  "version": "2.6.3",
+  "author": {
+    "name": "All The Vibes",
+    "url": "https://github.com/All-The-Vibes"
+  },
+  "homepage": "https://github.com/All-The-Vibes/ATV-StarterKit",
+  "repository": "https://github.com/All-The-Vibes/ATV-StarterKit",
+  "license": "MIT",
+  "keywords": [
+    "atv",
+    "starter-kit",
+    "vscode",
+    "agent-plugin"
+  ]
+}

--- a/plugins/atv-everything/skills/atv-doctor/SKILL.md
+++ b/plugins/atv-everything/skills/atv-doctor/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: atv-doctor
-description: "Diagnose ATV Starter Kit installation health across both install paths (project scaffold from `atv init` and Copilot CLI marketplace plugins). Detects install scope, version drift, file integrity (checksums vs install manifest), hook validity, MCP prereqs, and optional dependency status. Triggers on 'atv doctor', 'atv health', 'check atv', 'diagnose atv', 'atv status', 'atv check', 'atv healthcheck', 'is atv ok'."
+description: "Diagnose ATV Starter Kit installation health across project scaffold, Copilot CLI marketplace plugins, and VS Code source-installed AgentPlugins. Detects install scope, version drift, AgentPlugin git state, file integrity, hook validity, MCP prereqs, and optional dependency status. Triggers on 'atv doctor', 'atv health', 'check atv', 'diagnose atv', 'atv status', 'atv check', 'atv healthcheck', 'is atv ok'."
 argument-hint: "[mode: report (default) | fix]"
 ---
 
 # /atv-doctor — ATV installation health check
 
-Diagnose your ATV Starter Kit installation. Checks both install paths (project scaffold via `atv init` and Copilot CLI marketplace plugins via `copilot plugin install`), version drift, file integrity, hook validity, MCP prereqs, and optional dependency status.
+Diagnose your ATV Starter Kit installation. Checks project scaffold via `atv init`, Copilot CLI marketplace plugins via `copilot plugin install`, and VS Code source-installed AgentPlugins via `Chat: Install Plugin from source`. Reports version drift, AgentPlugin git state, file integrity, hook validity, MCP prereqs, and optional dependency status.
 
 ## Arguments
 
@@ -17,14 +17,15 @@ Diagnose your ATV Starter Kit installation. Checks both install paths (project s
 ## Execution Flow
 
 ```
-Phase 1: Detect install scope        → repo-artifact + ~/.copilot/installed-plugins/ walk
-Phase 2: Version check               → installed vs latest npm
-Phase 3: File integrity (project)    → manifest checksum verification (when manifest exists)
-Phase 4: Hook validity (project)     → JSON parse + script existence
-Phase 5: MCP prereqs (project)       → parse inputs[] from MCP config
-Phase 6: Optional dep gating         → only warn for deps the user opted into
-Phase 7: Output graded report
-Phase 8: Fix mode (opt-in, marketplace plugins only)
+Phase 1: Detect install scope        → repo-artifact + marketplace + VS Code AgentPlugin roots
+Phase 2: Version check               → installed vs latest npm / source git state
+Phase 3: Source AgentPlugin health   → owner/repo, path, commit, version metadata, divergence
+Phase 4: File integrity (project)    → manifest checksum verification (when manifest exists)
+Phase 5: Hook validity (project)     → JSON parse + script existence
+Phase 6: MCP prereqs (project)       → parse inputs[] from MCP config
+Phase 7: Optional dep gating         → only warn for deps the user opted into
+Phase 8: Output graded report
+Phase 9: Fix mode (opt-in, marketplace plugins only)
 ```
 
 ---
@@ -40,8 +41,16 @@ Set these flags from the working directory's repo root (or `~/.copilot/` for mar
 | `hasProject` | true if **any** of these exist: `.github/skills/` (directory), `.github/copilot-instructions.md`, `.github/copilot-mcp-config.json`, `.github/hooks/copilot-hooks.json` |
 | `hasManifest` | true if `.atv/install-manifest.json` exists (used to enable Phases 3 & 5; not gating) |
 | `hasMarketplace` | true if `~/.copilot/installed-plugins/atv-starter-kit/` exists OR `copilot plugin marketplace list` mentions `atv-starter-kit` |
+| `hasSourceAgentPlugins` | true if any git checkout exists under a VS Code AgentPlugin root such as `$HOME/.vscode/agent-plugins/github.com/<owner>/<repo>` or `$HOME/.vscode-insiders/agent-plugins/github.com/<owner>/<repo>` |
 
-If `!hasProject && !hasMarketplace`: print "No ATV install detected. To install: `npx atv-starterkit init` (project scaffold) or `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit && copilot plugin install atv-everything@atv-starter-kit` (marketplace)." and stop.
+On Windows, `$HOME` may resolve through Git Bash and `%USERPROFILE%` may be clearer in PowerShell. Probe both Stable and Insiders roots without hardcoding a machine-specific username:
+
+| Product | Root examples |
+|---------|---------------|
+| VS Code Stable | `$HOME/.vscode/agent-plugins/github.com`, `%USERPROFILE%\.vscode\agent-plugins\github.com` |
+| VS Code Insiders | `$HOME/.vscode-insiders/agent-plugins/github.com`, `%USERPROFILE%\.vscode-insiders\agent-plugins\github.com` |
+
+If `!hasProject && !hasMarketplace && !hasSourceAgentPlugins`: print "No ATV install detected. To install: `npx atv-starterkit init` (project scaffold), `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit && copilot plugin install atv-everything@atv-starter-kit` (marketplace), or VS Code `Chat: Install Plugin from source` with `All-The-Vibes/ATV-StarterKit`." and stop.
 
 Record what was detected for the report header.
 
@@ -85,9 +94,66 @@ done
 
 For each installed version, compare to latest. Use semver-aware comparison if possible; otherwise string compare and flag any difference as 🟡 with the suggestion to run `/atv-update`.
 
+### 2e. Source-installed AgentPlugin versions
+
+If `hasSourceAgentPlugins`, inspect each discovered checkout under the VS Code AgentPlugin roots. Include ATV and other GitHub-source AgentPlugins such as Compound Engineering in the report, because stale source installs are easiest to diagnose when the actual installed directory is inspected.
+
+For each plugin directory:
+
+1. Derive `owner/repo` from the `github.com/<owner>/<repo>` path segments.
+2. Read version metadata from the first available source:
+   - `package.json` `version`
+   - `VERSION`
+   - `.claude-plugin/plugin.json` `version`
+   - `plugin.json` `version`
+3. Read git state from inside that directory:
+   - current branch or detached HEAD
+   - current commit
+   - `git describe --tags --always` when available
+   - `origin` URL when available
+   - dirty state from `git status --short`
+   - upstream tracking branch and ahead/behind counts when available
+4. Best-effort fetch remote state before ahead/behind comparison. If fetch fails because the user is offline or the remote is unavailable, report remote drift as unknown and keep going.
+
+Do not mutate source AgentPlugin checkouts in `/atv-doctor`. This phase is read-only except for best-effort git remote metadata fetch.
+
 ---
 
-## Phase 3: File integrity (project scaffold, manifest required)
+## Phase 3: Source AgentPlugin health
+
+Summarize source-installed AgentPlugins separately from Copilot CLI marketplace plugins.
+
+Suggested report shape:
+
+```markdown
+**VS Code source-installed AgentPlugins:**
+- All-The-Vibes/ATV-StarterKit
+  - Path: <exact installed path>
+  - Version: 2.6.3 (from VERSION)
+  - Git: main @ b2a2d11 (v2.6.3)
+  - Remote: origin/main, clean, behind by 0 / ahead by 0 🟢
+- EveryInc/compound-engineering-plugin
+  - Path: <exact installed path>
+  - Version: 3.2.0 (from package.json)
+  - Git: main @ <commit> (<describe>)
+  - Remote: origin/main, behind by N 🟡 update available
+```
+
+Severity rules:
+
+| State | Severity | Meaning |
+|-------|----------|---------|
+| clean and aligned with upstream | 🟢 ok | Source plugin checkout appears current |
+| clean and behind upstream | 🟡 warn | Update available; run `/atv-update` |
+| dirty worktree | 🟡 warn | Local edits present; update must not overwrite silently |
+| ahead of upstream | 🟡 warn | Local commits present; update needs manual review |
+| diverged from upstream | 🔴 critical | Both local and remote changed; do not auto-update |
+| detached HEAD or no upstream | ⚪ info | Version can be reported, but update path is manual |
+| missing version metadata | ⚪ info | Git state is still useful; version is unknown |
+
+---
+
+## Phase 4: File integrity (project scaffold, manifest required)
 
 Skip this phase entirely when `!hasManifest` and emit:
 
@@ -110,7 +176,7 @@ Group findings by severity in the final report (don't print one line per file un
 
 ---
 
-## Phase 4: Hook validity (project scaffold only)
+## Phase 5: Hook validity (project scaffold only)
 
 Skip when `!hasProject` or `.github/hooks/copilot-hooks.json` is absent.
 
@@ -120,7 +186,7 @@ Skip when `!hasProject` or `.github/hooks/copilot-hooks.json` is absent.
 
 ---
 
-## Phase 5: MCP prereqs (project scaffold only)
+## Phase 6: MCP prereqs (project scaffold only)
 
 Skip when `!hasProject` or `.github/copilot-mcp-config.json` is absent.
 
@@ -142,7 +208,7 @@ MCP servers configured:
 
 ---
 
-## Phase 6: Optional dep gating
+## Phase 7: Optional dep gating
 
 For each optional tool, only warn when there's evidence the user wants it. **Never warn unconditionally.**
 
@@ -158,7 +224,7 @@ When `!hasManifest`, fall back to ⚪ informational status for everything option
 
 ---
 
-## Phase 7: Output
+## Phase 8: Output
 
 Print a graded report. Use this skeleton:
 
@@ -168,6 +234,7 @@ Print a graded report. Use this skeleton:
 **Detected:**
 - Project scaffold: ✓ (manifest: yes/no)
 - Marketplace plugins: ✓ (N installed)
+- Source AgentPlugins: ✓ (N detected)
 
 **Versions:**
 - Latest on npm: 2.6.3
@@ -188,7 +255,7 @@ Print a graded report. Use this skeleton:
 - ...
 
 **Next steps:**
-- Run `/atv-update` to update marketplace plugins.
+- Run `/atv-update` to update marketplace plugins or clean source-installed ATV checkouts.
 - Project scaffold updates require manual review (today's installer is additive-only).
 ```
 
@@ -196,9 +263,9 @@ If zero non-info findings: "Your ATV install looks healthy! 🩺"
 
 ---
 
-## Phase 8: Fix mode (opt-in)
+## Phase 9: Fix mode (opt-in)
 
-Only runs when `mode=fix`. **Limited scope today** — only marketplace plugin updates are auto-fixable. Project scaffold "fixes" require the user to manually re-run the installer because today's `atv init` is additive-only and would not refresh existing files.
+Only runs when `mode=fix`. **Limited scope today** — only Copilot CLI marketplace plugin updates are auto-fixable from doctor mode. Project scaffold "fixes" require the user to manually re-run the installer because today's `atv init` is additive-only and would not refresh existing files. Source AgentPlugin updates belong in `/atv-update`, where the workflow can inspect git state and ask for explicit confirmation before changing a checkout.
 
 For each stale marketplace plugin:
 
@@ -212,6 +279,7 @@ After all fixes, print a summary: "Updated N plugins, skipped M."
 **Constraints:**
 - Never auto-rerun `atv init` (today's installer is additive-only — would not actually refresh files).
 - Never modify scaffold files directly.
+- Never update, reset, delete, or reinstall VS Code AgentPlugin folders from `/atv-doctor`.
 - Always confirm before running anything.
 
 ---
@@ -219,6 +287,7 @@ After all fixes, print a summary: "Updated N plugins, skipped M."
 ## What this skill does NOT do
 
 - Refresh project scaffold files (installer is additive-only today; tracked as future work).
+- Update VS Code source-installed AgentPlugins directly (use `/atv-update`).
 - Validate MCP server connectivity (would require network calls to each server).
 - Run JSON-schema validation on configs (just parse + key presence).
 - Auto-install missing optional dependencies (Bun, agent-browser, gh, az).

--- a/plugins/atv-everything/skills/atv-update/SKILL.md
+++ b/plugins/atv-everything/skills/atv-update/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: atv-update
-description: "Update ATV Starter Kit to the latest version. For Copilot CLI marketplace plugins (`atv-skill-*`, `atv-pack-*`, `atv-everything`, `atv-agents`): runs `copilot plugin update` per installed ATV plugin with per-step confirmation. For project scaffold (`atv init`): reports the version delta and prints the exact commands you can run — does NOT auto-rerun the installer because today's installer is additive-only and would not refresh existing files. Triggers on 'atv update', 'update atv', 'upgrade atv', 'atv upgrade', 'refresh atv', 'atv latest'."
+description: "Update ATV Starter Kit to the latest version. Handles Copilot CLI marketplace plugins, VS Code source-installed AgentPlugins, and project scaffold advisory status. Marketplace plugins use `copilot plugin update` with confirmation. Clean source AgentPlugins can fast-forward with confirmation. Project scaffold remains advisory because today's installer is additive-only. Triggers on 'atv update', 'update atv', 'upgrade atv', 'atv upgrade', 'refresh atv', 'atv latest'."
 argument-hint: "[mode: dry-run | apply (default)]"
 ---
 
 # /atv-update — Update ATV Starter Kit
 
-Bring your ATV install up to the latest version. Handles both install paths:
+Bring your ATV install up to the latest version. Handles three install paths:
 
 - **Marketplace plugins** — auto-updated via `copilot plugin update` (with per-plugin confirmation).
+- **VS Code source-installed AgentPlugins** — updated only when the checkout is clean and can fast-forward safely (with confirmation and reload guidance).
 - **Project scaffold** — advisory only. Today's installer is `additive-only` and `npx atv-starterkit@latest init` will NOT refresh existing scaffold files. This skill prints the version delta and the exact commands you can run yourself.
 
 > **Future:** Once the installer gains a `--refresh` flag (read manifest → overwrite checksum-clean files → preserve drifted files), this skill will gain auto-update for project scaffold too. Tracked as a known gap.
@@ -23,12 +24,13 @@ Bring your ATV install up to the latest version. Handles both install paths:
 
 ```
 Phase 1: Detect install scope         → same as /atv-doctor Phase 1
-Phase 2: Read installed versions      → manifest (project) + plugin.json files (marketplace)
+Phase 2: Read installed versions      → project + marketplace + source AgentPlugins
 Phase 3: Fetch latest npm version     → npm view
 Phase 4: Show changelog (best-effort) → fetch + parse, fall back to link
 Phase 5: Plan update                  → structured table of components + commands
-Phase 6: Apply (marketplace only)     → copilot plugin update with confirmation
-Phase 7: Verify (suggest /atv-doctor)
+Phase 6: Apply marketplace updates    → copilot plugin update with confirmation
+Phase 7: Apply source plugin updates  → clean fast-forward only, with confirmation
+Phase 8: Verify and reload guidance   → suggest /atv-doctor + VS Code reload/restart
 ```
 
 ---
@@ -42,8 +44,11 @@ Same detection logic as `/atv-doctor` Phase 1 — repo-artifact-based, not manif
 | `hasProject` | any of `.github/skills/`, `.github/copilot-instructions.md`, `.github/copilot-mcp-config.json` exists |
 | `hasManifest` | `.atv/install-manifest.json` exists |
 | `hasMarketplace` | `~/.copilot/installed-plugins/atv-starter-kit/` exists |
+| `hasSourceAgentPlugins` | any git checkout exists under a VS Code AgentPlugin root such as `$HOME/.vscode/agent-plugins/github.com/<owner>/<repo>` or `$HOME/.vscode-insiders/agent-plugins/github.com/<owner>/<repo>` |
 
-If `!hasProject && !hasMarketplace`: print "No ATV install detected. Nothing to update. Run `npx atv-starterkit init` to scaffold, or `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit` to register the marketplace." and stop.
+Probe both Stable and Insiders roots. On Windows, prefer profile-aware paths such as `%USERPROFILE%\.vscode-insiders\agent-plugins\github.com` in PowerShell and `$HOME/.vscode-insiders/agent-plugins/github.com` in Bash; never hardcode a machine-specific user directory.
+
+If `!hasProject && !hasMarketplace && !hasSourceAgentPlugins`: print "No ATV install detected. Nothing to update. Run `npx atv-starterkit init` to scaffold, `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit` to register the marketplace, or VS Code `Chat: Install Plugin from source` with `All-The-Vibes/ATV-StarterKit`." and stop.
 
 ---
 
@@ -70,6 +75,35 @@ done
 ```
 
 Build a list `{name, currentVersion}` for each ATV plugin.
+
+### VS Code source-installed AgentPlugins
+
+Walk VS Code Stable and Insiders AgentPlugin roots under `agent-plugins/github.com/<owner>/<repo>`. By default, target only `All-The-Vibes/ATV-StarterKit` and `datorresb/ATV-StarterKit` source installs. If the user explicitly named another owner/repo or exact plugin path in the arguments, inspect that target too.
+
+For each target checkout, collect:
+
+- exact path
+- owner/repo from the path
+- version metadata from `package.json`, `VERSION`, `.claude-plugin/plugin.json`, or `plugin.json`
+- current branch or detached HEAD
+- current commit and `git describe --tags --always` when available
+- origin URL
+- dirty state from `git status --short`
+- upstream tracking branch and ahead/behind counts after best-effort fetch
+
+Classify source plugin update state:
+
+| State | Update action |
+|-------|---------------|
+| clean, tracking branch, behind remote only | eligible for fast-forward after confirmation |
+| clean and aligned | no update needed |
+| dirty worktree | stop; explain local edits must be reviewed first |
+| ahead of remote | stop; explain local commits must be reviewed first |
+| diverged | stop; explain both local and remote changed |
+| detached HEAD or no upstream | stop; manual update path only |
+| fetch failed | stop; remote state unknown |
+
+Do not run `git reset`, `git stash`, branch checkout, folder deletion, or reclone as part of normal update.
 
 ---
 
@@ -151,13 +185,37 @@ For each plugin from Phase 2 that's behind `LATEST`, list it as:
 
 If all plugins are up to date: print "All marketplace plugins are up to date."
 
+### VS Code source-installed AgentPlugins (auto only when safe)
+
+For each detected ATV source plugin:
+
+```
+🔄 Source AgentPlugin updates
+  • All-The-Vibes/ATV-StarterKit
+    Path: <exact path>
+    State: clean, main behind origin/main by N commits
+    Action: eligible for fast-forward in Phase 7
+```
+
+For blocked states, print the exact reason and do not include an automatic command in the apply plan:
+
+```
+⚠️ Source AgentPlugin requires manual review
+  • EveryInc/compound-engineering-plugin
+    Path: <exact path>
+    State: dirty worktree
+    Action: skipped — local edits would be overwritten by an update
+```
+
+If a reinstall/removal is the only practical remediation, present it as a separate destructive option, not as the default update path. It must show the exact folder that would be removed and require explicit confirmation before removal.
+
 ---
 
-## Phase 6: Apply (marketplace only)
+## Phase 6: Apply marketplace updates
 
 **Skip this phase entirely in `dry-run` mode.**
 
-Project scaffold updates are NEVER auto-applied — see Phase 5 rationale.
+Project scaffold updates are NEVER auto-applied — see Phase 5 rationale. Source AgentPlugin updates are handled in Phase 7.
 
 For each marketplace plugin from Phase 5 that's behind:
 
@@ -177,19 +235,61 @@ Errored on X (see above for details).
 
 ---
 
-## Phase 7: Verify
+## Phase 7: Apply source plugin updates
+
+**Skip this phase entirely in `dry-run` mode.**
+
+For each source AgentPlugin classified as clean and behind-only:
+
+1. Show the exact owner/repo, installed path, current commit, upstream branch, and behind count.
+2. Use `AskUserQuestion`:
+  > Fast-forward source AgentPlugin `<owner>/<repo>` at `<exact path>` now? (y/n)
+3. On `y`: run a fast-forward-only update in that plugin directory.
+4. On `n`: skip and continue.
+5. On error: report the failure clearly and do not try destructive remediation automatically.
+
+For blocked states:
+
+- **Dirty worktree:** print the changed-file summary and stop. Do not stash, reset, or overwrite.
+- **Ahead or diverged:** print ahead/behind counts and stop. The user must review local commits before update.
+- **Detached HEAD or no upstream:** print that no safe automatic update target exists.
+- **Fetch failed:** print that remote state is unknown and stop.
+
+### Destructive reinstall/removal fallback
+
+Only offer this after a clean in-place update is impossible or has failed, and only when the user asks to remediate.
+
+Before removal:
+
+1. Print exactly what would be lost: the full plugin folder path and all files inside it.
+2. Ask for explicit confirmation naming that exact folder.
+3. Remove only that plugin folder after confirmation.
+4. Verify the folder and its metadata file are gone.
+5. Tell the user to reinstall through VS Code `Chat: Install Plugin from source`.
+
+Never remove an entire `agent-plugins`, `github.com`, `.vscode`, or `.vscode-insiders` directory.
+
+---
+
+## Phase 8: Verify and reload guidance
 
 After applying any changes, suggest:
 
 > Run `/atv-doctor` to verify the post-update install state.
 
-Don't run it automatically — let the user choose.
+If any source AgentPlugin was updated or reinstalled, also print:
+
+> Reload or restart VS Code / VS Code Insiders so the AgentPlugin content is reloaded. If the old skills still appear, close all VS Code windows and reopen the workspace before re-running `/atv-doctor`.
+
+Don't run `/atv-doctor` or reload VS Code automatically — let the user choose.
 
 ---
 
 ## What this skill does NOT do
 
 - Auto-refresh project scaffold files (installer limitation; tracked as future work).
+- Force-update dirty, ahead, diverged, detached, or untracked source AgentPlugin checkouts.
+- Silently delete or reinstall VS Code AgentPlugin folders.
 - Update gstack — that's `gstack`'s own responsibility (gstack syncs from its source repo).
 - Update agent-browser — `npm install -g agent-browser` is manual.
 - Pin specific versions — `copilot plugin install plugin@marketplace` doesn't accept a version. All ATV plugins share the kit version.

--- a/plugins/atv-pack-maintenance/skills/atv-doctor/SKILL.md
+++ b/plugins/atv-pack-maintenance/skills/atv-doctor/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: atv-doctor
-description: "Diagnose ATV Starter Kit installation health across both install paths (project scaffold from `atv init` and Copilot CLI marketplace plugins). Detects install scope, version drift, file integrity (checksums vs install manifest), hook validity, MCP prereqs, and optional dependency status. Triggers on 'atv doctor', 'atv health', 'check atv', 'diagnose atv', 'atv status', 'atv check', 'atv healthcheck', 'is atv ok'."
+description: "Diagnose ATV Starter Kit installation health across project scaffold, Copilot CLI marketplace plugins, and VS Code source-installed AgentPlugins. Detects install scope, version drift, AgentPlugin git state, file integrity, hook validity, MCP prereqs, and optional dependency status. Triggers on 'atv doctor', 'atv health', 'check atv', 'diagnose atv', 'atv status', 'atv check', 'atv healthcheck', 'is atv ok'."
 argument-hint: "[mode: report (default) | fix]"
 ---
 
 # /atv-doctor — ATV installation health check
 
-Diagnose your ATV Starter Kit installation. Checks both install paths (project scaffold via `atv init` and Copilot CLI marketplace plugins via `copilot plugin install`), version drift, file integrity, hook validity, MCP prereqs, and optional dependency status.
+Diagnose your ATV Starter Kit installation. Checks project scaffold via `atv init`, Copilot CLI marketplace plugins via `copilot plugin install`, and VS Code source-installed AgentPlugins via `Chat: Install Plugin from source`. Reports version drift, AgentPlugin git state, file integrity, hook validity, MCP prereqs, and optional dependency status.
 
 ## Arguments
 
@@ -17,14 +17,15 @@ Diagnose your ATV Starter Kit installation. Checks both install paths (project s
 ## Execution Flow
 
 ```
-Phase 1: Detect install scope        → repo-artifact + ~/.copilot/installed-plugins/ walk
-Phase 2: Version check               → installed vs latest npm
-Phase 3: File integrity (project)    → manifest checksum verification (when manifest exists)
-Phase 4: Hook validity (project)     → JSON parse + script existence
-Phase 5: MCP prereqs (project)       → parse inputs[] from MCP config
-Phase 6: Optional dep gating         → only warn for deps the user opted into
-Phase 7: Output graded report
-Phase 8: Fix mode (opt-in, marketplace plugins only)
+Phase 1: Detect install scope        → repo-artifact + marketplace + VS Code AgentPlugin roots
+Phase 2: Version check               → installed vs latest npm / source git state
+Phase 3: Source AgentPlugin health   → owner/repo, path, commit, version metadata, divergence
+Phase 4: File integrity (project)    → manifest checksum verification (when manifest exists)
+Phase 5: Hook validity (project)     → JSON parse + script existence
+Phase 6: MCP prereqs (project)       → parse inputs[] from MCP config
+Phase 7: Optional dep gating         → only warn for deps the user opted into
+Phase 8: Output graded report
+Phase 9: Fix mode (opt-in, marketplace plugins only)
 ```
 
 ---
@@ -40,8 +41,16 @@ Set these flags from the working directory's repo root (or `~/.copilot/` for mar
 | `hasProject` | true if **any** of these exist: `.github/skills/` (directory), `.github/copilot-instructions.md`, `.github/copilot-mcp-config.json`, `.github/hooks/copilot-hooks.json` |
 | `hasManifest` | true if `.atv/install-manifest.json` exists (used to enable Phases 3 & 5; not gating) |
 | `hasMarketplace` | true if `~/.copilot/installed-plugins/atv-starter-kit/` exists OR `copilot plugin marketplace list` mentions `atv-starter-kit` |
+| `hasSourceAgentPlugins` | true if any git checkout exists under a VS Code AgentPlugin root such as `$HOME/.vscode/agent-plugins/github.com/<owner>/<repo>` or `$HOME/.vscode-insiders/agent-plugins/github.com/<owner>/<repo>` |
 
-If `!hasProject && !hasMarketplace`: print "No ATV install detected. To install: `npx atv-starterkit init` (project scaffold) or `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit && copilot plugin install atv-everything@atv-starter-kit` (marketplace)." and stop.
+On Windows, `$HOME` may resolve through Git Bash and `%USERPROFILE%` may be clearer in PowerShell. Probe both Stable and Insiders roots without hardcoding a machine-specific username:
+
+| Product | Root examples |
+|---------|---------------|
+| VS Code Stable | `$HOME/.vscode/agent-plugins/github.com`, `%USERPROFILE%\.vscode\agent-plugins\github.com` |
+| VS Code Insiders | `$HOME/.vscode-insiders/agent-plugins/github.com`, `%USERPROFILE%\.vscode-insiders\agent-plugins\github.com` |
+
+If `!hasProject && !hasMarketplace && !hasSourceAgentPlugins`: print "No ATV install detected. To install: `npx atv-starterkit init` (project scaffold), `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit && copilot plugin install atv-everything@atv-starter-kit` (marketplace), or VS Code `Chat: Install Plugin from source` with `All-The-Vibes/ATV-StarterKit`." and stop.
 
 Record what was detected for the report header.
 
@@ -85,9 +94,66 @@ done
 
 For each installed version, compare to latest. Use semver-aware comparison if possible; otherwise string compare and flag any difference as 🟡 with the suggestion to run `/atv-update`.
 
+### 2e. Source-installed AgentPlugin versions
+
+If `hasSourceAgentPlugins`, inspect each discovered checkout under the VS Code AgentPlugin roots. Include ATV and other GitHub-source AgentPlugins such as Compound Engineering in the report, because stale source installs are easiest to diagnose when the actual installed directory is inspected.
+
+For each plugin directory:
+
+1. Derive `owner/repo` from the `github.com/<owner>/<repo>` path segments.
+2. Read version metadata from the first available source:
+   - `package.json` `version`
+   - `VERSION`
+   - `.claude-plugin/plugin.json` `version`
+   - `plugin.json` `version`
+3. Read git state from inside that directory:
+   - current branch or detached HEAD
+   - current commit
+   - `git describe --tags --always` when available
+   - `origin` URL when available
+   - dirty state from `git status --short`
+   - upstream tracking branch and ahead/behind counts when available
+4. Best-effort fetch remote state before ahead/behind comparison. If fetch fails because the user is offline or the remote is unavailable, report remote drift as unknown and keep going.
+
+Do not mutate source AgentPlugin checkouts in `/atv-doctor`. This phase is read-only except for best-effort git remote metadata fetch.
+
 ---
 
-## Phase 3: File integrity (project scaffold, manifest required)
+## Phase 3: Source AgentPlugin health
+
+Summarize source-installed AgentPlugins separately from Copilot CLI marketplace plugins.
+
+Suggested report shape:
+
+```markdown
+**VS Code source-installed AgentPlugins:**
+- All-The-Vibes/ATV-StarterKit
+  - Path: <exact installed path>
+  - Version: 2.6.3 (from VERSION)
+  - Git: main @ b2a2d11 (v2.6.3)
+  - Remote: origin/main, clean, behind by 0 / ahead by 0 🟢
+- EveryInc/compound-engineering-plugin
+  - Path: <exact installed path>
+  - Version: 3.2.0 (from package.json)
+  - Git: main @ <commit> (<describe>)
+  - Remote: origin/main, behind by N 🟡 update available
+```
+
+Severity rules:
+
+| State | Severity | Meaning |
+|-------|----------|---------|
+| clean and aligned with upstream | 🟢 ok | Source plugin checkout appears current |
+| clean and behind upstream | 🟡 warn | Update available; run `/atv-update` |
+| dirty worktree | 🟡 warn | Local edits present; update must not overwrite silently |
+| ahead of upstream | 🟡 warn | Local commits present; update needs manual review |
+| diverged from upstream | 🔴 critical | Both local and remote changed; do not auto-update |
+| detached HEAD or no upstream | ⚪ info | Version can be reported, but update path is manual |
+| missing version metadata | ⚪ info | Git state is still useful; version is unknown |
+
+---
+
+## Phase 4: File integrity (project scaffold, manifest required)
 
 Skip this phase entirely when `!hasManifest` and emit:
 
@@ -110,7 +176,7 @@ Group findings by severity in the final report (don't print one line per file un
 
 ---
 
-## Phase 4: Hook validity (project scaffold only)
+## Phase 5: Hook validity (project scaffold only)
 
 Skip when `!hasProject` or `.github/hooks/copilot-hooks.json` is absent.
 
@@ -120,7 +186,7 @@ Skip when `!hasProject` or `.github/hooks/copilot-hooks.json` is absent.
 
 ---
 
-## Phase 5: MCP prereqs (project scaffold only)
+## Phase 6: MCP prereqs (project scaffold only)
 
 Skip when `!hasProject` or `.github/copilot-mcp-config.json` is absent.
 
@@ -142,7 +208,7 @@ MCP servers configured:
 
 ---
 
-## Phase 6: Optional dep gating
+## Phase 7: Optional dep gating
 
 For each optional tool, only warn when there's evidence the user wants it. **Never warn unconditionally.**
 
@@ -158,7 +224,7 @@ When `!hasManifest`, fall back to ⚪ informational status for everything option
 
 ---
 
-## Phase 7: Output
+## Phase 8: Output
 
 Print a graded report. Use this skeleton:
 
@@ -168,6 +234,7 @@ Print a graded report. Use this skeleton:
 **Detected:**
 - Project scaffold: ✓ (manifest: yes/no)
 - Marketplace plugins: ✓ (N installed)
+- Source AgentPlugins: ✓ (N detected)
 
 **Versions:**
 - Latest on npm: 2.6.3
@@ -188,7 +255,7 @@ Print a graded report. Use this skeleton:
 - ...
 
 **Next steps:**
-- Run `/atv-update` to update marketplace plugins.
+- Run `/atv-update` to update marketplace plugins or clean source-installed ATV checkouts.
 - Project scaffold updates require manual review (today's installer is additive-only).
 ```
 
@@ -196,9 +263,9 @@ If zero non-info findings: "Your ATV install looks healthy! 🩺"
 
 ---
 
-## Phase 8: Fix mode (opt-in)
+## Phase 9: Fix mode (opt-in)
 
-Only runs when `mode=fix`. **Limited scope today** — only marketplace plugin updates are auto-fixable. Project scaffold "fixes" require the user to manually re-run the installer because today's `atv init` is additive-only and would not refresh existing files.
+Only runs when `mode=fix`. **Limited scope today** — only Copilot CLI marketplace plugin updates are auto-fixable from doctor mode. Project scaffold "fixes" require the user to manually re-run the installer because today's `atv init` is additive-only and would not refresh existing files. Source AgentPlugin updates belong in `/atv-update`, where the workflow can inspect git state and ask for explicit confirmation before changing a checkout.
 
 For each stale marketplace plugin:
 
@@ -212,6 +279,7 @@ After all fixes, print a summary: "Updated N plugins, skipped M."
 **Constraints:**
 - Never auto-rerun `atv init` (today's installer is additive-only — would not actually refresh files).
 - Never modify scaffold files directly.
+- Never update, reset, delete, or reinstall VS Code AgentPlugin folders from `/atv-doctor`.
 - Always confirm before running anything.
 
 ---
@@ -219,6 +287,7 @@ After all fixes, print a summary: "Updated N plugins, skipped M."
 ## What this skill does NOT do
 
 - Refresh project scaffold files (installer is additive-only today; tracked as future work).
+- Update VS Code source-installed AgentPlugins directly (use `/atv-update`).
 - Validate MCP server connectivity (would require network calls to each server).
 - Run JSON-schema validation on configs (just parse + key presence).
 - Auto-install missing optional dependencies (Bun, agent-browser, gh, az).

--- a/plugins/atv-pack-maintenance/skills/atv-update/SKILL.md
+++ b/plugins/atv-pack-maintenance/skills/atv-update/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: atv-update
-description: "Update ATV Starter Kit to the latest version. For Copilot CLI marketplace plugins (`atv-skill-*`, `atv-pack-*`, `atv-everything`, `atv-agents`): runs `copilot plugin update` per installed ATV plugin with per-step confirmation. For project scaffold (`atv init`): reports the version delta and prints the exact commands you can run — does NOT auto-rerun the installer because today's installer is additive-only and would not refresh existing files. Triggers on 'atv update', 'update atv', 'upgrade atv', 'atv upgrade', 'refresh atv', 'atv latest'."
+description: "Update ATV Starter Kit to the latest version. Handles Copilot CLI marketplace plugins, VS Code source-installed AgentPlugins, and project scaffold advisory status. Marketplace plugins use `copilot plugin update` with confirmation. Clean source AgentPlugins can fast-forward with confirmation. Project scaffold remains advisory because today's installer is additive-only. Triggers on 'atv update', 'update atv', 'upgrade atv', 'atv upgrade', 'refresh atv', 'atv latest'."
 argument-hint: "[mode: dry-run | apply (default)]"
 ---
 
 # /atv-update — Update ATV Starter Kit
 
-Bring your ATV install up to the latest version. Handles both install paths:
+Bring your ATV install up to the latest version. Handles three install paths:
 
 - **Marketplace plugins** — auto-updated via `copilot plugin update` (with per-plugin confirmation).
+- **VS Code source-installed AgentPlugins** — updated only when the checkout is clean and can fast-forward safely (with confirmation and reload guidance).
 - **Project scaffold** — advisory only. Today's installer is `additive-only` and `npx atv-starterkit@latest init` will NOT refresh existing scaffold files. This skill prints the version delta and the exact commands you can run yourself.
 
 > **Future:** Once the installer gains a `--refresh` flag (read manifest → overwrite checksum-clean files → preserve drifted files), this skill will gain auto-update for project scaffold too. Tracked as a known gap.
@@ -23,12 +24,13 @@ Bring your ATV install up to the latest version. Handles both install paths:
 
 ```
 Phase 1: Detect install scope         → same as /atv-doctor Phase 1
-Phase 2: Read installed versions      → manifest (project) + plugin.json files (marketplace)
+Phase 2: Read installed versions      → project + marketplace + source AgentPlugins
 Phase 3: Fetch latest npm version     → npm view
 Phase 4: Show changelog (best-effort) → fetch + parse, fall back to link
 Phase 5: Plan update                  → structured table of components + commands
-Phase 6: Apply (marketplace only)     → copilot plugin update with confirmation
-Phase 7: Verify (suggest /atv-doctor)
+Phase 6: Apply marketplace updates    → copilot plugin update with confirmation
+Phase 7: Apply source plugin updates  → clean fast-forward only, with confirmation
+Phase 8: Verify and reload guidance   → suggest /atv-doctor + VS Code reload/restart
 ```
 
 ---
@@ -42,8 +44,11 @@ Same detection logic as `/atv-doctor` Phase 1 — repo-artifact-based, not manif
 | `hasProject` | any of `.github/skills/`, `.github/copilot-instructions.md`, `.github/copilot-mcp-config.json` exists |
 | `hasManifest` | `.atv/install-manifest.json` exists |
 | `hasMarketplace` | `~/.copilot/installed-plugins/atv-starter-kit/` exists |
+| `hasSourceAgentPlugins` | any git checkout exists under a VS Code AgentPlugin root such as `$HOME/.vscode/agent-plugins/github.com/<owner>/<repo>` or `$HOME/.vscode-insiders/agent-plugins/github.com/<owner>/<repo>` |
 
-If `!hasProject && !hasMarketplace`: print "No ATV install detected. Nothing to update. Run `npx atv-starterkit init` to scaffold, or `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit` to register the marketplace." and stop.
+Probe both Stable and Insiders roots. On Windows, prefer profile-aware paths such as `%USERPROFILE%\.vscode-insiders\agent-plugins\github.com` in PowerShell and `$HOME/.vscode-insiders/agent-plugins/github.com` in Bash; never hardcode a machine-specific user directory.
+
+If `!hasProject && !hasMarketplace && !hasSourceAgentPlugins`: print "No ATV install detected. Nothing to update. Run `npx atv-starterkit init` to scaffold, `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit` to register the marketplace, or VS Code `Chat: Install Plugin from source` with `All-The-Vibes/ATV-StarterKit`." and stop.
 
 ---
 
@@ -70,6 +75,35 @@ done
 ```
 
 Build a list `{name, currentVersion}` for each ATV plugin.
+
+### VS Code source-installed AgentPlugins
+
+Walk VS Code Stable and Insiders AgentPlugin roots under `agent-plugins/github.com/<owner>/<repo>`. By default, target only `All-The-Vibes/ATV-StarterKit` and `datorresb/ATV-StarterKit` source installs. If the user explicitly named another owner/repo or exact plugin path in the arguments, inspect that target too.
+
+For each target checkout, collect:
+
+- exact path
+- owner/repo from the path
+- version metadata from `package.json`, `VERSION`, `.claude-plugin/plugin.json`, or `plugin.json`
+- current branch or detached HEAD
+- current commit and `git describe --tags --always` when available
+- origin URL
+- dirty state from `git status --short`
+- upstream tracking branch and ahead/behind counts after best-effort fetch
+
+Classify source plugin update state:
+
+| State | Update action |
+|-------|---------------|
+| clean, tracking branch, behind remote only | eligible for fast-forward after confirmation |
+| clean and aligned | no update needed |
+| dirty worktree | stop; explain local edits must be reviewed first |
+| ahead of remote | stop; explain local commits must be reviewed first |
+| diverged | stop; explain both local and remote changed |
+| detached HEAD or no upstream | stop; manual update path only |
+| fetch failed | stop; remote state unknown |
+
+Do not run `git reset`, `git stash`, branch checkout, folder deletion, or reclone as part of normal update.
 
 ---
 
@@ -151,13 +185,37 @@ For each plugin from Phase 2 that's behind `LATEST`, list it as:
 
 If all plugins are up to date: print "All marketplace plugins are up to date."
 
+### VS Code source-installed AgentPlugins (auto only when safe)
+
+For each detected ATV source plugin:
+
+```
+🔄 Source AgentPlugin updates
+  • All-The-Vibes/ATV-StarterKit
+    Path: <exact path>
+    State: clean, main behind origin/main by N commits
+    Action: eligible for fast-forward in Phase 7
+```
+
+For blocked states, print the exact reason and do not include an automatic command in the apply plan:
+
+```
+⚠️ Source AgentPlugin requires manual review
+  • EveryInc/compound-engineering-plugin
+    Path: <exact path>
+    State: dirty worktree
+    Action: skipped — local edits would be overwritten by an update
+```
+
+If a reinstall/removal is the only practical remediation, present it as a separate destructive option, not as the default update path. It must show the exact folder that would be removed and require explicit confirmation before removal.
+
 ---
 
-## Phase 6: Apply (marketplace only)
+## Phase 6: Apply marketplace updates
 
 **Skip this phase entirely in `dry-run` mode.**
 
-Project scaffold updates are NEVER auto-applied — see Phase 5 rationale.
+Project scaffold updates are NEVER auto-applied — see Phase 5 rationale. Source AgentPlugin updates are handled in Phase 7.
 
 For each marketplace plugin from Phase 5 that's behind:
 
@@ -177,19 +235,61 @@ Errored on X (see above for details).
 
 ---
 
-## Phase 7: Verify
+## Phase 7: Apply source plugin updates
+
+**Skip this phase entirely in `dry-run` mode.**
+
+For each source AgentPlugin classified as clean and behind-only:
+
+1. Show the exact owner/repo, installed path, current commit, upstream branch, and behind count.
+2. Use `AskUserQuestion`:
+  > Fast-forward source AgentPlugin `<owner>/<repo>` at `<exact path>` now? (y/n)
+3. On `y`: run a fast-forward-only update in that plugin directory.
+4. On `n`: skip and continue.
+5. On error: report the failure clearly and do not try destructive remediation automatically.
+
+For blocked states:
+
+- **Dirty worktree:** print the changed-file summary and stop. Do not stash, reset, or overwrite.
+- **Ahead or diverged:** print ahead/behind counts and stop. The user must review local commits before update.
+- **Detached HEAD or no upstream:** print that no safe automatic update target exists.
+- **Fetch failed:** print that remote state is unknown and stop.
+
+### Destructive reinstall/removal fallback
+
+Only offer this after a clean in-place update is impossible or has failed, and only when the user asks to remediate.
+
+Before removal:
+
+1. Print exactly what would be lost: the full plugin folder path and all files inside it.
+2. Ask for explicit confirmation naming that exact folder.
+3. Remove only that plugin folder after confirmation.
+4. Verify the folder and its metadata file are gone.
+5. Tell the user to reinstall through VS Code `Chat: Install Plugin from source`.
+
+Never remove an entire `agent-plugins`, `github.com`, `.vscode`, or `.vscode-insiders` directory.
+
+---
+
+## Phase 8: Verify and reload guidance
 
 After applying any changes, suggest:
 
 > Run `/atv-doctor` to verify the post-update install state.
 
-Don't run it automatically — let the user choose.
+If any source AgentPlugin was updated or reinstalled, also print:
+
+> Reload or restart VS Code / VS Code Insiders so the AgentPlugin content is reloaded. If the old skills still appear, close all VS Code windows and reopen the workspace before re-running `/atv-doctor`.
+
+Don't run `/atv-doctor` or reload VS Code automatically — let the user choose.
 
 ---
 
 ## What this skill does NOT do
 
 - Auto-refresh project scaffold files (installer limitation; tracked as future work).
+- Force-update dirty, ahead, diverged, detached, or untracked source AgentPlugin checkouts.
+- Silently delete or reinstall VS Code AgentPlugin folders.
 - Update gstack — that's `gstack`'s own responsibility (gstack syncs from its source repo).
 - Update agent-browser — `npm install -g agent-browser` is manual.
 - Pin specific versions — `copilot plugin install plugin@marketplace` doesn't accept a version. All ATV plugins share the kit version.

--- a/plugins/atv-skill-atv-doctor/README.md
+++ b/plugins/atv-skill-atv-doctor/README.md
@@ -1,6 +1,6 @@
 # atv-skill-atv-doctor
 
-ATV `atv-doctor` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `atv-doctor` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-atv-doctor/plugin.json
+++ b/plugins/atv-skill-atv-doctor/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-atv-doctor",
-  "description": "ATV `atv-doctor` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `atv-doctor` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-atv-doctor/skills/atv-doctor/SKILL.md
+++ b/plugins/atv-skill-atv-doctor/skills/atv-doctor/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: atv-doctor
-description: "Diagnose ATV Starter Kit installation health across both install paths (project scaffold from `atv init` and Copilot CLI marketplace plugins). Detects install scope, version drift, file integrity (checksums vs install manifest), hook validity, MCP prereqs, and optional dependency status. Triggers on 'atv doctor', 'atv health', 'check atv', 'diagnose atv', 'atv status', 'atv check', 'atv healthcheck', 'is atv ok'."
+description: "Diagnose ATV Starter Kit installation health across project scaffold, Copilot CLI marketplace plugins, and VS Code source-installed AgentPlugins. Detects install scope, version drift, AgentPlugin git state, file integrity, hook validity, MCP prereqs, and optional dependency status. Triggers on 'atv doctor', 'atv health', 'check atv', 'diagnose atv', 'atv status', 'atv check', 'atv healthcheck', 'is atv ok'."
 argument-hint: "[mode: report (default) | fix]"
 ---
 
 # /atv-doctor — ATV installation health check
 
-Diagnose your ATV Starter Kit installation. Checks both install paths (project scaffold via `atv init` and Copilot CLI marketplace plugins via `copilot plugin install`), version drift, file integrity, hook validity, MCP prereqs, and optional dependency status.
+Diagnose your ATV Starter Kit installation. Checks project scaffold via `atv init`, Copilot CLI marketplace plugins via `copilot plugin install`, and VS Code source-installed AgentPlugins via `Chat: Install Plugin from source`. Reports version drift, AgentPlugin git state, file integrity, hook validity, MCP prereqs, and optional dependency status.
 
 ## Arguments
 
@@ -17,14 +17,15 @@ Diagnose your ATV Starter Kit installation. Checks both install paths (project s
 ## Execution Flow
 
 ```
-Phase 1: Detect install scope        → repo-artifact + ~/.copilot/installed-plugins/ walk
-Phase 2: Version check               → installed vs latest npm
-Phase 3: File integrity (project)    → manifest checksum verification (when manifest exists)
-Phase 4: Hook validity (project)     → JSON parse + script existence
-Phase 5: MCP prereqs (project)       → parse inputs[] from MCP config
-Phase 6: Optional dep gating         → only warn for deps the user opted into
-Phase 7: Output graded report
-Phase 8: Fix mode (opt-in, marketplace plugins only)
+Phase 1: Detect install scope        → repo-artifact + marketplace + VS Code AgentPlugin roots
+Phase 2: Version check               → installed vs latest npm / source git state
+Phase 3: Source AgentPlugin health   → owner/repo, path, commit, version metadata, divergence
+Phase 4: File integrity (project)    → manifest checksum verification (when manifest exists)
+Phase 5: Hook validity (project)     → JSON parse + script existence
+Phase 6: MCP prereqs (project)       → parse inputs[] from MCP config
+Phase 7: Optional dep gating         → only warn for deps the user opted into
+Phase 8: Output graded report
+Phase 9: Fix mode (opt-in, marketplace plugins only)
 ```
 
 ---
@@ -40,8 +41,16 @@ Set these flags from the working directory's repo root (or `~/.copilot/` for mar
 | `hasProject` | true if **any** of these exist: `.github/skills/` (directory), `.github/copilot-instructions.md`, `.github/copilot-mcp-config.json`, `.github/hooks/copilot-hooks.json` |
 | `hasManifest` | true if `.atv/install-manifest.json` exists (used to enable Phases 3 & 5; not gating) |
 | `hasMarketplace` | true if `~/.copilot/installed-plugins/atv-starter-kit/` exists OR `copilot plugin marketplace list` mentions `atv-starter-kit` |
+| `hasSourceAgentPlugins` | true if any git checkout exists under a VS Code AgentPlugin root such as `$HOME/.vscode/agent-plugins/github.com/<owner>/<repo>` or `$HOME/.vscode-insiders/agent-plugins/github.com/<owner>/<repo>` |
 
-If `!hasProject && !hasMarketplace`: print "No ATV install detected. To install: `npx atv-starterkit init` (project scaffold) or `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit && copilot plugin install atv-everything@atv-starter-kit` (marketplace)." and stop.
+On Windows, `$HOME` may resolve through Git Bash and `%USERPROFILE%` may be clearer in PowerShell. Probe both Stable and Insiders roots without hardcoding a machine-specific username:
+
+| Product | Root examples |
+|---------|---------------|
+| VS Code Stable | `$HOME/.vscode/agent-plugins/github.com`, `%USERPROFILE%\.vscode\agent-plugins\github.com` |
+| VS Code Insiders | `$HOME/.vscode-insiders/agent-plugins/github.com`, `%USERPROFILE%\.vscode-insiders\agent-plugins\github.com` |
+
+If `!hasProject && !hasMarketplace && !hasSourceAgentPlugins`: print "No ATV install detected. To install: `npx atv-starterkit init` (project scaffold), `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit && copilot plugin install atv-everything@atv-starter-kit` (marketplace), or VS Code `Chat: Install Plugin from source` with `All-The-Vibes/ATV-StarterKit`." and stop.
 
 Record what was detected for the report header.
 
@@ -85,9 +94,66 @@ done
 
 For each installed version, compare to latest. Use semver-aware comparison if possible; otherwise string compare and flag any difference as 🟡 with the suggestion to run `/atv-update`.
 
+### 2e. Source-installed AgentPlugin versions
+
+If `hasSourceAgentPlugins`, inspect each discovered checkout under the VS Code AgentPlugin roots. Include ATV and other GitHub-source AgentPlugins such as Compound Engineering in the report, because stale source installs are easiest to diagnose when the actual installed directory is inspected.
+
+For each plugin directory:
+
+1. Derive `owner/repo` from the `github.com/<owner>/<repo>` path segments.
+2. Read version metadata from the first available source:
+   - `package.json` `version`
+   - `VERSION`
+   - `.claude-plugin/plugin.json` `version`
+   - `plugin.json` `version`
+3. Read git state from inside that directory:
+   - current branch or detached HEAD
+   - current commit
+   - `git describe --tags --always` when available
+   - `origin` URL when available
+   - dirty state from `git status --short`
+   - upstream tracking branch and ahead/behind counts when available
+4. Best-effort fetch remote state before ahead/behind comparison. If fetch fails because the user is offline or the remote is unavailable, report remote drift as unknown and keep going.
+
+Do not mutate source AgentPlugin checkouts in `/atv-doctor`. This phase is read-only except for best-effort git remote metadata fetch.
+
 ---
 
-## Phase 3: File integrity (project scaffold, manifest required)
+## Phase 3: Source AgentPlugin health
+
+Summarize source-installed AgentPlugins separately from Copilot CLI marketplace plugins.
+
+Suggested report shape:
+
+```markdown
+**VS Code source-installed AgentPlugins:**
+- All-The-Vibes/ATV-StarterKit
+  - Path: <exact installed path>
+  - Version: 2.6.3 (from VERSION)
+  - Git: main @ b2a2d11 (v2.6.3)
+  - Remote: origin/main, clean, behind by 0 / ahead by 0 🟢
+- EveryInc/compound-engineering-plugin
+  - Path: <exact installed path>
+  - Version: 3.2.0 (from package.json)
+  - Git: main @ <commit> (<describe>)
+  - Remote: origin/main, behind by N 🟡 update available
+```
+
+Severity rules:
+
+| State | Severity | Meaning |
+|-------|----------|---------|
+| clean and aligned with upstream | 🟢 ok | Source plugin checkout appears current |
+| clean and behind upstream | 🟡 warn | Update available; run `/atv-update` |
+| dirty worktree | 🟡 warn | Local edits present; update must not overwrite silently |
+| ahead of upstream | 🟡 warn | Local commits present; update needs manual review |
+| diverged from upstream | 🔴 critical | Both local and remote changed; do not auto-update |
+| detached HEAD or no upstream | ⚪ info | Version can be reported, but update path is manual |
+| missing version metadata | ⚪ info | Git state is still useful; version is unknown |
+
+---
+
+## Phase 4: File integrity (project scaffold, manifest required)
 
 Skip this phase entirely when `!hasManifest` and emit:
 
@@ -110,7 +176,7 @@ Group findings by severity in the final report (don't print one line per file un
 
 ---
 
-## Phase 4: Hook validity (project scaffold only)
+## Phase 5: Hook validity (project scaffold only)
 
 Skip when `!hasProject` or `.github/hooks/copilot-hooks.json` is absent.
 
@@ -120,7 +186,7 @@ Skip when `!hasProject` or `.github/hooks/copilot-hooks.json` is absent.
 
 ---
 
-## Phase 5: MCP prereqs (project scaffold only)
+## Phase 6: MCP prereqs (project scaffold only)
 
 Skip when `!hasProject` or `.github/copilot-mcp-config.json` is absent.
 
@@ -142,7 +208,7 @@ MCP servers configured:
 
 ---
 
-## Phase 6: Optional dep gating
+## Phase 7: Optional dep gating
 
 For each optional tool, only warn when there's evidence the user wants it. **Never warn unconditionally.**
 
@@ -158,7 +224,7 @@ When `!hasManifest`, fall back to ⚪ informational status for everything option
 
 ---
 
-## Phase 7: Output
+## Phase 8: Output
 
 Print a graded report. Use this skeleton:
 
@@ -168,6 +234,7 @@ Print a graded report. Use this skeleton:
 **Detected:**
 - Project scaffold: ✓ (manifest: yes/no)
 - Marketplace plugins: ✓ (N installed)
+- Source AgentPlugins: ✓ (N detected)
 
 **Versions:**
 - Latest on npm: 2.6.3
@@ -188,7 +255,7 @@ Print a graded report. Use this skeleton:
 - ...
 
 **Next steps:**
-- Run `/atv-update` to update marketplace plugins.
+- Run `/atv-update` to update marketplace plugins or clean source-installed ATV checkouts.
 - Project scaffold updates require manual review (today's installer is additive-only).
 ```
 
@@ -196,9 +263,9 @@ If zero non-info findings: "Your ATV install looks healthy! 🩺"
 
 ---
 
-## Phase 8: Fix mode (opt-in)
+## Phase 9: Fix mode (opt-in)
 
-Only runs when `mode=fix`. **Limited scope today** — only marketplace plugin updates are auto-fixable. Project scaffold "fixes" require the user to manually re-run the installer because today's `atv init` is additive-only and would not refresh existing files.
+Only runs when `mode=fix`. **Limited scope today** — only Copilot CLI marketplace plugin updates are auto-fixable from doctor mode. Project scaffold "fixes" require the user to manually re-run the installer because today's `atv init` is additive-only and would not refresh existing files. Source AgentPlugin updates belong in `/atv-update`, where the workflow can inspect git state and ask for explicit confirmation before changing a checkout.
 
 For each stale marketplace plugin:
 
@@ -212,6 +279,7 @@ After all fixes, print a summary: "Updated N plugins, skipped M."
 **Constraints:**
 - Never auto-rerun `atv init` (today's installer is additive-only — would not actually refresh files).
 - Never modify scaffold files directly.
+- Never update, reset, delete, or reinstall VS Code AgentPlugin folders from `/atv-doctor`.
 - Always confirm before running anything.
 
 ---
@@ -219,6 +287,7 @@ After all fixes, print a summary: "Updated N plugins, skipped M."
 ## What this skill does NOT do
 
 - Refresh project scaffold files (installer is additive-only today; tracked as future work).
+- Update VS Code source-installed AgentPlugins directly (use `/atv-update`).
 - Validate MCP server connectivity (would require network calls to each server).
 - Run JSON-schema validation on configs (just parse + key presence).
 - Auto-install missing optional dependencies (Bun, agent-browser, gh, az).

--- a/plugins/atv-skill-atv-security/README.md
+++ b/plugins/atv-skill-atv-security/README.md
@@ -1,6 +1,6 @@
 # atv-skill-atv-security
 
-ATV `atv-security` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `atv-security` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-atv-security/plugin.json
+++ b/plugins/atv-skill-atv-security/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-atv-security",
-  "description": "ATV `atv-security` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `atv-security` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-atv-update/README.md
+++ b/plugins/atv-skill-atv-update/README.md
@@ -1,6 +1,6 @@
 # atv-skill-atv-update
 
-ATV `atv-update` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `atv-update` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-atv-update/plugin.json
+++ b/plugins/atv-skill-atv-update/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-atv-update",
-  "description": "ATV `atv-update` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `atv-update` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-atv-update/skills/atv-update/SKILL.md
+++ b/plugins/atv-skill-atv-update/skills/atv-update/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: atv-update
-description: "Update ATV Starter Kit to the latest version. For Copilot CLI marketplace plugins (`atv-skill-*`, `atv-pack-*`, `atv-everything`, `atv-agents`): runs `copilot plugin update` per installed ATV plugin with per-step confirmation. For project scaffold (`atv init`): reports the version delta and prints the exact commands you can run — does NOT auto-rerun the installer because today's installer is additive-only and would not refresh existing files. Triggers on 'atv update', 'update atv', 'upgrade atv', 'atv upgrade', 'refresh atv', 'atv latest'."
+description: "Update ATV Starter Kit to the latest version. Handles Copilot CLI marketplace plugins, VS Code source-installed AgentPlugins, and project scaffold advisory status. Marketplace plugins use `copilot plugin update` with confirmation. Clean source AgentPlugins can fast-forward with confirmation. Project scaffold remains advisory because today's installer is additive-only. Triggers on 'atv update', 'update atv', 'upgrade atv', 'atv upgrade', 'refresh atv', 'atv latest'."
 argument-hint: "[mode: dry-run | apply (default)]"
 ---
 
 # /atv-update — Update ATV Starter Kit
 
-Bring your ATV install up to the latest version. Handles both install paths:
+Bring your ATV install up to the latest version. Handles three install paths:
 
 - **Marketplace plugins** — auto-updated via `copilot plugin update` (with per-plugin confirmation).
+- **VS Code source-installed AgentPlugins** — updated only when the checkout is clean and can fast-forward safely (with confirmation and reload guidance).
 - **Project scaffold** — advisory only. Today's installer is `additive-only` and `npx atv-starterkit@latest init` will NOT refresh existing scaffold files. This skill prints the version delta and the exact commands you can run yourself.
 
 > **Future:** Once the installer gains a `--refresh` flag (read manifest → overwrite checksum-clean files → preserve drifted files), this skill will gain auto-update for project scaffold too. Tracked as a known gap.
@@ -23,12 +24,13 @@ Bring your ATV install up to the latest version. Handles both install paths:
 
 ```
 Phase 1: Detect install scope         → same as /atv-doctor Phase 1
-Phase 2: Read installed versions      → manifest (project) + plugin.json files (marketplace)
+Phase 2: Read installed versions      → project + marketplace + source AgentPlugins
 Phase 3: Fetch latest npm version     → npm view
 Phase 4: Show changelog (best-effort) → fetch + parse, fall back to link
 Phase 5: Plan update                  → structured table of components + commands
-Phase 6: Apply (marketplace only)     → copilot plugin update with confirmation
-Phase 7: Verify (suggest /atv-doctor)
+Phase 6: Apply marketplace updates    → copilot plugin update with confirmation
+Phase 7: Apply source plugin updates  → clean fast-forward only, with confirmation
+Phase 8: Verify and reload guidance   → suggest /atv-doctor + VS Code reload/restart
 ```
 
 ---
@@ -42,8 +44,11 @@ Same detection logic as `/atv-doctor` Phase 1 — repo-artifact-based, not manif
 | `hasProject` | any of `.github/skills/`, `.github/copilot-instructions.md`, `.github/copilot-mcp-config.json` exists |
 | `hasManifest` | `.atv/install-manifest.json` exists |
 | `hasMarketplace` | `~/.copilot/installed-plugins/atv-starter-kit/` exists |
+| `hasSourceAgentPlugins` | any git checkout exists under a VS Code AgentPlugin root such as `$HOME/.vscode/agent-plugins/github.com/<owner>/<repo>` or `$HOME/.vscode-insiders/agent-plugins/github.com/<owner>/<repo>` |
 
-If `!hasProject && !hasMarketplace`: print "No ATV install detected. Nothing to update. Run `npx atv-starterkit init` to scaffold, or `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit` to register the marketplace." and stop.
+Probe both Stable and Insiders roots. On Windows, prefer profile-aware paths such as `%USERPROFILE%\.vscode-insiders\agent-plugins\github.com` in PowerShell and `$HOME/.vscode-insiders/agent-plugins/github.com` in Bash; never hardcode a machine-specific user directory.
+
+If `!hasProject && !hasMarketplace && !hasSourceAgentPlugins`: print "No ATV install detected. Nothing to update. Run `npx atv-starterkit init` to scaffold, `copilot plugin marketplace add All-The-Vibes/ATV-StarterKit` to register the marketplace, or VS Code `Chat: Install Plugin from source` with `All-The-Vibes/ATV-StarterKit`." and stop.
 
 ---
 
@@ -70,6 +75,35 @@ done
 ```
 
 Build a list `{name, currentVersion}` for each ATV plugin.
+
+### VS Code source-installed AgentPlugins
+
+Walk VS Code Stable and Insiders AgentPlugin roots under `agent-plugins/github.com/<owner>/<repo>`. By default, target only `All-The-Vibes/ATV-StarterKit` and `datorresb/ATV-StarterKit` source installs. If the user explicitly named another owner/repo or exact plugin path in the arguments, inspect that target too.
+
+For each target checkout, collect:
+
+- exact path
+- owner/repo from the path
+- version metadata from `package.json`, `VERSION`, `.claude-plugin/plugin.json`, or `plugin.json`
+- current branch or detached HEAD
+- current commit and `git describe --tags --always` when available
+- origin URL
+- dirty state from `git status --short`
+- upstream tracking branch and ahead/behind counts after best-effort fetch
+
+Classify source plugin update state:
+
+| State | Update action |
+|-------|---------------|
+| clean, tracking branch, behind remote only | eligible for fast-forward after confirmation |
+| clean and aligned | no update needed |
+| dirty worktree | stop; explain local edits must be reviewed first |
+| ahead of remote | stop; explain local commits must be reviewed first |
+| diverged | stop; explain both local and remote changed |
+| detached HEAD or no upstream | stop; manual update path only |
+| fetch failed | stop; remote state unknown |
+
+Do not run `git reset`, `git stash`, branch checkout, folder deletion, or reclone as part of normal update.
 
 ---
 
@@ -151,13 +185,37 @@ For each plugin from Phase 2 that's behind `LATEST`, list it as:
 
 If all plugins are up to date: print "All marketplace plugins are up to date."
 
+### VS Code source-installed AgentPlugins (auto only when safe)
+
+For each detected ATV source plugin:
+
+```
+🔄 Source AgentPlugin updates
+  • All-The-Vibes/ATV-StarterKit
+    Path: <exact path>
+    State: clean, main behind origin/main by N commits
+    Action: eligible for fast-forward in Phase 7
+```
+
+For blocked states, print the exact reason and do not include an automatic command in the apply plan:
+
+```
+⚠️ Source AgentPlugin requires manual review
+  • EveryInc/compound-engineering-plugin
+    Path: <exact path>
+    State: dirty worktree
+    Action: skipped — local edits would be overwritten by an update
+```
+
+If a reinstall/removal is the only practical remediation, present it as a separate destructive option, not as the default update path. It must show the exact folder that would be removed and require explicit confirmation before removal.
+
 ---
 
-## Phase 6: Apply (marketplace only)
+## Phase 6: Apply marketplace updates
 
 **Skip this phase entirely in `dry-run` mode.**
 
-Project scaffold updates are NEVER auto-applied — see Phase 5 rationale.
+Project scaffold updates are NEVER auto-applied — see Phase 5 rationale. Source AgentPlugin updates are handled in Phase 7.
 
 For each marketplace plugin from Phase 5 that's behind:
 
@@ -177,19 +235,61 @@ Errored on X (see above for details).
 
 ---
 
-## Phase 7: Verify
+## Phase 7: Apply source plugin updates
+
+**Skip this phase entirely in `dry-run` mode.**
+
+For each source AgentPlugin classified as clean and behind-only:
+
+1. Show the exact owner/repo, installed path, current commit, upstream branch, and behind count.
+2. Use `AskUserQuestion`:
+  > Fast-forward source AgentPlugin `<owner>/<repo>` at `<exact path>` now? (y/n)
+3. On `y`: run a fast-forward-only update in that plugin directory.
+4. On `n`: skip and continue.
+5. On error: report the failure clearly and do not try destructive remediation automatically.
+
+For blocked states:
+
+- **Dirty worktree:** print the changed-file summary and stop. Do not stash, reset, or overwrite.
+- **Ahead or diverged:** print ahead/behind counts and stop. The user must review local commits before update.
+- **Detached HEAD or no upstream:** print that no safe automatic update target exists.
+- **Fetch failed:** print that remote state is unknown and stop.
+
+### Destructive reinstall/removal fallback
+
+Only offer this after a clean in-place update is impossible or has failed, and only when the user asks to remediate.
+
+Before removal:
+
+1. Print exactly what would be lost: the full plugin folder path and all files inside it.
+2. Ask for explicit confirmation naming that exact folder.
+3. Remove only that plugin folder after confirmation.
+4. Verify the folder and its metadata file are gone.
+5. Tell the user to reinstall through VS Code `Chat: Install Plugin from source`.
+
+Never remove an entire `agent-plugins`, `github.com`, `.vscode`, or `.vscode-insiders` directory.
+
+---
+
+## Phase 8: Verify and reload guidance
 
 After applying any changes, suggest:
 
 > Run `/atv-doctor` to verify the post-update install state.
 
-Don't run it automatically — let the user choose.
+If any source AgentPlugin was updated or reinstalled, also print:
+
+> Reload or restart VS Code / VS Code Insiders so the AgentPlugin content is reloaded. If the old skills still appear, close all VS Code windows and reopen the workspace before re-running `/atv-doctor`.
+
+Don't run `/atv-doctor` or reload VS Code automatically — let the user choose.
 
 ---
 
 ## What this skill does NOT do
 
 - Auto-refresh project scaffold files (installer limitation; tracked as future work).
+- Force-update dirty, ahead, diverged, detached, or untracked source AgentPlugin checkouts.
+- Silently delete or reinstall VS Code AgentPlugin folders.
 - Update gstack — that's `gstack`'s own responsibility (gstack syncs from its source repo).
 - Update agent-browser — `npm install -g agent-browser` is manual.
 - Pin specific versions — `copilot plugin install plugin@marketplace` doesn't accept a version. All ATV plugins share the kit version.

--- a/plugins/atv-skill-autoresearch/README.md
+++ b/plugins/atv-skill-autoresearch/README.md
@@ -1,6 +1,6 @@
 # atv-skill-autoresearch
 
-ATV `autoresearch` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `autoresearch` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-autoresearch/plugin.json
+++ b/plugins/atv-skill-autoresearch/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-autoresearch",
-  "description": "ATV `autoresearch` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `autoresearch` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-brainstorming/README.md
+++ b/plugins/atv-skill-brainstorming/README.md
@@ -1,6 +1,6 @@
 # atv-skill-brainstorming
 
-ATV `brainstorming` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `brainstorming` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-brainstorming/plugin.json
+++ b/plugins/atv-skill-brainstorming/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-brainstorming",
-  "description": "ATV `brainstorming` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `brainstorming` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-ce-brainstorm/README.md
+++ b/plugins/atv-skill-ce-brainstorm/README.md
@@ -1,6 +1,6 @@
 # atv-skill-ce-brainstorm
 
-ATV `ce-brainstorm` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `ce-brainstorm` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-ce-brainstorm/plugin.json
+++ b/plugins/atv-skill-ce-brainstorm/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-ce-brainstorm",
-  "description": "ATV `ce-brainstorm` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `ce-brainstorm` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-ce-compound-refresh/README.md
+++ b/plugins/atv-skill-ce-compound-refresh/README.md
@@ -1,6 +1,6 @@
 # atv-skill-ce-compound-refresh
 
-ATV `ce-compound-refresh` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `ce-compound-refresh` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-ce-compound-refresh/plugin.json
+++ b/plugins/atv-skill-ce-compound-refresh/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-ce-compound-refresh",
-  "description": "ATV `ce-compound-refresh` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `ce-compound-refresh` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-ce-compound/README.md
+++ b/plugins/atv-skill-ce-compound/README.md
@@ -1,6 +1,6 @@
 # atv-skill-ce-compound
 
-ATV `ce-compound` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `ce-compound` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-ce-compound/plugin.json
+++ b/plugins/atv-skill-ce-compound/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-ce-compound",
-  "description": "ATV `ce-compound` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `ce-compound` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-ce-ideate/README.md
+++ b/plugins/atv-skill-ce-ideate/README.md
@@ -1,6 +1,6 @@
 # atv-skill-ce-ideate
 
-ATV `ce-ideate` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `ce-ideate` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-ce-ideate/plugin.json
+++ b/plugins/atv-skill-ce-ideate/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-ce-ideate",
-  "description": "ATV `ce-ideate` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `ce-ideate` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-ce-plan/README.md
+++ b/plugins/atv-skill-ce-plan/README.md
@@ -1,6 +1,6 @@
 # atv-skill-ce-plan
 
-ATV `ce-plan` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `ce-plan` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-ce-plan/plugin.json
+++ b/plugins/atv-skill-ce-plan/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-ce-plan",
-  "description": "ATV `ce-plan` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `ce-plan` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-ce-review/README.md
+++ b/plugins/atv-skill-ce-review/README.md
@@ -1,6 +1,6 @@
 # atv-skill-ce-review
 
-ATV `ce-review` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `ce-review` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-ce-review/plugin.json
+++ b/plugins/atv-skill-ce-review/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-ce-review",
-  "description": "ATV `ce-review` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `ce-review` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-ce-work/README.md
+++ b/plugins/atv-skill-ce-work/README.md
@@ -1,6 +1,6 @@
 # atv-skill-ce-work
 
-ATV `ce-work` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `ce-work` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-ce-work/plugin.json
+++ b/plugins/atv-skill-ce-work/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-ce-work",
-  "description": "ATV `ce-work` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `ce-work` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-deepen-plan/README.md
+++ b/plugins/atv-skill-deepen-plan/README.md
@@ -1,6 +1,6 @@
 # atv-skill-deepen-plan
 
-ATV `deepen-plan` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `deepen-plan` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-deepen-plan/plugin.json
+++ b/plugins/atv-skill-deepen-plan/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-deepen-plan",
-  "description": "ATV `deepen-plan` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `deepen-plan` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-document-review/README.md
+++ b/plugins/atv-skill-document-review/README.md
@@ -1,6 +1,6 @@
 # atv-skill-document-review
 
-ATV `document-review` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `document-review` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-document-review/plugin.json
+++ b/plugins/atv-skill-document-review/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-document-review",
-  "description": "ATV `document-review` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `document-review` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-evolve/README.md
+++ b/plugins/atv-skill-evolve/README.md
@@ -1,6 +1,6 @@
 # atv-skill-evolve
 
-ATV `evolve` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `evolve` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-evolve/plugin.json
+++ b/plugins/atv-skill-evolve/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-evolve",
-  "description": "ATV `evolve` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `evolve` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-feature-video/README.md
+++ b/plugins/atv-skill-feature-video/README.md
@@ -1,6 +1,6 @@
 # atv-skill-feature-video
 
-ATV `feature-video` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `feature-video` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-feature-video/plugin.json
+++ b/plugins/atv-skill-feature-video/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-feature-video",
-  "description": "ATV `feature-video` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `feature-video` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-instincts/README.md
+++ b/plugins/atv-skill-instincts/README.md
@@ -1,6 +1,6 @@
 # atv-skill-instincts
 
-ATV `instincts` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `instincts` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-instincts/plugin.json
+++ b/plugins/atv-skill-instincts/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-instincts",
-  "description": "ATV `instincts` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `instincts` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-karpathy-guidelines/README.md
+++ b/plugins/atv-skill-karpathy-guidelines/README.md
@@ -1,6 +1,6 @@
 # atv-skill-karpathy-guidelines
 
-ATV `karpathy-guidelines` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `karpathy-guidelines` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-karpathy-guidelines/plugin.json
+++ b/plugins/atv-skill-karpathy-guidelines/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-karpathy-guidelines",
-  "description": "ATV `karpathy-guidelines` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `karpathy-guidelines` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-land/README.md
+++ b/plugins/atv-skill-land/README.md
@@ -1,6 +1,6 @@
 # atv-skill-land
 
-ATV `land` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `land` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-land/plugin.json
+++ b/plugins/atv-skill-land/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-land",
-  "description": "ATV `land` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `land` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-learn/README.md
+++ b/plugins/atv-skill-learn/README.md
@@ -1,6 +1,6 @@
 # atv-skill-learn
 
-ATV `learn` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `learn` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-learn/plugin.json
+++ b/plugins/atv-skill-learn/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-learn",
-  "description": "ATV `learn` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `learn` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-lfg/README.md
+++ b/plugins/atv-skill-lfg/README.md
@@ -1,6 +1,6 @@
 # atv-skill-lfg
 
-ATV `lfg` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `lfg` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-lfg/plugin.json
+++ b/plugins/atv-skill-lfg/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-lfg",
-  "description": "ATV `lfg` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `lfg` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-meme-iq/README.md
+++ b/plugins/atv-skill-meme-iq/README.md
@@ -1,6 +1,6 @@
 # atv-skill-meme-iq
 
-ATV `meme-iq` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `meme-iq` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-meme-iq/plugin.json
+++ b/plugins/atv-skill-meme-iq/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-meme-iq",
-  "description": "ATV `meme-iq` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `meme-iq` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-observe/README.md
+++ b/plugins/atv-skill-observe/README.md
@@ -1,6 +1,6 @@
 # atv-skill-observe
 
-ATV `observe` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `observe` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-observe/plugin.json
+++ b/plugins/atv-skill-observe/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-observe",
-  "description": "ATV `observe` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `observe` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-ralph-loop/README.md
+++ b/plugins/atv-skill-ralph-loop/README.md
@@ -1,6 +1,6 @@
 # atv-skill-ralph-loop
 
-ATV `ralph-loop` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `ralph-loop` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-ralph-loop/plugin.json
+++ b/plugins/atv-skill-ralph-loop/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-ralph-loop",
-  "description": "ATV `ralph-loop` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `ralph-loop` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-resolve-todo-parallel/README.md
+++ b/plugins/atv-skill-resolve-todo-parallel/README.md
@@ -1,6 +1,6 @@
 # atv-skill-resolve-todo-parallel
 
-ATV `resolve_todo_parallel` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `resolve_todo_parallel` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-resolve-todo-parallel/plugin.json
+++ b/plugins/atv-skill-resolve-todo-parallel/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-resolve-todo-parallel",
-  "description": "ATV `resolve_todo_parallel` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `resolve_todo_parallel` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-setup/README.md
+++ b/plugins/atv-skill-setup/README.md
@@ -1,6 +1,6 @@
 # atv-skill-setup
 
-ATV `setup` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `setup` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-setup/plugin.json
+++ b/plugins/atv-skill-setup/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-setup",
-  "description": "ATV `setup` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `setup` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-slfg/README.md
+++ b/plugins/atv-skill-slfg/README.md
@@ -1,6 +1,6 @@
 # atv-skill-slfg
 
-ATV `slfg` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `slfg` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-slfg/plugin.json
+++ b/plugins/atv-skill-slfg/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-slfg",
-  "description": "ATV `slfg` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `slfg` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-takeoff/README.md
+++ b/plugins/atv-skill-takeoff/README.md
@@ -1,6 +1,6 @@
 # atv-skill-takeoff
 
-ATV `takeoff` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `takeoff` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-takeoff/plugin.json
+++ b/plugins/atv-skill-takeoff/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-takeoff",
-  "description": "ATV `takeoff` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `takeoff` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-test-browser/README.md
+++ b/plugins/atv-skill-test-browser/README.md
@@ -1,6 +1,6 @@
 # atv-skill-test-browser
 
-ATV `test-browser` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `test-browser` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-test-browser/plugin.json
+++ b/plugins/atv-skill-test-browser/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-test-browser",
-  "description": "ATV `test-browser` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `test-browser` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",

--- a/plugins/atv-skill-unslop/README.md
+++ b/plugins/atv-skill-unslop/README.md
@@ -1,6 +1,6 @@
 # atv-skill-unslop
 
-ATV `unslop` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
+ATV `unslop` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.
 
 ## Install
 

--- a/plugins/atv-skill-unslop/plugin.json
+++ b/plugins/atv-skill-unslop/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atv-skill-unslop",
-  "description": "ATV `unslop` skill — single-skill plugin (granular install). NOT standalone: some ATV skills dispatch agents bundled separately in `atv-agents`. For typical use install `atv-pack-*` (category bundle) or `atv-everything` (full kit) instead. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
+  "description": "ATV `unslop` skill — single-skill plugin (granular install). Some ATV skills dispatch agents bundled separately in `atv-agents`, so single-skill and category-pack installs may need `atv-agents` alongside them. For the full standalone kit, install `atv-everything`. See https://github.com/All-The-Vibes/ATV-StarterKit/blob/main/docs/marketplace.md.",
   "version": "2.6.3",
   "author": {
     "name": "All The Vibes",


### PR DESCRIPTION
## Summary

VS Code users can now install ATV from source as one clean `atv-starter-kit` option while Copilot CLI users keep the granular marketplace. The generator owns both catalog surfaces so release checks catch drift across root, `.claude-plugin`, `.github/plugin`, and generated plugin artifacts.

## What changed

- Added curated source-install catalogs at `marketplace.json` and `.claude-plugin/marketplace.json`, both pointing at `./plugins/atv-everything`.
- Kept `.github/plugin/marketplace.json` granular for CLI installs, ranked `atv-everything` first and `atv-agents` second, and clarified when granular skills/packs need `atv-agents`.
- Added source-install metadata under `plugins/atv-everything/.claude-plugin/plugin.json`.
- Extended `/atv-doctor` and `/atv-update` to detect, report, and safely update VS Code source-installed AgentPlugins with fast-forward-only guidance and destructive fallback guardrails.
- Added generator tests for catalog shape, deterministic output, CRLF-tolerant drift checks, prefixed drift diagnostics, and maintenance skill coverage.
- Documented the install paths and captured the catalog split as a solution note.

## Design notes

- Root `marketplace.json` intentionally differs from `.github/plugin/marketplace.json`: VS Code source install should offer one curated choice, while Copilot CLI keeps bundles and single-skill plugins.
- `README.md` keeps upstream's CRLF convention explicitly via `.gitattributes`, preventing whitespace-check noise without turning the README into a full-file diff.

## Testing

- `go build ./...`
- `go test ./pkg/plugingen -count=1`
- `go run ./cmd/plugingen -check`
- `go test ./... -count=1`
- `git diff --check upstream/main...HEAD`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-000000?logo=githubcopilot&logoColor=white)
