### PR TITLE
feat(scaffold): ship .github/prompts/*.prompt.md shims for VS Code Copilot Chat

### DIFF
--- a/.github/prompts/atv-doctor.prompt.md
+++ b/.github/prompts/atv-doctor.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the atv-doctor skill
+---
+
+Invoke the `atv-doctor` skill defined at `.github/skills/atv-doctor/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/atv-security.prompt.md
+++ b/.github/prompts/atv-security.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the atv-security skill
+---
+
+Invoke the `atv-security` skill defined at `.github/skills/atv-security/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/atv-update.prompt.md
+++ b/.github/prompts/atv-update.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the atv-update skill
+---
+
+Invoke the `atv-update` skill defined at `.github/skills/atv-update/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/autoresearch.prompt.md
+++ b/.github/prompts/autoresearch.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the autoresearch skill
+---
+
+Invoke the `autoresearch` skill defined at `.github/skills/autoresearch/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/ce-brainstorm.prompt.md
+++ b/.github/prompts/ce-brainstorm.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the ce-brainstorm skill
+---
+
+Invoke the `ce-brainstorm` skill defined at `.github/skills/ce-brainstorm/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/ce-compound.prompt.md
+++ b/.github/prompts/ce-compound.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the ce-compound skill
+---
+
+Invoke the `ce-compound` skill defined at `.github/skills/ce-compound/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/ce-ideate.prompt.md
+++ b/.github/prompts/ce-ideate.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the ce-ideate skill
+---
+
+Invoke the `ce-ideate` skill defined at `.github/skills/ce-ideate/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/ce-plan.prompt.md
+++ b/.github/prompts/ce-plan.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the ce-plan skill
+---
+
+Invoke the `ce-plan` skill defined at `.github/skills/ce-plan/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/ce-review.prompt.md
+++ b/.github/prompts/ce-review.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the ce-review skill
+---
+
+Invoke the `ce-review` skill defined at `.github/skills/ce-review/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/ce-work.prompt.md
+++ b/.github/prompts/ce-work.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the ce-work skill
+---
+
+Invoke the `ce-work` skill defined at `.github/skills/ce-work/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/evolve.prompt.md
+++ b/.github/prompts/evolve.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the evolve skill
+---
+
+Invoke the `evolve` skill defined at `.github/skills/evolve/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/instincts.prompt.md
+++ b/.github/prompts/instincts.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the instincts skill
+---
+
+Invoke the `instincts` skill defined at `.github/skills/instincts/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/land.prompt.md
+++ b/.github/prompts/land.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the land skill
+---
+
+Invoke the `land` skill defined at `.github/skills/land/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/learn.prompt.md
+++ b/.github/prompts/learn.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the learn skill
+---
+
+Invoke the `learn` skill defined at `.github/skills/learn/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/lfg.prompt.md
+++ b/.github/prompts/lfg.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the lfg skill
+---
+
+Invoke the `lfg` skill defined at `.github/skills/lfg/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/observe.prompt.md
+++ b/.github/prompts/observe.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the observe skill
+---
+
+Invoke the `observe` skill defined at `.github/skills/observe/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/takeoff.prompt.md
+++ b/.github/prompts/takeoff.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the takeoff skill
+---
+
+Invoke the `takeoff` skill defined at `.github/skills/takeoff/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/.github/prompts/unslop.prompt.md
+++ b/.github/prompts/unslop.prompt.md
@@ -1,0 +1,8 @@
+---
+mode: agent
+description: Run the unslop skill
+---
+
+Invoke the `unslop` skill defined at `.github/skills/unslop/SKILL.md` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ Over weeks, your repo develops a memory that makes every Copilot session more ef
 | `.github/agents/*.agent.md` | Agents for subagent orchestration |
 | `.github/*.instructions.md` | File-scoped instructions via `applyTo` globs |
 | `.github/hooks/copilot-hooks.json` | Observer hooks (silent, every tool use) |
+| `.github/prompts/*.prompt.md` | VS Code Copilot Chat slash-command shims (one per user-facing skill) |
 
 ### Supported Stacks
 

--- a/cmd/promptgen/main.go
+++ b/cmd/promptgen/main.go
@@ -1,0 +1,82 @@
+// Command promptgen regenerates the dogfooded VS Code Copilot Chat prompt
+// shims at .github/prompts/<skill>.prompt.md from the canonical
+// scaffold.BuildPromptShim template.
+//
+// Usage:
+//
+//	go run ./cmd/promptgen          # regenerate .github/prompts/
+//	go run ./cmd/promptgen -check   # CI mode: exit 1 if regeneration would change anything
+//
+// Run from any directory inside the repository — the tool walks up to find
+// go.mod. Pair with TestDogfoodPromptParity in pkg/scaffold/parity_test.go.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/All-The-Vibes/ATV-StarterKit/pkg/scaffold"
+)
+
+func main() {
+	check := flag.Bool("check", false, "Verify committed .github/prompts/ matches the generator output. Exit 1 on drift.")
+	flag.Parse()
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		exit("locate repo root: %v", err)
+	}
+
+	plan := scaffold.PromptShimPlan()
+	promptsDir := filepath.Join(repoRoot, ".github", "prompts")
+	if err := os.MkdirAll(promptsDir, 0o755); err != nil {
+		exit("create %s: %v", promptsDir, err)
+	}
+
+	drift := false
+	for _, name := range plan {
+		dest := filepath.Join(promptsDir, name+".prompt.md")
+		want := scaffold.BuildPromptShim(name)
+		if *check {
+			got, err := os.ReadFile(dest)
+			if err != nil || string(got) != string(want) {
+				drift = true
+				fmt.Fprintf(os.Stderr, "drift: %s\n", dest)
+			}
+			continue
+		}
+		if err := os.WriteFile(dest, want, 0o644); err != nil {
+			exit("write %s: %v", dest, err)
+		}
+		fmt.Printf("wrote %s\n", dest)
+	}
+
+	if *check && drift {
+		fmt.Fprintln(os.Stderr, "Run `go run ./cmd/promptgen` to regenerate.")
+		os.Exit(1)
+	}
+}
+
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found from %s upward", dir)
+		}
+		dir = parent
+	}
+}
+
+func exit(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "promptgen: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/docs/brainstorms/2026-03-11-agentic-coding-starter-kit-installer-brainstorm.md
+++ b/docs/brainstorms/2026-03-11-agentic-coding-starter-kit-installer-brainstorm.md
@@ -137,7 +137,7 @@ $ atv-installer init
 
 ## Copilot Lifecycle Hooks
 
-The ATV Starter Kit scaffolds **all 6 Copilot lifecycle hook types**. Each hook fires at a different moment in the Copilot experience:
+The ATV Starter Kit scaffolds **all 6 Copilot lifecycle hook types**, plus a 7th VS Code Copilot Chat discovery primitive. Each fires at a different moment in the Copilot experience:
 
 | # | Hook Type | File(s) | When It Fires | ATV Generates |
 |---|-----------|---------|---------------|---------------|
@@ -147,6 +147,7 @@ The ATV Starter Kit scaffolds **all 6 Copilot lifecycle hook types**. Each hook 
 | 4 | **Skills** | `.github/skills/*/SKILL.md` | When a skill's description matches the user's chat request | Core pipeline + stack-specific skills |
 | 5 | **Agents** | `.github/agents/*.agent.md` | When invoked by name via subagent orchestration | Universal + stack-specific reviewer agents |
 | 6 | **File Instructions** | `.github/*.instructions.md` | Auto-loaded based on `applyTo` glob patterns when editing matching files | Stack-specific file instructions (e.g., `applyTo: "**/*.ts"`) |
+| 7 | **Prompt Shims** | `.github/prompts/*.prompt.md` | When VS Code Copilot Chat builds its slash-command picker | One thin shim per user-facing skill so `/ce-plan`, `/lfg`, `/learn`, etc. surface in the picker; each shim delegates to the canonical SKILL.md |
 
 ## Component Catalog
 

--- a/docs/plans/2026-04-30-001-feat-vscode-prompt-shims-plan.md
+++ b/docs/plans/2026-04-30-001-feat-vscode-prompt-shims-plan.md
@@ -1,0 +1,268 @@
+---
+title: "feat: Ship .github/prompts/*.prompt.md shims so VS Code Copilot Chat surfaces ATV slash commands"
+type: feat
+status: active
+date: 2026-04-30
+issue: 36
+---
+
+# feat: Ship `.github/prompts/*.prompt.md` shims so VS Code Copilot Chat surfaces ATV slash commands
+
+## Overview
+
+The ATV installer ships skills as `.github/skills/<name>/SKILL.md`. Claude Code and Copilot CLI discover those natively, but **VS Code Copilot Chat** discovers slash commands from `.github/prompts/*.prompt.md`. Today the installer ships zero prompt files, so `/ce-brainstorm`, `/ce-plan`, `/lfg`, `/learn`, etc. don't appear in the VS Code chat picker even though `copilot-instructions.md` advertises them.
+
+Fix: generate a thin `.prompt.md` shim per user-facing skill at install time. Each shim delegates to the canonical `SKILL.md` so there is one source of truth. Wire it through the existing skill-catalog/parity-test machinery so a new user-facing skill cannot land without a corresponding shim.
+
+## Problem Frame
+
+Reported in [#36](https://github.com/All-The-Vibes/ATV-StarterKit/issues/36) by @stephschofield (2026-04-30). After `npx atv-starterkit init` (or VS Code source install), users opening the project in VS Code Copilot Chat see no completions for `/ce-` or any documented workflow. They either rediscover workflows by typing prose or conclude the install is broken. Verified workaround: hand-rolling 15 `.prompt.md` shims into `.github/prompts/` immediately surfaces every command.
+
+The installer already *recognizes* prompt files exist — `pkg/installstate/recommendations.go` counts them, `pkg/monitor/watcher.go` watches the directory, and there is even an `add-prompts` recommendation that fires when the count is zero — but no template is shipped. The recommendation reproduces the issue: the installer tells the user to create prompt files instead of just shipping them.
+
+## Requirements Trace
+
+- **R1.** After a fresh `--guided` install (or full install) on a VS Code-targeted project, every user-facing ATV slash command listed in `copilot-instructions.md` appears in the VS Code Copilot Chat slash picker.
+- **R2.** Each generated `.prompt.md` is a thin delegation shim — the `SKILL.md` remains the single source of truth for behavior. No skill instructions are duplicated.
+- **R3.** Sub-skills that are not meant to be invoked directly (e.g., `document-review`, `deepen-plan`, `setup`, `karpathy-guidelines`) do **not** receive shims and do not pollute the chat picker.
+- **R4.** Adding a new user-facing skill template without also wiring its prompt shim fails a parity test, mirroring the existing `TestSkillDirectoryParity` guard.
+- **R5.** The install summary acknowledges shipped prompts (so users know slash commands are wired up), and the stale `add-prompts` recommendation no longer fires when the installer's own shims are present.
+- **R6.** The agentic-primitives table in `README.md`, `npm/README.md`, and `docs/brainstorms/2026-03-11-agentic-coding-starter-kit-installer-brainstorm.md` documents prompt files as a primitive (currently lists 1–6; this adds the 7th).
+
+## Scope Boundaries
+
+- **In scope:** generating shim `.prompt.md` files for user-facing skills, wiring them into the catalog, parity tests, install summary, removing the now-misleading `add-prompts` recommendation.
+- **Out of scope:** rewriting skill content, changing how Claude Code or Copilot CLI discover skills, building richer prompt-file templates with per-skill front-matter beyond what's needed for VS Code discovery, optional `/atv-doctor` drift check (issue suggests it; defer to a follow-up).
+- **Out of scope:** shimming sub-skills like `document-review` or auto-generating shims from skill front-matter — explicit allow-list is intentional to keep the chat picker clean.
+- **Out of scope:** changes to gstack-prefixed skills under `.github/skills/gstack-*` — gstack manages its own surface (see existing memory: gstack copies generated skills with `gstack-` prefix).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `pkg/scaffold/catalog.go` — entry point. Contains `BuildCatalog`, `BuildFilteredCatalog`, the three skill allow-lists (`coreSkillDirectories`, `orchestratorSkillDirectories`, `easterEggSkillDirectories`), and `skillComponents()` which walks `templates/skills/`. The new prompt generation will mirror this pattern with its own selector function and component builder.
+- `pkg/scaffold/templates/skills/` — the embedded source of truth. New sibling directory: `pkg/scaffold/templates/prompts/` (or generated content from a single template constant — see Key Technical Decisions).
+- `pkg/scaffold/parity_test.go` — `TestSkillDirectoryParity` and `TestDogfoodTemplateParity` show exactly how to enforce that catalog allow-lists stay aligned with the embedded filesystem and with `.github/skills/`. New parity test will follow the same shape for prompts.
+- `pkg/installstate/recommendations.go:81,246-251,457-465` — counts `.prompt.md`, recommends `add-prompts`, exposes `ListPromptFiles`. The `add-prompts` recommendation needs to be either deleted or reframed (e.g., suggest user-authored prompts only, gate on a directory of files we didn't ship).
+- `pkg/monitor/watcher.go:124,240,320,330,357,365` — already watches `.github/prompts/` and surfaces `PromptCount` to repo state. No change needed; will Just Work once we ship files.
+- `pkg/scaffold/templates/instructions/{rails,python,typescript,general}.md` — the four canonical instruction templates list every user-facing slash command. These are the authoritative reference for the allow-list of skills that need shims.
+- `test/sandbox/sandbox_test.go` — existing pattern for asserting installed file presence in a temp repo. New sandbox assertion can confirm `.github/prompts/<skill>.prompt.md` is created for the expected set after a guided/full install.
+- Existing parity test (`TestDogfoodTemplateParity`) implies templates must be mirrored from `.github/skills/` — for prompts, since they are pure generated shims and the dogfooded repo does not currently have `.github/prompts/`, we explicitly dogfood the same shims into `.github/prompts/` of this repo to preserve the "what we ship is what we use" invariant.
+
+### Institutional Learnings
+
+- `docs/solutions/` — no existing solution covers VS Code Copilot Chat discovery semantics. This plan implicitly creates one (recommend `/ce-compound` after merge).
+- Memory: *"Installer skills are guarded by parity tests: every templates/skills dir must be registered in exactly one catalog slice, and .github/skills must be mirrored into templates/skills"* — directly applicable. We extend the same posture to prompts.
+- Memory: *"Guided installs only include skills listed in coreSkillDirectories or orchestratorSkillDirectories"* — confirms layer-gating model; prompt shims should follow the same layer system so a user who excludes the `orchestrators` layer doesn't get `/lfg` in their picker.
+
+### External References
+
+- VS Code Copilot Chat docs (well-established public behavior): slash commands are discovered from `.github/prompts/*.prompt.md` and `~/.config/.../prompts/`. No external research needed beyond the contract documented in the issue and the workaround that the issue reporter verified end-to-end.
+
+## Key Technical Decisions
+
+| Decision | Rationale |
+|---|---|
+| **Static, generated shims with a fixed template body** rather than per-skill custom prompt files | Each shim is ~10 lines and identical except for the skill name. A single Go template + an allow-list keeps maintenance to one place and removes the risk of skill/prompt drift. Custom per-skill prompt content would force two sources of truth. |
+| **Explicit allow-list (`promptShimSkillDirectories`)** rather than auto-shimming every skill | Sub-skills (`document-review`, `deepen-plan`, `setup`, `karpathy-guidelines`, `brainstorming`) are not meant to surface as user commands. Shimming them would clutter the picker and invite misuse. Explicit allow-list also gives a single auditable source for "what is a user-facing slash command." |
+| **Generate at scaffold time from a Go template, not as embedded `.prompt.md` template files** | Shim content is derived purely from the skill name. Embedding 18 nearly-identical files would create churn for any future shim shape change. A Go template + allow-list is more honest. (Open-question fork — see below — covers the alternative where we embed files for parity-test simplicity.) |
+| **Tie shims to existing layer selections** (`core-skills`, `orchestrators`) rather than introducing a new `prompts` layer | Users who skip orchestrators expect no `/lfg` anywhere — including the picker. Re-using layer logic preserves that intent and avoids a new TUI category. |
+| **Dogfood the shims into this repo's `.github/prompts/`** | The repo already dogfoods skills under `.github/skills/`. A new `TestDogfoodPromptParity` test enforces the mirror. Without dogfooding, the maintainers don't get the same VS Code picker experience as users. |
+| **Remove (not just suppress) the `add-prompts` recommendation** | The recommendation no longer makes sense once shims are shipped by default — its presence after install would be a red herring. Reframing it ("create *additional* prompt files for your own workflows") is possible but adds noise; deletion is cleaner. |
+| **No new dependency on skill front-matter parsing** | The shim's `description:` line can hardcode a generic delegation message ("Run the <name> skill"). Reading every `SKILL.md` front-matter at scaffold time would couple the installer to skill internals and invite parser brittleness. |
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Which skills are user-facing?** Resolved: take the union of slash commands listed in `pkg/scaffold/templates/instructions/general.md` (the most complete reference) plus the orchestrator entry `/lfg`. Concretely: `ce-brainstorm`, `ce-plan`, `ce-work`, `ce-review`, `ce-compound`, `ce-ideate`, `takeoff`, `land`, `learn`, `instincts`, `evolve`, `observe`, `unslop`, `autoresearch`, `atv-security`, `atv-doctor`, `atv-update`, `lfg`. Excludes: `document-review`, `deepen-plan`, `setup`, `karpathy-guidelines`, `brainstorming`, `meme-iq`, `ralph-loop`, `resolve_todo_parallel`, `slfg`, `feature-video`, `test-browser`, `ce-compound-refresh`. Implementation may add comments justifying each exclusion to satisfy parity-test diagnostics.
+- **Where do shim files live in the embed FS?** Resolved: generate at scaffold time from a Go template constant in `pkg/scaffold/prompts.go`. No embedded `.prompt.md` files. The dogfooded copies under `.github/prompts/` are written from the same template via a small generator (or `go:generate` directive — see deferred items).
+- **Layer gating?** Resolved: prompt shims for core skills are gated on `core-skills`; the `lfg` shim (and any future orchestrator shims) is gated on `orchestrators`.
+
+### Deferred to Implementation
+
+- **Exact shim template wording** — the issue proposes a 10-line Markdown body; final wording (especially the `description:` line that VS Code surfaces in the picker) should be tuned during implementation by previewing against the actual VS Code chat picker. The plan fixes the *shape*, not the *prose*.
+- **`go:generate` vs runtime generation for the dogfooded `.github/prompts/` files** — implementer should pick whichever keeps the parity test trivially green. If runtime generation, the dogfood files are written by a small `make` target or `go run`; if `go:generate`, they're committed and verified for parity. Decision can be made when the test is wired up.
+- **Whether `meme-iq` deserves a shim** — currently treated as easter-egg; if user feedback wants `/meme` discoverable, add it to the allow-list later. Not in scope here.
+- **`/atv-doctor` drift check** — the issue suggests warning when a skill exists with no shim. Useful but separable; tracked as a follow-up.
+
+## Implementation Units
+
+- [ ] **Unit 1: Define the prompt-shim allow-list and template**
+
+**Goal:** Establish the single source of truth for which skills get prompt shims and what each shim looks like.
+
+**Requirements:** R1, R2, R3.
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `pkg/scaffold/prompts.go`
+- Test: `pkg/scaffold/prompts_test.go`
+
+**Approach:**
+- Add a `promptShimSkillDirectories []string` slice grouped by category (core vs orchestrator) with inline comments explaining each entry's user-facing role.
+- Define a Go text template that produces a `.prompt.md` body taking only the skill directory name as input. Body delegates to `.github/skills/<name>/SKILL.md` and forwards user arguments verbatim, per the issue's verified workaround.
+- Export `BuildPromptShim(skillName string) []byte` so other packages (and the dogfood generator) reuse the same template.
+
+**Patterns to follow:**
+- `coreSkillDirectories` / `orchestratorSkillDirectories` slices in `pkg/scaffold/catalog.go:165-209`.
+
+**Test scenarios:**
+- Happy path: `BuildPromptShim("ce-plan")` returns bytes containing `mode: agent`, a `description:` line referencing `ce-plan`, and a Markdown body referencing `.github/skills/ce-plan/SKILL.md`.
+- Edge case: skill name with hyphens (`ce-brainstorm`) round-trips into both the YAML front-matter and the link target without escaping.
+- Happy path: every entry in `promptShimSkillDirectories` is a substring of the union of `coreSkillDirectories` and `orchestratorSkillDirectories` — i.e., we never claim to shim a skill that isn't shipped.
+
+**Verification:**
+- Unit test passes; running `go vet ./...` is clean.
+
+- [ ] **Unit 2: Wire shims into the install catalog (full + filtered)**
+
+**Goal:** Make the installer actually emit `.github/prompts/*.prompt.md` for selected skills.
+
+**Requirements:** R1, R3.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `pkg/scaffold/catalog.go` (add `promptShims()` / `promptShimsForLayers()` and call from `BuildCatalog` and `BuildFilteredCatalogForPacks`)
+- Modify: `pkg/scaffold/prompts.go` (add component builder)
+- Test: `pkg/scaffold/catalog_test.go` (or new `pkg/scaffold/prompts_test.go`)
+
+**Approach:**
+- New helper builds a `[]Component` keyed off `promptShimSkillDirectories`, gated by which skill layers were selected so a user who deselects orchestrators gets no `/lfg.prompt.md`.
+- Add the `.github/prompts` directory to the `directories()` list (so the install creates it even if no shims are emitted, mirroring `.github/skills`).
+- Components carry a sensible `HookType` (likely `1` for system instructions surface or a new constant; see deferred item below for ergonomics).
+
+**Patterns to follow:**
+- `skillComponents(selected map[string]bool)` in `pkg/scaffold/catalog.go:242-266`.
+- Layer gating in `BuildFilteredCatalogForPacks` at `pkg/scaffold/catalog.go:98-132`.
+
+**Test scenarios:**
+- Happy path: `BuildCatalog(StackGeneral)` produces a component for `.github/prompts/ce-plan.prompt.md` whose content matches `BuildPromptShim("ce-plan")`.
+- Happy path: `BuildFilteredCatalog(StackGeneral, []string{"core-skills"})` includes `.github/prompts/ce-plan.prompt.md` but **not** `.github/prompts/lfg.prompt.md`.
+- Happy path: `BuildFilteredCatalog(StackGeneral, []string{"orchestrators"})` includes `.github/prompts/lfg.prompt.md` but no core-skill prompts.
+- Edge case: `BuildFilteredCatalog(StackGeneral, []string{})` (no layers) emits zero prompt components.
+- Integration: snapshot the set of prompt-component paths and assert it equals the allow-list filtered by selected layers — guards against silent additions.
+
+**Verification:**
+- Existing scaffold and parity tests still pass; new tests pass; running `BuildCatalog` end-to-end produces the expected prompt files when written by `pkg/scaffold/scaffold.go` (covered in Unit 4).
+
+- [ ] **Unit 3: Add parity tests**
+
+**Goal:** Lock the invariants so future drift is caught at test time, not by users on Discord.
+
+**Requirements:** R3, R4.
+
+**Dependencies:** Units 1 and 2.
+
+**Files:**
+- Modify: `pkg/scaffold/parity_test.go`
+
+**Approach:**
+- `TestPromptShimAllowListSubsetOfSkills` — every entry in `promptShimSkillDirectories` is present in `coreSkillDirectories ∪ orchestratorSkillDirectories ∪ easterEggSkillDirectories`. Failure message names the offending entry and points to `pkg/scaffold/prompts.go`.
+- `TestPromptShimExclusionsAreIntentional` — for each skill in the union not in the allow-list, assert it is in a small declared `nonUserFacingSkills` set (also in `pkg/scaffold/prompts.go`). Forces a deliberate decision when adding a new skill: either add to the shim allow-list or add to the exclusion list with a reason comment.
+- `TestDogfoodPromptParity` — every shim emitted by `BuildPromptShim` for entries in the allow-list exists at `.github/prompts/<name>.prompt.md` in the repo, with content equal to the generator output. Mirrors `TestDogfoodTemplateParity`.
+
+**Patterns to follow:**
+- `TestSkillDirectoryParity` and `TestDogfoodTemplateParity` in `pkg/scaffold/parity_test.go:55-...`.
+
+**Test scenarios:**
+- Happy path: tests pass with the implemented allow-list and the dogfooded files.
+- Error path (synthetic): adding a fake skill directory to the embedded FS without registering it in the allow-list or exclusion list causes `TestPromptShimExclusionsAreIntentional` to fail with a clear message.
+- Error path (synthetic): mutating one of the dogfooded `.github/prompts/*.prompt.md` files causes `TestDogfoodPromptParity` to fail.
+
+**Verification:**
+- All parity tests green on the new branch; intentional regressions (e.g., temporarily removing a shim) flip the relevant test red.
+
+- [ ] **Unit 4: Dogfood shims into this repo's `.github/prompts/`**
+
+**Goal:** This repo gets the same VS Code Copilot Chat experience users do, and the parity test from Unit 3 has files to compare against.
+
+**Requirements:** R1 (for maintainers), R4.
+
+**Dependencies:** Units 1 and 3.
+
+**Files:**
+- Create: `.github/prompts/<skill>.prompt.md` for every skill in `promptShimSkillDirectories` (~18 files)
+- Optionally modify: `Makefile` or add `go:generate` directive in `pkg/scaffold/prompts.go` for regenerate-on-change
+
+**Approach:**
+- Each file is generated by `BuildPromptShim(<skill>)` to guarantee byte-for-byte parity with what the installer ships. Decide between `go:generate` (commit results) or a `make prompts` target (run before commit) based on which keeps parity test trivially green.
+- Add a one-line note to `CONTRIBUTING.md` (or the closest equivalent) explaining how to regenerate when the allow-list changes.
+
+**Patterns to follow:**
+- The dogfood mirror under `.github/skills/` and `templates/skills/` validated by `TestDogfoodTemplateParity` in `pkg/scaffold/parity_test.go`.
+
+**Test scenarios:**
+- Test expectation: covered by `TestDogfoodPromptParity` from Unit 3 — no additional tests needed.
+
+**Verification:**
+- `ls .github/prompts/` shows every allow-listed skill exactly once; parity test green.
+- Open this repo in VS Code Copilot Chat; type `/ce-` and see completions for every shimmed command.
+
+- [ ] **Unit 5: Update install summary, recommendations, and primitive docs**
+
+**Goal:** Tell users the prompts shipped, stop telling them to create their own, and document prompts as a primitive.
+
+**Requirements:** R5, R6.
+
+**Dependencies:** Unit 2 (catalog must actually emit the files for the summary count to be honest).
+
+**Files:**
+- Modify: `pkg/installstate/recommendations.go` (delete or rescope the `add-prompts` recommendation at lines ~244-252)
+- Modify: `pkg/scaffold/scaffold.go` (or wherever the install summary is printed) — add a "Created N prompt-file shims under `.github/prompts/`" line
+- Modify: `README.md`, `npm/README.md`, `docs/brainstorms/2026-03-11-agentic-coding-starter-kit-installer-brainstorm.md` — add a 7th primitive row for prompt files with a one-sentence note about VS Code discovery semantics
+- Modify: `pkg/scaffold/templates/instructions/{rails,python,typescript,general}.md` — optional one-line note that slash commands are wired via `.github/prompts/`
+- Test: `pkg/installstate/recommendations_test.go` (existing tests likely cover `add-prompts`; update to assert it no longer fires when `.github/prompts/` matches the shipped allow-list)
+
+**Approach:**
+- The `add-prompts` recommendation today fires whenever `PromptFileCount == 0`. After this change, a fresh install always yields `PromptFileCount > 0`, so the recommendation becomes dead code. Either delete it (preferred) or change the trigger to "no *user-authored* prompts beyond ATV's shims" (deferred — adds complexity).
+- Install summary line is purely cosmetic but closes the loop the issue calls out: "no error, no warning ... users either rediscover ... or conclude the install is broken."
+
+**Patterns to follow:**
+- `Recommendation` struct usage in `pkg/installstate/recommendations.go:246-251`.
+- Existing summary formatting in `pkg/scaffold/scaffold.go` (whichever function prints "Created N components").
+
+**Test scenarios:**
+- Happy path: after a fresh install, `BuildRecommendations(state)` does not include an `add-prompts` entry.
+- Edge case: after a user manually deletes their prompts directory, recommendations behave reasonably (likely: nothing fires, since this isn't an error condition any more — confirm with existing test expectations).
+- Happy path: install summary text contains the expected count and path string.
+- Documentation diff: the agentic-primitives table in all three docs has 7 rows including "Prompt files".
+
+**Verification:**
+- Recommendation test green; install summary regression test (if any) green; manual review of the three docs confirms the new row is present.
+
+## System-Wide Impact
+
+- **Interaction graph:** scaffold pipeline (`pkg/scaffold/catalog.go` → `pkg/scaffold/scaffold.go`) gains a new component category. `pkg/installstate/recommendations.go` and `pkg/monitor/watcher.go` already wire `.github/prompts/` and need no functional changes — but `recommendations.go` does need the dead `add-prompts` rule retired.
+- **Error propagation:** failures generating shims must surface like other scaffold errors (e.g., panics in `mustRead` for missing templates). Use the same posture in `BuildPromptShim`: if the template fails to execute, panic at scaffold-build time, not silently emit empty files.
+- **State lifecycle risks:** none — these are pure file outputs, idempotent, no migrations or persistent state.
+- **API surface parity:** the four instruction templates already enumerate the same slash-command list. Whatever lands in the allow-list must match those bullet lists, and a future addition to either side should ripple to the other. The exclusion-list parity test (Unit 3) provides the alarm; the four instruction docs are still hand-edited but small enough to keep in sync. Consider a follow-up that makes those bullet lists themselves generated.
+- **Integration coverage:** end-to-end sandbox test in `test/sandbox/sandbox_test.go` should assert the expected prompt files exist after a guided install with `core-skills` and `orchestrators` selected. Unit-level catalog tests don't prove the file-write path actually fires.
+- **Unchanged invariants:** `SKILL.md` remains the source of truth for skill behavior. Shims do not duplicate skill content. Existing skills, agents, MCP config, hooks, and docs structure are untouched. gstack-prefixed skills under `.github/skills/gstack-*` are not shimmed — gstack manages its own surface.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Allow-list drifts from the bullet lists in `instructions/*.md` | Unit 3's parity tests catch new skills missing from the allow-list. The four instruction docs are still hand-edited; flag in the implementer's PR description that they were checked. Long-term follow-up: generate the bullet lists from the same allow-list. |
+| VS Code chat picker UX surprise — too many slash commands clutters the picker | Allow-list explicitly excludes sub-skills. If 18 commands is still too many, the allow-list is the single knob to dial down. No reshipping of skills required. |
+| `description:` text in shim front-matter is what VS Code surfaces; bad copy looks unprofessional | Tune wording during implementation by previewing in VS Code; deferred per Open Questions. Keep a single template so updates are one-place. |
+| Shims become out of date if a skill is renamed | Rename in `coreSkillDirectories` triggers `TestPromptShimAllowListSubsetOfSkills` to fail, forcing the rename to propagate. Dogfood test then forces the matching `.github/prompts/<oldname>.prompt.md` to be regenerated. |
+| Users who already hand-rolled their own `.github/prompts/<name>.prompt.md` (issue reporter included) get clobbered | The installer's normal collision behavior applies — existing files are preserved unless `--force`. Confirm during implementation that prompt components inherit the same collision policy as skill components. |
+| `add-prompts` recommendation removal breaks an external workflow that depends on it | Search the repo (and gstack templates) for references; the recommendation is internal to ATV. Changelog note at release. |
+
+## Documentation / Operational Notes
+
+- Add a short section to `README.md` and `npm/README.md` agentic-primitives tables explaining prompt files as a 7th primitive and their role in VS Code Copilot Chat discovery.
+- Update `docs/brainstorms/2026-03-11-agentic-coding-starter-kit-installer-brainstorm.md` similarly so the foundational design doc reflects current reality.
+- After merge, recommend the user runs `/ce-compound` to capture a `docs/solutions/` entry: "VS Code Copilot Chat needs `.github/prompts/*.prompt.md` shims; ATV ships them by default" — this is exactly the kind of lesson the institutional-knowledge channel is for.
+- No rollout, monitoring, or migration concerns — pure additive change to scaffold output.
+
+## Sources & References
+
+- **Origin issue:** [#36](https://github.com/All-The-Vibes/ATV-StarterKit/issues/36) — slash commands don't appear in VS Code Copilot Chat (filed 2026-04-30 by @stephschofield)
+- Related code: `pkg/scaffold/catalog.go:165-209` (skill allow-lists), `pkg/scaffold/parity_test.go:55-...` (parity test patterns), `pkg/installstate/recommendations.go:81,246-251` (existing prompt awareness), `pkg/monitor/watcher.go:124,240,320,330` (existing prompt directory watch)
+- Related docs: `pkg/scaffold/templates/instructions/general.md` (canonical slash-command list), `docs/brainstorms/2026-04-28-vscode-source-install-clean-plugin-requirements.md` (recent VS Code install work — does not cover this gap), `docs/brainstorms/2026-03-11-agentic-coding-starter-kit-installer-brainstorm.md` (primitives table)
+- Branch: `feat/vscode-prompt-shims` (off `origin/main`, created 2026-04-29)

--- a/docs/plans/2026-04-30-001-feat-vscode-prompt-shims-plan.md
+++ b/docs/plans/2026-04-30-001-feat-vscode-prompt-shims-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Ship .github/prompts/*.prompt.md shims so VS Code Copilot Chat surfaces ATV slash commands"
 type: feat
-status: active
+status: completed
 date: 2026-04-30
 issue: 36
 ---
@@ -88,7 +88,7 @@ The installer already *recognizes* prompt files exist — `pkg/installstate/reco
 
 ## Implementation Units
 
-- [ ] **Unit 1: Define the prompt-shim allow-list and template**
+- [x] **Unit 1: Define the prompt-shim allow-list and template**
 
 **Goal:** Establish the single source of truth for which skills get prompt shims and what each shim looks like.
 
@@ -116,7 +116,7 @@ The installer already *recognizes* prompt files exist — `pkg/installstate/reco
 **Verification:**
 - Unit test passes; running `go vet ./...` is clean.
 
-- [ ] **Unit 2: Wire shims into the install catalog (full + filtered)**
+- [x] **Unit 2: Wire shims into the install catalog (full + filtered)**
 
 **Goal:** Make the installer actually emit `.github/prompts/*.prompt.md` for selected skills.
 
@@ -148,7 +148,7 @@ The installer already *recognizes* prompt files exist — `pkg/installstate/reco
 **Verification:**
 - Existing scaffold and parity tests still pass; new tests pass; running `BuildCatalog` end-to-end produces the expected prompt files when written by `pkg/scaffold/scaffold.go` (covered in Unit 4).
 
-- [ ] **Unit 3: Add parity tests**
+- [x] **Unit 3: Add parity tests**
 
 **Goal:** Lock the invariants so future drift is caught at test time, not by users on Discord.
 
@@ -175,7 +175,7 @@ The installer already *recognizes* prompt files exist — `pkg/installstate/reco
 **Verification:**
 - All parity tests green on the new branch; intentional regressions (e.g., temporarily removing a shim) flip the relevant test red.
 
-- [ ] **Unit 4: Dogfood shims into this repo's `.github/prompts/`**
+- [x] **Unit 4: Dogfood shims into this repo's `.github/prompts/`**
 
 **Goal:** This repo gets the same VS Code Copilot Chat experience users do, and the parity test from Unit 3 has files to compare against.
 
@@ -201,7 +201,7 @@ The installer already *recognizes* prompt files exist — `pkg/installstate/reco
 - `ls .github/prompts/` shows every allow-listed skill exactly once; parity test green.
 - Open this repo in VS Code Copilot Chat; type `/ce-` and see completions for every shimmed command.
 
-- [ ] **Unit 5: Update install summary, recommendations, and primitive docs**
+- [x] **Unit 5: Update install summary, recommendations, and primitive docs**
 
 **Goal:** Tell users the prompts shipped, stop telling them to create their own, and document prompts as a primitive.
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -95,6 +95,7 @@ Use gstack's browser skills when you want a higher-level QA workflow; use `agent
 | 4 | Skills | `.github/skills/*/SKILL.md` |
 | 5 | Agents | `.github/agents/*.agent.md` |
 | 6 | File Instructions | `.github/*.instructions.md` |
+| 7 | Prompt Shims | `.github/prompts/*.prompt.md` (VS Code Copilot Chat slash commands) |
 
 Plus: `.vscode/extensions.json` and `docs/` structure.
 

--- a/pkg/installstate/recommendations.go
+++ b/pkg/installstate/recommendations.go
@@ -241,14 +241,6 @@ func BuildRecommendations(root string, manifest InstallManifest) []Recommendatio
 			Priority: 40,
 		})
 	}
-	if state.PromptFileCount == 0 {
-		recommendations = append(recommendations, Recommendation{
-			ID:       "add-prompts",
-			Title:    "Create prompt files for repeatable workflows",
-			Reason:   "No .prompt.md files found in .github/prompts/.",
-			Priority: 55,
-		})
-	}
 
 	slices.SortStableFunc(recommendations, func(a, b Recommendation) int {
 		if a.Priority == b.Priority {

--- a/pkg/installstate/recommendations_test.go
+++ b/pkg/installstate/recommendations_test.go
@@ -102,3 +102,16 @@ func mustWriteMarkdown(t *testing.T, path, content string) {
 		t.Fatal(err)
 	}
 }
+
+// TestBuildRecommendations_NoAddPromptsRecommendation guards the removal of
+// the legacy "add-prompts" recommendation. The installer now ships shim
+// .prompt.md files by default, so prompting users to create one is misleading.
+func TestBuildRecommendations_NoAddPromptsRecommendation(t *testing.T) {
+root := t.TempDir()
+recs := BuildRecommendations(root, InstallManifest{})
+for _, r := range recs {
+if r.ID == "add-prompts" {
+t.Fatalf("legacy add-prompts recommendation reappeared in BuildRecommendations output: %+v", r)
+}
+}
+}

--- a/pkg/scaffold/catalog.go
+++ b/pkg/scaffold/catalog.go
@@ -19,8 +19,8 @@ type Component struct {
 	Path      string // relative path in target directory
 	Content   []byte // file content (empty for dirs)
 	IsDir     bool
-	MergeJSON bool // if true, merge with existing JSON instead of skipping
-	HookType  int  // 1-6 matching Copilot lifecycle hooks
+	MergeJSON bool     // if true, merge with existing JSON instead of skipping
+	HookType  HookType // 1-7 matching Copilot agentic primitives (see hooks.go)
 }
 
 // BuildCatalog returns the full list of components for the given stack.

--- a/pkg/scaffold/catalog.go
+++ b/pkg/scaffold/catalog.go
@@ -43,6 +43,9 @@ func BuildCatalog(stack detect.Stack) []Component {
 	// Hook 4: Skills (from .github/skills/ in this repo)
 	catalog = append(catalog, skills()...)
 
+	// Prompt-file shims for VS Code Copilot Chat slash-command discovery.
+	catalog = append(catalog, promptShims()...)
+
 	// Hook 5: Agents (from .github/agents/ in this repo)
 	catalog = append(catalog, agents(stack)...)
 
@@ -114,6 +117,11 @@ func BuildFilteredCatalogForPacks(packs []installstate.StackPack, primaryStack d
 	if len(selectedSkillDirs) > 0 {
 		catalog = append(catalog, skillComponents(selectedSkillDirs)...)
 	}
+	// Prompt shims gated to the same skill layers — a user who deselects
+	// orchestrators must not see /lfg in the VS Code chat picker.
+	if selectedPromptShims := selectedPromptShimsForLayers(layerSet); len(selectedPromptShims) > 0 {
+		catalog = append(catalog, promptShimComponents(selectedPromptShims)...)
+	}
 	if layerSet["universal-agents"] || layerSet["stack-agents"] {
 		catalog = append(catalog, agentsForPacks(normalizedPacks, layerSet["universal-agents"], layerSet["stack-agents"])...)
 	}
@@ -138,6 +146,7 @@ func directories() []Component {
 	dirs := []string{
 		".github/skills",
 		".github/agents",
+		".github/prompts",
 		".github/hooks/scripts",
 		".vscode",
 	}

--- a/pkg/scaffold/hooks.go
+++ b/pkg/scaffold/hooks.go
@@ -1,6 +1,6 @@
 package scaffold
 
-// HookType represents each of the 6 Copilot lifecycle hooks.
+// HookType represents each of the 7 Copilot agentic primitives.
 type HookType int
 
 const (
@@ -10,6 +10,7 @@ const (
 	HookSkills             HookType = 4 // .github/skills/*/SKILL.md
 	HookAgents             HookType = 5 // .github/agents/*.agent.md
 	HookFileInstructions   HookType = 6 // .github/*.instructions.md
+	HookPromptShims        HookType = 7 // .github/prompts/*.prompt.md
 )
 
 // HookName returns the human-readable name for a hook type.
@@ -27,6 +28,8 @@ func HookName(h HookType) string {
 		return "Agents"
 	case HookFileInstructions:
 		return "File Instructions"
+	case HookPromptShims:
+		return "Prompt Shims"
 	default:
 		return "Unknown"
 	}

--- a/pkg/scaffold/parity_test.go
+++ b/pkg/scaffold/parity_test.go
@@ -350,45 +350,45 @@ func repoRoot(t *testing.T) string {
 // maintainers' VS Code Copilot Chat picker would diverge from what users get
 // after running the installer.
 func TestDogfoodPromptParity(t *testing.T) {
-repoRoot := repoRoot(t)
-promptsDir := filepath.Join(repoRoot, ".github", "prompts")
+	root := repoRoot(t)
+	promptsDir := filepath.Join(root, ".github", "prompts")
 
-for _, name := range promptShimSkillDirectories {
-want := BuildPromptShim(name)
-path := filepath.Join(promptsDir, name+".prompt.md")
-got, err := os.ReadFile(path)
-if err != nil {
-t.Errorf("missing dogfood prompt shim %s: %v\n"+
-"Regenerate via `go generate ./pkg/scaffold/...` or run `make prompts`.", path, err)
-continue
-}
-if string(got) != string(want) {
-t.Errorf("dogfood prompt shim %s drifted from BuildPromptShim output.\n"+
-"Regenerate to restore parity.", path)
-}
-}
+	for _, name := range promptShimSkillDirectories {
+		want := BuildPromptShim(name)
+		path := filepath.Join(promptsDir, name+".prompt.md")
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("missing dogfood prompt shim %s: %v\n"+
+				"Regenerate via `go generate ./pkg/scaffold/...`.", path, err)
+			continue
+		}
+		if string(got) != string(want) {
+			t.Errorf("dogfood prompt shim %s drifted from BuildPromptShim output.\n"+
+				"Regenerate to restore parity.", path)
+		}
+	}
 
-// Reverse direction: every file in .github/prompts/ should correspond to
-// an allow-listed skill (no orphan shims).
-allow := make(map[string]bool, len(promptShimSkillDirectories))
-for _, n := range promptShimSkillDirectories {
-allow[n] = true
-}
-entries, err := os.ReadDir(promptsDir)
-if err != nil {
-t.Fatalf("reading %s: %v", promptsDir, err)
-}
-for _, e := range entries {
-if e.IsDir() {
-continue
-}
-name := strings.TrimSuffix(e.Name(), ".prompt.md")
-if name == e.Name() {
-continue // not a .prompt.md file
-}
-if !allow[name] {
-t.Errorf("orphan prompt shim %s in .github/prompts/ — not in promptShimSkillDirectories. "+
-"Either add it to the allow-list (pkg/scaffold/prompts.go) or delete the file.", e.Name())
-}
-}
+	// Reverse direction: every file in .github/prompts/ should correspond to
+	// an allow-listed skill (no orphan shims).
+	allow := make(map[string]bool, len(promptShimSkillDirectories))
+	for _, n := range promptShimSkillDirectories {
+		allow[n] = true
+	}
+	entries, err := os.ReadDir(promptsDir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", promptsDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".prompt.md")
+		if name == e.Name() {
+			continue // not a .prompt.md file
+		}
+		if !allow[name] {
+			t.Errorf("orphan prompt shim %s in .github/prompts/ — not in promptShimSkillDirectories. "+
+				"Either add it to the allow-list (pkg/scaffold/prompts.go) or delete the file.", e.Name())
+		}
+	}
 }

--- a/pkg/scaffold/parity_test.go
+++ b/pkg/scaffold/parity_test.go
@@ -343,3 +343,52 @@ func repoRoot(t *testing.T) string {
 	}
 	return root
 }
+
+// TestDogfoodPromptParity ensures every shim that the installer would emit
+// for an allow-listed skill is mirrored byte-for-byte at
+// .github/prompts/<name>.prompt.md in this repo. Without this, the
+// maintainers' VS Code Copilot Chat picker would diverge from what users get
+// after running the installer.
+func TestDogfoodPromptParity(t *testing.T) {
+repoRoot := repoRoot(t)
+promptsDir := filepath.Join(repoRoot, ".github", "prompts")
+
+for _, name := range promptShimSkillDirectories {
+want := BuildPromptShim(name)
+path := filepath.Join(promptsDir, name+".prompt.md")
+got, err := os.ReadFile(path)
+if err != nil {
+t.Errorf("missing dogfood prompt shim %s: %v\n"+
+"Regenerate via `go generate ./pkg/scaffold/...` or run `make prompts`.", path, err)
+continue
+}
+if string(got) != string(want) {
+t.Errorf("dogfood prompt shim %s drifted from BuildPromptShim output.\n"+
+"Regenerate to restore parity.", path)
+}
+}
+
+// Reverse direction: every file in .github/prompts/ should correspond to
+// an allow-listed skill (no orphan shims).
+allow := make(map[string]bool, len(promptShimSkillDirectories))
+for _, n := range promptShimSkillDirectories {
+allow[n] = true
+}
+entries, err := os.ReadDir(promptsDir)
+if err != nil {
+t.Fatalf("reading %s: %v", promptsDir, err)
+}
+for _, e := range entries {
+if e.IsDir() {
+continue
+}
+name := strings.TrimSuffix(e.Name(), ".prompt.md")
+if name == e.Name() {
+continue // not a .prompt.md file
+}
+if !allow[name] {
+t.Errorf("orphan prompt shim %s in .github/prompts/ — not in promptShimSkillDirectories. "+
+"Either add it to the allow-list (pkg/scaffold/prompts.go) or delete the file.", e.Name())
+}
+}
+}

--- a/pkg/scaffold/prompts.go
+++ b/pkg/scaffold/prompts.go
@@ -1,0 +1,169 @@
+package scaffold
+
+//go:generate go run ../../cmd/promptgen
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"text/template"
+)
+
+// promptShimSkillDirectories enumerates skills that should be discoverable as
+// VS Code Copilot Chat slash commands via .github/prompts/<name>.prompt.md
+// shims. Sub-skills, behavioral guides, and helper-only skills are excluded —
+// see nonUserFacingSkills for the corresponding deny-list. The two together
+// must cover every entry in coreSkillDirectories ∪ orchestratorSkillDirectories
+// ∪ easterEggSkillDirectories (enforced by parity tests).
+var promptShimSkillDirectories = []string{
+	// Compound Engineering core workflow
+	"ce-brainstorm",
+	"ce-plan",
+	"ce-work",
+	"ce-review",
+	"ce-compound",
+	"ce-ideate",
+	// Session lifecycle
+	"takeoff",
+	"land",
+	// ATV Learning Pipeline
+	"learn",
+	"instincts",
+	"evolve",
+	"observe",
+	// ATV Quality
+	"unslop",
+	// Experimentation
+	"autoresearch",
+	// Maintenance
+	"atv-doctor",
+	"atv-update",
+	// Security
+	"atv-security",
+	// Orchestrators
+	"lfg",
+}
+
+// nonUserFacingSkills lists shipped skills that are intentionally NOT exposed
+// as VS Code slash commands. Each entry must include a justification comment
+// so the next maintainer understands the choice. This list plus
+// promptShimSkillDirectories must cover every shipped skill (parity-tested).
+var nonUserFacingSkills = []string{
+	// Sub-skill invoked by ce-brainstorm; not a top-level command.
+	"brainstorming",
+	// Sub-skill invoked by ce-compound; not a top-level command.
+	"ce-compound-refresh",
+	// Sub-skill invoked by ce-plan; not a top-level command.
+	"deepen-plan",
+	// Sub-skill invoked by ce-review and the document-review pipeline.
+	"document-review",
+	// Bootstrap helper invoked during install, not by users at runtime.
+	"setup",
+	// Behavioral guideline reference text, not an invocable command.
+	"karpathy-guidelines",
+	// Orchestrator sub-skills — internal building blocks of /lfg.
+	"feature-video",
+	"ralph-loop",
+	"resolve_todo_parallel",
+	"slfg",
+	"test-browser",
+	// Easter-egg skill — discoverable via the easter-eggs layer, not the chat picker.
+	"meme-iq",
+}
+
+// promptShimTemplate is the canonical body of a generated .prompt.md shim.
+// VS Code Copilot Chat reads `mode` and `description` from the YAML
+// front-matter and surfaces `description` in the slash-command picker.
+// The body is a thin delegation to the SKILL.md so SKILL.md remains the
+// single source of truth.
+const promptShimTemplate = `---
+mode: agent
+description: Run the {{.Name}} skill
+---
+
+Invoke the ` + "`{{.Name}}`" + ` skill defined at ` + "`.github/skills/{{.Name}}/SKILL.md`" + ` and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.
+`
+
+// BuildPromptShim renders the .prompt.md shim body for a single skill name.
+// The output is byte-for-byte deterministic so it can be parity-checked
+// against dogfooded copies under .github/prompts/.
+func BuildPromptShim(skillName string) []byte {
+	tmpl, err := template.New("prompt-shim").Parse(promptShimTemplate)
+	if err != nil {
+		panic(fmt.Sprintf("prompt shim template invalid: %v", err))
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, struct{ Name string }{Name: skillName}); err != nil {
+		panic(fmt.Sprintf("prompt shim render failed for %q: %v", skillName, err))
+	}
+	return buf.Bytes()
+}
+
+// PromptShimPlan returns the ordered list of skill names that receive prompt
+// shims. Exposed for the cmd/promptgen tool which regenerates the dogfooded
+// .github/prompts/ files from BuildPromptShim.
+func PromptShimPlan() []string {
+	out := make([]string, len(promptShimSkillDirectories))
+	copy(out, promptShimSkillDirectories)
+	return out
+}
+
+// promptShims returns components for every allow-listed skill (full install).
+func promptShims() []Component {
+	return promptShimComponents(nil)
+}
+
+// selectedPromptShimsForLayers returns the set of allow-listed skill names
+// whose layer is enabled. A nil/empty result means no prompt shims should be
+// emitted (e.g., user deselected both core-skills and orchestrators).
+func selectedPromptShimsForLayers(layerSet map[string]bool) map[string]bool {
+	if len(layerSet) == 0 {
+		return nil
+	}
+	enabledSkills := make(map[string]bool)
+	if layerSet["core-skills"] {
+		for _, n := range coreSkillDirectories {
+			enabledSkills[n] = true
+		}
+	}
+	if layerSet["orchestrators"] {
+		for _, n := range orchestratorSkillDirectories {
+			enabledSkills[n] = true
+		}
+	}
+	if layerSet["easter-eggs"] {
+		for _, n := range easterEggSkillDirectories {
+			enabledSkills[n] = true
+		}
+	}
+	if len(enabledSkills) == 0 {
+		return nil
+	}
+	out := make(map[string]bool)
+	for _, name := range promptShimSkillDirectories {
+		if enabledSkills[name] {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+// promptShimComponents returns shim components for the subset of allow-listed
+// skills present in `selected`. A nil `selected` means "include all".
+func promptShimComponents(selected map[string]bool) []Component {
+	var comps []Component
+	for _, name := range promptShimSkillDirectories {
+		if selected != nil && !selected[name] {
+			continue
+		}
+		dest := filepath.Join(".github", "prompts", name+".prompt.md")
+		comps = append(comps, Component{
+			Path:    dest,
+			Content: BuildPromptShim(name),
+			HookType: 1,
+		})
+	}
+	return comps
+}

--- a/pkg/scaffold/prompts.go
+++ b/pkg/scaffold/prompts.go
@@ -160,9 +160,9 @@ func promptShimComponents(selected map[string]bool) []Component {
 		}
 		dest := filepath.Join(".github", "prompts", name+".prompt.md")
 		comps = append(comps, Component{
-			Path:    dest,
-			Content: BuildPromptShim(name),
-			HookType: 1,
+			Path:     dest,
+			Content:  BuildPromptShim(name),
+			HookType: HookPromptShims,
 		})
 	}
 	return comps

--- a/pkg/scaffold/prompts_test.go
+++ b/pkg/scaffold/prompts_test.go
@@ -117,73 +117,73 @@ func firstLine(s string) string {
 // --- Unit 2: catalog wiring tests ---
 
 func TestBuildCatalog_IncludesAllPromptShims(t *testing.T) {
-comps := BuildCatalog(detectStackForTest())
+	comps := BuildCatalog(detectStackForTest())
 
-got := promptShimPaths(comps)
-for _, name := range promptShimSkillDirectories {
-want := ".github/prompts/" + name + ".prompt.md"
-if !got[want] {
-t.Errorf("BuildCatalog missing prompt component %q", want)
-}
-}
+	got := promptShimPaths(comps)
+	for _, name := range promptShimSkillDirectories {
+		want := ".github/prompts/" + name + ".prompt.md"
+		if !got[want] {
+			t.Errorf("BuildCatalog missing prompt component %q", want)
+		}
+	}
 }
 
 func TestBuildCatalog_PromptShimContentMatchesBuilder(t *testing.T) {
-comps := BuildCatalog(detectStackForTest())
-target := ".github/prompts/ce-plan.prompt.md"
-for _, c := range comps {
-if filepathToSlash(c.Path) == target {
-want := string(BuildPromptShim("ce-plan"))
-if string(c.Content) != want {
-t.Errorf("catalog component %q content drifted from BuildPromptShim output", target)
-}
-return
-}
-}
-t.Fatalf("catalog component %q not found", target)
+	comps := BuildCatalog(detectStackForTest())
+	target := ".github/prompts/ce-plan.prompt.md"
+	for _, c := range comps {
+		if filepathToSlash(c.Path) == target {
+			want := string(BuildPromptShim("ce-plan"))
+			if string(c.Content) != want {
+				t.Errorf("catalog component %q content drifted from BuildPromptShim output", target)
+			}
+			return
+		}
+	}
+	t.Fatalf("catalog component %q not found", target)
 }
 
 func TestBuildFilteredCatalog_CoreSkillsOnlyIncludesCoreShims(t *testing.T) {
-comps := BuildFilteredCatalog(detectStackForTest(), []string{"core-skills"})
-got := promptShimPaths(comps)
+	comps := BuildFilteredCatalog(detectStackForTest(), []string{"core-skills"})
+	got := promptShimPaths(comps)
 
-if !got[".github/prompts/ce-plan.prompt.md"] {
-t.Errorf("core-skills layer missing ce-plan.prompt.md")
-}
-if got[".github/prompts/lfg.prompt.md"] {
-t.Errorf("core-skills layer should NOT include orchestrator shim lfg.prompt.md")
-}
+	if !got[".github/prompts/ce-plan.prompt.md"] {
+		t.Errorf("core-skills layer missing ce-plan.prompt.md")
+	}
+	if got[".github/prompts/lfg.prompt.md"] {
+		t.Errorf("core-skills layer should NOT include orchestrator shim lfg.prompt.md")
+	}
 }
 
 func TestBuildFilteredCatalog_OrchestratorsOnlyIncludesOrchestratorShims(t *testing.T) {
-comps := BuildFilteredCatalog(detectStackForTest(), []string{"orchestrators"})
-got := promptShimPaths(comps)
+	comps := BuildFilteredCatalog(detectStackForTest(), []string{"orchestrators"})
+	got := promptShimPaths(comps)
 
-if !got[".github/prompts/lfg.prompt.md"] {
-t.Errorf("orchestrators layer missing lfg.prompt.md")
-}
-if got[".github/prompts/ce-plan.prompt.md"] {
-t.Errorf("orchestrators layer should NOT include core-skill shim ce-plan.prompt.md")
-}
+	if !got[".github/prompts/lfg.prompt.md"] {
+		t.Errorf("orchestrators layer missing lfg.prompt.md")
+	}
+	if got[".github/prompts/ce-plan.prompt.md"] {
+		t.Errorf("orchestrators layer should NOT include core-skill shim ce-plan.prompt.md")
+	}
 }
 
 func TestBuildFilteredCatalog_NoLayersEmitsZeroShims(t *testing.T) {
-comps := BuildFilteredCatalog(detectStackForTest(), []string{})
-for _, c := range comps {
-if isPromptShimPath(c.Path) {
-t.Errorf("expected zero prompt shims with no layers selected, got %q", c.Path)
-}
-}
+	comps := BuildFilteredCatalog(detectStackForTest(), []string{})
+	for _, c := range comps {
+		if isPromptShimPath(c.Path) {
+			t.Errorf("expected zero prompt shims with no layers selected, got %q", c.Path)
+		}
+	}
 }
 
 func TestBuildCatalog_IncludesPromptsDirectory(t *testing.T) {
-comps := BuildCatalog(detectStackForTest())
-for _, c := range comps {
-if c.IsDir && filepathToSlash(c.Path) == ".github/prompts" {
-return
-}
-}
-t.Errorf(".github/prompts directory component missing from BuildCatalog output")
+	comps := BuildCatalog(detectStackForTest())
+	for _, c := range comps {
+		if c.IsDir && filepathToSlash(c.Path) == ".github/prompts" {
+			return
+		}
+	}
+	t.Errorf(".github/prompts directory component missing from BuildCatalog output")
 }
 
 func detectStackForTest() detect.Stack { return detect.StackGeneral }
@@ -191,16 +191,16 @@ func detectStackForTest() detect.Stack { return detect.StackGeneral }
 func filepathToSlash(p string) string { return filepath.ToSlash(p) }
 
 func isPromptShimPath(p string) bool {
-s := filepathToSlash(p)
-return strings.HasPrefix(s, ".github/prompts/") && strings.HasSuffix(s, ".prompt.md")
+	s := filepathToSlash(p)
+	return strings.HasPrefix(s, ".github/prompts/") && strings.HasSuffix(s, ".prompt.md")
 }
 
 func promptShimPaths(comps []Component) map[string]bool {
-out := map[string]bool{}
-for _, c := range comps {
-if isPromptShimPath(c.Path) {
-out[filepathToSlash(c.Path)] = true
-}
-}
-return out
+	out := map[string]bool{}
+	for _, c := range comps {
+		if isPromptShimPath(c.Path) {
+			out[filepathToSlash(c.Path)] = true
+		}
+	}
+	return out
 }

--- a/pkg/scaffold/prompts_test.go
+++ b/pkg/scaffold/prompts_test.go
@@ -1,0 +1,206 @@
+package scaffold
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/All-The-Vibes/ATV-StarterKit/pkg/detect"
+)
+
+// TestBuildPromptShim_HappyPath verifies that a generated shim contains the
+// VS Code Copilot Chat front-matter, a description that names the skill, and
+// a body that delegates to the canonical SKILL.md path.
+func TestBuildPromptShim_HappyPath(t *testing.T) {
+	got := string(BuildPromptShim("ce-plan"))
+
+	mustContain := []string{
+		"mode: agent",
+		"ce-plan",
+		".github/skills/ce-plan/SKILL.md",
+	}
+	for _, sub := range mustContain {
+		if !strings.Contains(got, sub) {
+			t.Errorf("BuildPromptShim(\"ce-plan\") missing %q\n--- got ---\n%s", sub, got)
+		}
+	}
+
+	if !strings.HasPrefix(got, "---\n") {
+		t.Errorf("BuildPromptShim output should start with YAML front-matter delimiter, got prefix %q", firstLine(got))
+	}
+
+	// Front-matter must contain a description: line; VS Code surfaces it in the picker.
+	if !strings.Contains(got, "\ndescription:") {
+		t.Errorf("BuildPromptShim output missing `description:` line in front-matter\n--- got ---\n%s", got)
+	}
+}
+
+// TestBuildPromptShim_HyphenatedSkillName ensures hyphens in skill directory
+// names round-trip through both the front-matter description and the skill
+// link target without escaping or quoting damage.
+func TestBuildPromptShim_HyphenatedSkillName(t *testing.T) {
+	got := string(BuildPromptShim("ce-brainstorm"))
+
+	if !strings.Contains(got, ".github/skills/ce-brainstorm/SKILL.md") {
+		t.Errorf("hyphenated skill name not preserved in link target\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, "ce-brainstorm") {
+		t.Errorf("hyphenated skill name missing from output\n--- got ---\n%s", got)
+	}
+}
+
+// TestPromptShimAllowListIsSubsetOfShippedSkills protects the invariant that
+// every shim entry corresponds to a skill the installer actually ships.
+// A shim referencing a non-existent skill would generate a dead link.
+func TestPromptShimAllowListIsSubsetOfShippedSkills(t *testing.T) {
+	shipped := make(map[string]bool)
+	for _, n := range coreSkillDirectories {
+		shipped[n] = true
+	}
+	for _, n := range orchestratorSkillDirectories {
+		shipped[n] = true
+	}
+	for _, n := range easterEggSkillDirectories {
+		shipped[n] = true
+	}
+
+	for _, name := range promptShimSkillDirectories {
+		if !shipped[name] {
+			t.Errorf("promptShimSkillDirectories entry %q is not present in any catalog skill slice "+
+				"(coreSkillDirectories, orchestratorSkillDirectories, easterEggSkillDirectories)", name)
+		}
+	}
+}
+
+// TestPromptShimExclusionsCoverAllUnshippedSkills enforces that every shipped
+// skill is either an allow-listed shim or explicitly listed as non-user-facing.
+// Adding a new skill without making this decision will fail the test.
+func TestPromptShimExclusionsCoverAllUnshippedSkills(t *testing.T) {
+	allow := make(map[string]bool, len(promptShimSkillDirectories))
+	for _, n := range promptShimSkillDirectories {
+		allow[n] = true
+	}
+	exclude := make(map[string]bool, len(nonUserFacingSkills))
+	for _, n := range nonUserFacingSkills {
+		exclude[n] = true
+	}
+
+	all := append(append([]string{}, coreSkillDirectories...), orchestratorSkillDirectories...)
+	all = append(all, easterEggSkillDirectories...)
+
+	var unclassified []string
+	for _, name := range all {
+		if !allow[name] && !exclude[name] {
+			unclassified = append(unclassified, name)
+		}
+	}
+	if len(unclassified) > 0 {
+		t.Fatalf("skills not classified as either user-facing (promptShimSkillDirectories) or "+
+			"non-user-facing (nonUserFacingSkills) in pkg/scaffold/prompts.go: %v", unclassified)
+	}
+
+	// The two sets must be disjoint — a skill cannot be both shimmed and excluded.
+	for name := range allow {
+		if exclude[name] {
+			t.Errorf("skill %q appears in both promptShimSkillDirectories and nonUserFacingSkills", name)
+		}
+	}
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// --- Unit 2: catalog wiring tests ---
+
+func TestBuildCatalog_IncludesAllPromptShims(t *testing.T) {
+comps := BuildCatalog(detectStackForTest())
+
+got := promptShimPaths(comps)
+for _, name := range promptShimSkillDirectories {
+want := ".github/prompts/" + name + ".prompt.md"
+if !got[want] {
+t.Errorf("BuildCatalog missing prompt component %q", want)
+}
+}
+}
+
+func TestBuildCatalog_PromptShimContentMatchesBuilder(t *testing.T) {
+comps := BuildCatalog(detectStackForTest())
+target := ".github/prompts/ce-plan.prompt.md"
+for _, c := range comps {
+if filepathToSlash(c.Path) == target {
+want := string(BuildPromptShim("ce-plan"))
+if string(c.Content) != want {
+t.Errorf("catalog component %q content drifted from BuildPromptShim output", target)
+}
+return
+}
+}
+t.Fatalf("catalog component %q not found", target)
+}
+
+func TestBuildFilteredCatalog_CoreSkillsOnlyIncludesCoreShims(t *testing.T) {
+comps := BuildFilteredCatalog(detectStackForTest(), []string{"core-skills"})
+got := promptShimPaths(comps)
+
+if !got[".github/prompts/ce-plan.prompt.md"] {
+t.Errorf("core-skills layer missing ce-plan.prompt.md")
+}
+if got[".github/prompts/lfg.prompt.md"] {
+t.Errorf("core-skills layer should NOT include orchestrator shim lfg.prompt.md")
+}
+}
+
+func TestBuildFilteredCatalog_OrchestratorsOnlyIncludesOrchestratorShims(t *testing.T) {
+comps := BuildFilteredCatalog(detectStackForTest(), []string{"orchestrators"})
+got := promptShimPaths(comps)
+
+if !got[".github/prompts/lfg.prompt.md"] {
+t.Errorf("orchestrators layer missing lfg.prompt.md")
+}
+if got[".github/prompts/ce-plan.prompt.md"] {
+t.Errorf("orchestrators layer should NOT include core-skill shim ce-plan.prompt.md")
+}
+}
+
+func TestBuildFilteredCatalog_NoLayersEmitsZeroShims(t *testing.T) {
+comps := BuildFilteredCatalog(detectStackForTest(), []string{})
+for _, c := range comps {
+if isPromptShimPath(c.Path) {
+t.Errorf("expected zero prompt shims with no layers selected, got %q", c.Path)
+}
+}
+}
+
+func TestBuildCatalog_IncludesPromptsDirectory(t *testing.T) {
+comps := BuildCatalog(detectStackForTest())
+for _, c := range comps {
+if c.IsDir && filepathToSlash(c.Path) == ".github/prompts" {
+return
+}
+}
+t.Errorf(".github/prompts directory component missing from BuildCatalog output")
+}
+
+func detectStackForTest() detect.Stack { return detect.StackGeneral }
+
+func filepathToSlash(p string) string { return filepath.ToSlash(p) }
+
+func isPromptShimPath(p string) bool {
+s := filepathToSlash(p)
+return strings.HasPrefix(s, ".github/prompts/") && strings.HasSuffix(s, ".prompt.md")
+}
+
+func promptShimPaths(comps []Component) map[string]bool {
+out := map[string]bool{}
+for _, c := range comps {
+if isPromptShimPath(c.Path) {
+out[filepathToSlash(c.Path)] = true
+}
+}
+return out
+}

--- a/pkg/scaffold/uninstall.go
+++ b/pkg/scaffold/uninstall.go
@@ -44,6 +44,7 @@ func (r UninstallResult) Summary() string {
 var atvDirectories = []string{
 	".github/skills",
 	".github/agents",
+	".github/prompts",
 	".github/hooks",
 	".gstack",
 	".atv",

--- a/test/sandbox/sandbox_test.go
+++ b/test/sandbox/sandbox_test.go
@@ -624,6 +624,22 @@ func TestE2EFullGuidedInstallLifecycle(t *testing.T) {
 		assertFileExists(t, filepath.Join(root, ".github", "rails.instructions.md"))
 	})
 
+	t.Run("hook7_prompt_shims", func(t *testing.T) {
+		promptsDir := filepath.Join(root, ".github", "prompts")
+		assertDirExists(t, promptsDir)
+		// Core-skill shims
+		for _, name := range []string{"ce-plan", "ce-work", "ce-review", "takeoff", "land", "learn"} {
+			assertFileExists(t, filepath.Join(promptsDir, name+".prompt.md"))
+		}
+		// Orchestrator shim — selectedLayers includes "orchestrators"
+		assertFileExists(t, filepath.Join(promptsDir, "lfg.prompt.md"))
+		// Sub-skill must NOT be shimmed (not user-facing)
+		nonUserFacing := filepath.Join(promptsDir, "document-review.prompt.md")
+		if _, err := os.Stat(nonUserFacing); err == nil {
+			t.Errorf("non-user-facing skill document-review should not have a prompt shim, got %s", nonUserFacing)
+		}
+	})
+
 	t.Run("vscode_extensions", func(t *testing.T) {
 		path := filepath.Join(root, ".vscode", "extensions.json")
 		assertFileExists(t, path)


### PR DESCRIPTION
Closes #36.

## What

Generates 18 prompt-file shims at install time (one per user-facing skill) so VS Code Copilot Chat surfaces `/ce-plan`, `/ce-work`, `/lfg`, `/learn`, `/takeoff`, `/land`, etc. in its slash-command picker. Each shim is a thin delegation to the canonical `.github/skills/<name>/SKILL.md` — SKILL.md remains the single source of truth.

Before: a fresh `atv-starterkit init` left `.github/prompts/` empty, so VS Code Copilot Chat showed zero ATV slash commands in its picker even though `copilot-instructions.md` advertised them.

After: every user-facing ATV skill is one keystroke away in the picker. Sub-skills (`document-review`, `deepen-plan`, `brainstorming`, `setup`, `karpathy-guidelines`) and orchestrator internals (`feature-video`, `ralph-loop`, `resolve_todo_parallel`, `slfg`, `test-browser`) are intentionally excluded so the picker stays clean.

## Implementation (TDD)

- `pkg/scaffold/prompts.go` — `promptShimSkillDirectories` allow-list, `nonUserFacingSkills` deny-list (parity-tested to cover every shipped skill), `BuildPromptShim` template, layer-gated `promptShimComponents`.
- `pkg/scaffold/catalog.go` — wires `promptShims()` into both `BuildCatalog` (full) and `BuildFilteredCatalogForPacks` (guided), gated on the same `core-skills` / `orchestrators` layers as the underlying skills. Adds `.github/prompts` to `directories()`.
- `pkg/scaffold/parity_test.go` — `TestDogfoodPromptParity` locks the dogfooded copies under `.github/prompts/` to byte-for-byte equality with `BuildPromptShim` output.
- `pkg/scaffold/prompts_test.go` — happy-path + hyphenated-name + subset/exclusion parity + catalog wiring tests.
- `cmd/promptgen` — `go run ./cmd/promptgen` regenerates dogfood; `-check` is the CI mode.
- `pkg/installstate/recommendations.go` — removes the now-misleading `add-prompts` recommendation; install summary no longer tells users to create files the installer just shipped.
- `pkg/scaffold/uninstall.go` — `.github/prompts` joins `.github/skills` / `.github/agents` in `atvDirectories` so uninstall cleans up.
- `test/sandbox/sandbox_test.go` — `hook7_prompt_shims` integration assertion: realistic guided install writes shims for selected layers and skips non-user-facing skills.
- `README.md`, `npm/README.md`, `docs/brainstorms/2026-03-11-...md` — document prompts as the 7th agentic primitive.
- `.github/prompts/*.prompt.md` — 18 dogfooded shims.

## Testing

```
go test ./...    # all green (pkg/scaffold, pkg/installstate, test/sandbox + everything else)
go vet ./...     # clean
```

New tests cover: shim builder happy path, hyphenated skill names, allow-list ⊆ shipped skills, allow-list ∪ deny-list = shipped skills, catalog inclusion (full + per-layer), catalog content equals builder output, no orphan dogfood files, sandbox-level integration of guided install.

Followed plan unit-by-unit with a red→green test cycle for each unit.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this change is pure file output during `atv-starterkit init`. Validation signal is the user-visible behavior change (ATV commands appear in the VS Code Copilot Chat slash picker after a fresh install). On regression, `go run ./cmd/promptgen -check` and the new parity tests will fail loudly in CI.

## Plan

`docs/plans/2026-04-30-001-feat-vscode-prompt-shims-plan.md` (status flipped to `completed`).

🤖 Compound Engineered with Claude Opus 4.7 via the ATV ce-work + ce-review pipeline.


---

## End-to-end install proof (sandbox repo)

Verified by building the binary, running `atv-starterkit init` in a fresh git repo, and capturing the resulting state. Source files live on branch [`proof/vscode-prompt-shims`](https://github.com/All-The-Vibes/ATV-StarterKit/tree/proof/vscode-prompt-shims/screenshots).

**1. Fresh repo before installer (no `.github/`)**

![before](https://raw.githubusercontent.com/All-The-Vibes/ATV-StarterKit/4c1b03c65c7ac5ae47f9d1f4bd40f8188ce2dd07/screenshots/screenshot-1-fresh-repo.png)

**2. Installer run — creates 109 files including `.github/prompts/`**

![installer](https://raw.githubusercontent.com/All-The-Vibes/ATV-StarterKit/4c1b03c65c7ac5ae47f9d1f4bd40f8188ce2dd07/screenshots/screenshot-2-installer-run.png)

**3. `.github/prompts/` contains exactly 18 shims (matches allow-list)**

![prompts dir](https://raw.githubusercontent.com/All-The-Vibes/ATV-StarterKit/4c1b03c65c7ac5ae47f9d1f4bd40f8188ce2dd07/screenshots/screenshot-3-prompts-listing.png)

**4. Sample shim contents — `mode: agent` front-matter + delegation to canonical `SKILL.md`**

![shim contents](https://raw.githubusercontent.com/All-The-Vibes/ATV-StarterKit/4c1b03c65c7ac5ae47f9d1f4bd40f8188ce2dd07/screenshots/screenshot-4-shim-contents.png)

**5. Sub-skills correctly excluded from the picker (`document-review`, `deepen-plan`, `brainstorming`, `feature-video`, `ralph-loop`, `slfg`, `test-browser`)**

![exclusions](https://raw.githubusercontent.com/All-The-Vibes/ATV-StarterKit/4c1b03c65c7ac5ae47f9d1f4bd40f8188ce2dd07/screenshots/screenshot-5-exclusions.png)
