### PR TITLE
fix(skills): strip remaining CLAUDE.md references from land/takeoff mirrors

### DIFF
--- a/.github/skills/land/SKILL.md
+++ b/.github/skills/land/SKILL.md
@@ -215,4 +215,4 @@ These are non-negotiable when `/land` is invoked:
 
 ## Project-specific considerations
 
-Some repos have local conventions layered on top of this protocol — read `CLAUDE.md` and `AGENTS.md` at the repo root for project-specific rules (e.g., branch protection, PR comment workflows, backlog linkage requirements). Project rules override these defaults where they conflict.
+Some repos have local conventions layered on top of this protocol — read `AGENTS.md` at the repo root for project-specific rules (e.g., branch protection, PR comment workflows, backlog linkage requirements). Project rules override these defaults where they conflict.

--- a/.github/skills/takeoff/SKILL.md
+++ b/.github/skills/takeoff/SKILL.md
@@ -140,7 +140,7 @@ Emit the output directly as markdown in your final response — no code fences, 
 ⚪ LOW / Housekeeping
 
 - NEBULA-35 — Enforce backlog.md usage via MCP server and hooks
-- NEBULA-39 — Document backlog-first workflow in AGENTS.md / CLAUDE.md
+- NEBULA-39 — Document backlog-first workflow in AGENTS.md
 
 ### Recommendation
 Start with **AGENTSAPI-1**. It's the next unblocked HIGH-priority item and clears the path for 2 more.

--- a/pkg/scaffold/templates/skills/land/SKILL.md
+++ b/pkg/scaffold/templates/skills/land/SKILL.md
@@ -215,4 +215,4 @@ These are non-negotiable when `/land` is invoked:
 
 ## Project-specific considerations
 
-Some repos have local conventions layered on top of this protocol — read `CLAUDE.md` and `AGENTS.md` at the repo root for project-specific rules (e.g., branch protection, PR comment workflows, backlog linkage requirements). Project rules override these defaults where they conflict.
+Some repos have local conventions layered on top of this protocol — read `AGENTS.md` at the repo root for project-specific rules (e.g., branch protection, PR comment workflows, backlog linkage requirements). Project rules override these defaults where they conflict.

--- a/pkg/scaffold/templates/skills/takeoff/SKILL.md
+++ b/pkg/scaffold/templates/skills/takeoff/SKILL.md
@@ -140,7 +140,7 @@ Emit the output directly as markdown in your final response — no code fences, 
 ⚪ LOW / Housekeeping
 
 - NEBULA-35 — Enforce backlog.md usage via MCP server and hooks
-- NEBULA-39 — Document backlog-first workflow in AGENTS.md / CLAUDE.md
+- NEBULA-39 — Document backlog-first workflow in AGENTS.md
 
 ### Recommendation
 Start with **AGENTSAPI-1**. It's the next unblocked HIGH-priority item and clears the path for 2 more.

--- a/plugins/atv-everything/skills/land/SKILL.md
+++ b/plugins/atv-everything/skills/land/SKILL.md
@@ -215,4 +215,4 @@ These are non-negotiable when `/land` is invoked:
 
 ## Project-specific considerations
 
-Some repos have local conventions layered on top of this protocol — read `CLAUDE.md` and `AGENTS.md` at the repo root for project-specific rules (e.g., branch protection, PR comment workflows, backlog linkage requirements). Project rules override these defaults where they conflict.
+Some repos have local conventions layered on top of this protocol — read `AGENTS.md` at the repo root for project-specific rules (e.g., branch protection, PR comment workflows, backlog linkage requirements). Project rules override these defaults where they conflict.

--- a/plugins/atv-everything/skills/takeoff/SKILL.md
+++ b/plugins/atv-everything/skills/takeoff/SKILL.md
@@ -140,7 +140,7 @@ Emit the output directly as markdown in your final response — no code fences, 
 ⚪ LOW / Housekeeping
 
 - NEBULA-35 — Enforce backlog.md usage via MCP server and hooks
-- NEBULA-39 — Document backlog-first workflow in AGENTS.md / CLAUDE.md
+- NEBULA-39 — Document backlog-first workflow in AGENTS.md
 
 ### Recommendation
 Start with **AGENTSAPI-1**. It's the next unblocked HIGH-priority item and clears the path for 2 more.

--- a/plugins/atv-pack-shipping/skills/land/SKILL.md
+++ b/plugins/atv-pack-shipping/skills/land/SKILL.md
@@ -215,4 +215,4 @@ These are non-negotiable when `/land` is invoked:
 
 ## Project-specific considerations
 
-Some repos have local conventions layered on top of this protocol — read `CLAUDE.md` and `AGENTS.md` at the repo root for project-specific rules (e.g., branch protection, PR comment workflows, backlog linkage requirements). Project rules override these defaults where they conflict.
+Some repos have local conventions layered on top of this protocol — read `AGENTS.md` at the repo root for project-specific rules (e.g., branch protection, PR comment workflows, backlog linkage requirements). Project rules override these defaults where they conflict.

--- a/plugins/atv-pack-shipping/skills/takeoff/SKILL.md
+++ b/plugins/atv-pack-shipping/skills/takeoff/SKILL.md
@@ -140,7 +140,7 @@ Emit the output directly as markdown in your final response — no code fences, 
 ⚪ LOW / Housekeeping
 
 - NEBULA-35 — Enforce backlog.md usage via MCP server and hooks
-- NEBULA-39 — Document backlog-first workflow in AGENTS.md / CLAUDE.md
+- NEBULA-39 — Document backlog-first workflow in AGENTS.md
 
 ### Recommendation
 Start with **AGENTSAPI-1**. It's the next unblocked HIGH-priority item and clears the path for 2 more.

--- a/plugins/atv-skill-land/skills/land/SKILL.md
+++ b/plugins/atv-skill-land/skills/land/SKILL.md
@@ -215,4 +215,4 @@ These are non-negotiable when `/land` is invoked:
 
 ## Project-specific considerations
 
-Some repos have local conventions layered on top of this protocol — read `CLAUDE.md` and `AGENTS.md` at the repo root for project-specific rules (e.g., branch protection, PR comment workflows, backlog linkage requirements). Project rules override these defaults where they conflict.
+Some repos have local conventions layered on top of this protocol — read `AGENTS.md` at the repo root for project-specific rules (e.g., branch protection, PR comment workflows, backlog linkage requirements). Project rules override these defaults where they conflict.

--- a/plugins/atv-skill-takeoff/skills/takeoff/SKILL.md
+++ b/plugins/atv-skill-takeoff/skills/takeoff/SKILL.md
@@ -140,7 +140,7 @@ Emit the output directly as markdown in your final response — no code fences, 
 ⚪ LOW / Housekeeping
 
 - NEBULA-35 — Enforce backlog.md usage via MCP server and hooks
-- NEBULA-39 — Document backlog-first workflow in AGENTS.md / CLAUDE.md
+- NEBULA-39 — Document backlog-first workflow in AGENTS.md
 
 ### Recommendation
 Start with **AGENTSAPI-1**. It's the next unblocked HIGH-priority item and clears the path for 2 more.


### PR DESCRIPTION
## Summary
- Restores green CI on \`main\` — run [25631840125](https://github.com/All-The-Vibes/ATV-StarterKit/actions/runs/25631840125) failed \`TestNoClaudeCodeReferencesInSkills\` after PR #42 merged.
- Two CLAUDE.md mentions slipped through the PR #42 sync of \`land\` / \`takeoff\` skills:
  - \`land/SKILL.md\` L218 — protocol handoff sentence trimmed from "read \`CLAUDE.md\` and \`AGENTS.md\`" → "read \`AGENTS.md\`".
  - \`takeoff/SKILL.md\` L143 — NEBULA-39 backlog line trimmed from "AGENTS.md / CLAUDE.md" → "AGENTS.md".
- Applied uniformly across all 5 mirrors of each file: \`.github/skills/\`, \`pkg/scaffold/templates/skills/\`, \`plugins/atv-everything/\`, \`plugins/atv-pack-shipping/\`, and \`plugins/atv-skill-{land,takeoff}/\` (10 files total, 1 line each).
- ATV is a GitHub Copilot harness; the guard test added in PR #43 enforces this policy.

## Test plan
- [x] \`go test ./pkg/scaffold/ -run TestNoClaudeCodeReferencesInSkills -v\` → PASS
- [x] \`go build ./...\` → clean
- [x] \`go test ./...\` → all packages pass (scaffold, sdk, tui, sandbox, gstack, plugingen, etc.)
- [ ] CI green on PR

## Notes
- This is the natural drift problem flagged in the prior session: the same line lives in 5 mirrored locations. A future \`make sync-skills\` target (or a generator) would prevent the next round of this.