### PR TITLE
feat: expand unslop cleanup workflow

### DIFF
--- a/.github/prompts/unslop.prompt.md
+++ b/.github/prompts/unslop.prompt.md
@@ -3,6 +3,6 @@ mode: agent
 description: Run the unslop skill
 ---
 
-Invoke the `unslop` skill defined at `.github/skills/unslop/SKILL.md` and follow its instructions.
+Invoke the installed `unslop` skill and follow its instructions.
 
 Forward any arguments or context the user provided in this message verbatim to the skill.

--- a/README.md
+++ b/README.md
@@ -252,7 +252,10 @@ plan → deepen → work (swarm) ──→ review    ⎤              resolve �
                                   unslop   ⎦
 ```
 
-`unslop fix` removes AI slop after review. `compound` saves learnings for future `ce-plan` runs.
+`/unslop` reports code hygiene, comments/docs, frontend/design, and architecture slop.
+`/unslop fix` applies safe hygiene and comments/docs cleanup.
+`/unslop fix all` applies high-priority eligible fixes across all lanes.
+`compound` saves learnings for future `ce-plan` runs.
 
 ### `/autoresearch` — hill-climb against a metric
 

--- a/docs/plans/2026-05-16-001-feat-unslop-v2-full-surface-cleanup-plan.md
+++ b/docs/plans/2026-05-16-001-feat-unslop-v2-full-surface-cleanup-plan.md
@@ -1,0 +1,716 @@
+---
+title: "feat: unslop v2 full-surface cleanup workflow"
+type: feat
+status: active
+date: 2026-05-16
+---
+
+# feat: unslop v2 full-surface cleanup workflow
+
+## Summary
+
+Upgrade `/unslop` from a three-pass slop detector into a full-surface cleanup workflow. The default command reports every slop lane: code hygiene, comments/docs, frontend/design, and codebase architecture. Fix mode stays safe by default, while `fix all` applies high-priority auto-fix-eligible fixes across all lanes.
+
+The architecture lane should borrow Matt Pocock's "improve codebase architecture" framing: find deepening candidates, evaluate module depth, seam placement, locality, leverage, interface shape, fake adapters, and testability. ATV keeps its existing strengths: comment cleanup, code hygiene cleanup, and frontend design slop detection.
+
+---
+
+## Problem Frame
+
+Current `/unslop` is useful, but narrow:
+
+- It reports code slop, comment rot, and design slop.
+- `fix` only handles low-risk code/comment cleanup.
+- It does not report architecture slop as a first-class lane.
+- It does not expose priority/risk/effort in the report.
+- It does not have a complete forgiving command contract for slash-command usage.
+
+The new product direction:
+
+- `/unslop` should be the broad X-ray across all slop surfaces.
+- `/unslop fix` should stay conservative.
+- `/unslop fix all` and `/unslop fix --all` should apply high-priority auto-fix-eligible fixes across code hygiene, comments/docs, architecture, and frontend/design.
+- Users can scope fixes by lane, priority, path, and candidate ID.
+
+---
+
+## Requirements
+
+- R1. `/unslop` produces a full read-only report across four lanes:
+  - code hygiene
+  - comments/docs
+  - frontend/design
+  - architecture
+- R2. Every finding includes:
+  - stable ID
+  - lane
+  - file and line where possible
+  - finding
+  - priority: high, medium, low
+  - risk: low, medium, high
+  - effort: small, medium, large
+  - auto-fix eligibility
+  - suggested next command
+- R3. `/unslop fix` applies only safe code hygiene and comments/docs fixes.
+- R4. `/unslop fix all` and `/unslop fix --all` apply high-priority auto-fix-eligible fixes across all four lanes.
+- R5. Lane-specific fixes work with both flag and natural slash-command token forms:
+  - `/unslop fix architecture`
+  - `/unslop fix --architecture`
+  - `/unslop fix frontend medium`
+  - `/unslop fix --frontend --medium`
+- R6. Priority selectors are exact, not cumulative:
+  - no priority token means high
+  - `medium` means medium only
+  - `low` means low only
+  - `high` means high only
+- R7. Multiple lane selectors are rejected unless the user chose `all`.
+- R8. Path scope is supported for reports and fixes:
+  - `/unslop src/auth`
+  - `/unslop fix architecture src/auth`
+  - `/unslop fix all app/components`
+- R9. Candidate ID scope is supported:
+  - `/unslop fix architecture A1`
+  - `/unslop fix frontend F2,F4`
+- R10. Architecture reporting uses Matt-style deepening language:
+  - module
+  - interface
+  - implementation
+  - depth
+  - seam
+  - adapter
+  - leverage
+  - locality
+  - test surface
+- R11. Architecture fixes are only auto-fix eligible when scoped, testable, and low enough risk.
+- R12. Frontend fixes are only auto-fix eligible when visual behavior can be verified or the change is clearly mechanical, such as missing focus/hover state additions that follow existing conventions.
+- R13. The skill documentation and duplicated plugin/template copies remain in sync.
+- R14. Existing Go tests and scaffold parity tests continue to pass.
+
+---
+
+## Current Repo Surfaces
+
+### Skill copies that must stay in sync
+
+- `pkg/scaffold/templates/skills/unslop/SKILL.md`
+- `plugins/atv-skill-unslop/skills/unslop/SKILL.md`
+- `plugins/atv-pack-quality/skills/unslop/SKILL.md`
+- `plugins/atv-everything/skills/unslop/SKILL.md`
+
+These copies currently have the same SHA-256 hash. Edit the scaffold template first, then mirror the exact content to plugin copies.
+
+### Prompt shim
+
+- `.github/prompts/unslop.prompt.md`
+
+Current issue noticed during planning: this prompt says to invoke `.github/skills/unslop/SKILL.md`, but this checkout does not contain `.github/skills/unslop/SKILL.md`. Fix or clarify the prompt shim as part of this work so it points at the actual installed skill surface or uses harness-neutral "invoke the unslop skill" wording without a missing path.
+
+### Pipeline references
+
+- `plugins/atv-skill-lfg/skills/lfg/SKILL.md`
+- `plugins/atv-pack-shipping/skills/lfg/SKILL.md`
+- `plugins/atv-pack-shipping/skills/slfg/SKILL.md`
+- `README.md`
+- `docs/marketplace.md`
+- `.github/plugin/marketplace.json`
+
+These references should be updated only where the command semantics changed.
+
+---
+
+## Command Contract
+
+### Reports
+
+```text
+/unslop
+```
+
+Full report across all four lanes.
+
+```text
+/unslop frontend
+/unslop --frontend
+/unslop architecture
+/unslop --architecture
+/unslop comments
+/unslop --comments
+/unslop hygiene
+/unslop --hygiene
+```
+
+Filtered report for one lane.
+
+### Fixes
+
+```text
+/unslop fix
+```
+
+Safe default. Applies safe code hygiene and comments/docs fixes only.
+
+```text
+/unslop fix all
+/unslop fix --all
+```
+
+High-priority, auto-fix-eligible fixes across all four lanes:
+
+- code hygiene
+- comments/docs
+- frontend/design
+- architecture
+
+```text
+/unslop fix architecture
+/unslop fix --architecture
+```
+
+High-priority, auto-fix-eligible architecture fixes only.
+
+```text
+/unslop fix architecture medium
+/unslop fix --architecture --medium
+```
+
+Medium-priority, auto-fix-eligible architecture fixes only.
+
+```text
+/unslop fix architecture low
+/unslop fix --architecture --low
+```
+
+Low-priority, auto-fix-eligible architecture fixes only.
+
+```text
+/unslop fix frontend
+/unslop fix --frontend
+/unslop fix frontend medium
+/unslop fix --frontend --medium
+/unslop fix frontend low
+/unslop fix --frontend --low
+```
+
+Frontend/design equivalents.
+
+```text
+/unslop fix comments
+/unslop fix --comments
+/unslop fix hygiene
+/unslop fix --hygiene
+```
+
+Narrow safe cleanup lanes.
+
+### Aliases
+
+Treat these as equivalent:
+
+| Canonical | Aliases |
+|-----------|---------|
+| `all` | `--all` |
+| `architecture` | `--architecture`, `arch` |
+| `frontend` | `--frontend`, `front-end`, `design` |
+| `comments` | `--comments`, `comment`, `docs`, `documentation` |
+| `hygiene` | `--hygiene`, `code-hygiene` |
+| `high` | `--high` |
+| `medium` | `--medium` |
+| `low` | `--low` |
+| `dry-run` | `--dry-run`, `preview` |
+
+### Rejected combinations
+
+Reject multiple judgment lanes in one command:
+
+```text
+/unslop fix frontend architecture
+/unslop fix --frontend --architecture
+```
+
+Return:
+
+```text
+Choose one lane, or use all.
+
+Examples:
+- /unslop fix frontend
+- /unslop fix architecture
+- /unslop fix all
+```
+
+Do not support a lane-local `--all` meaning "all priorities" in v2. `all` means all lanes with high-priority eligible fixes. If all-priority lane cleanup is needed later, add a new unambiguous token such as `all-priorities`.
+
+---
+
+## Report Format
+
+```markdown
+# /unslop Report
+
+Scope: changed files since origin/main
+Fix default: safe hygiene + comments only
+Fix all: high-priority eligible fixes across all lanes
+
+## Executive Summary
+
+| Lane | Findings | High | Medium | Low | Auto-fix eligible | Recommended next |
+|------|----------|------|--------|-----|-------------------|------------------|
+| Hygiene | 4 | 1 | 2 | 1 | 3 | /unslop fix hygiene |
+| Comments/docs | 8 | 2 | 4 | 2 | 7 | /unslop fix comments |
+| Frontend/design | 3 | 1 | 2 | 0 | 1 | /unslop fix frontend |
+| Architecture | 3 | 1 | 1 | 1 | 1 | /unslop fix architecture |
+
+## Findings
+
+| ID | Lane | File | Finding | Priority | Risk | Effort | Auto-fix | Next command |
+|----|------|------|---------|----------|------|--------|----------|--------------|
+| H1 | Hygiene | src/foo.ts:42 | Dead helper never used | High | Low | Small | Yes | /unslop fix hygiene H1 |
+| C1 | Comments | src/foo.ts:12 | Comment restates function name | Low | Low | Small | Yes | /unslop fix comments C1 |
+| F1 | Frontend | app/card.tsx:70 | Generic card grid lacks hierarchy | High | Medium | Medium | Yes | /unslop fix frontend F1 |
+| A1 | Architecture | src/session.ts | Session rules leak into 4 callers | High | Medium | Medium | Yes | /unslop fix architecture A1 |
+```
+
+### ID prefixes
+
+- `H` for hygiene
+- `C` for comments/docs
+- `F` for frontend/design
+- `A` for architecture
+
+---
+
+## Architecture Lane Design
+
+### Architecture detector prompts
+
+Add a fourth analysis pass: Architecture Slop Detector.
+
+It should report deepening candidates, not generic refactor complaints.
+
+Detect:
+
+- shallow modules where the interface is nearly as complex as the implementation
+- pass-through wrappers that hide nothing
+- fake adapters with one implementation and no real seam
+- caller knowledge leakage
+- duplicated orchestration across call sites
+- interfaces that expose implementation detail
+- frontend components whose props mirror internals instead of product concepts
+- tests that mock internals instead of exercising a stable public interface
+- modules that fail the deletion test
+
+### Matt-style candidate output
+
+```json
+{
+  "pass": "architecture-slop",
+  "findings": [
+    {
+      "id": "A1",
+      "files": ["src/auth/session.ts", "src/auth/cookies.ts"],
+      "problem": "Callers must know cookie parsing order and session fallback behavior.",
+      "proposed_fix": "Create a deeper Session interface that owns load, refresh, and clear behavior.",
+      "deepening": {
+        "depth": "Callers stop coordinating cookie and session details.",
+        "locality": "Session rules move into one module.",
+        "leverage": "Four callers shrink to one stable interface.",
+        "test_surface": "Tests can exercise session behavior through the public interface."
+      },
+      "priority": "high",
+      "risk": "medium",
+      "effort": "medium",
+      "auto_fix_eligible": true,
+      "verification": ["targeted unit tests for session load/refresh/clear", "existing auth tests"]
+    }
+  ]
+}
+```
+
+### Architecture auto-fix eligibility
+
+An architecture finding is auto-fix eligible only when all are true:
+
+- priority matches the requested priority selector
+- risk is low or medium
+- effort is small or medium
+- affected files are inside the requested scope
+- behavior can be locked by existing tests or a narrow new test
+- the fix reduces caller knowledge or removes a fake seam without changing product behavior
+- the skill can name the exact verification commands before editing
+
+High-risk or large architecture findings must stay report-only and point users to a candidate workflow.
+
+---
+
+## Frontend Lane Design
+
+Frontend/design findings remain part of default `/unslop`.
+
+Detect:
+
+- generic card grids with no hierarchy
+- purple/blue default gradients without brand rationale
+- missing hover/focus/active states
+- generic emoji badges and redundant eyebrow/title/description stacks
+- design-system bypasses
+- overly uniform radius/shadow treatment
+- layout rhythm that feels template-generated
+- component props that expose internals rather than product concepts
+
+Frontend auto-fix eligibility requires one of:
+
+- purely mechanical accessibility/design-system cleanup
+- existing design-system convention clearly dictates the change
+- screenshot/browser verification is possible and included in the fix report
+
+If visual verification is not possible, skip the finding and report the reason.
+
+---
+
+## Fix Workflow
+
+```text
+parse arguments
+  -> determine report or fix mode
+  -> determine lane selector or all lanes
+  -> determine priority selector, default high for lane/all fixes
+  -> determine path scope
+  -> determine candidate IDs
+  -> reject conflicting lanes
+
+determine scope
+  -> default changed files since merge-base
+  -> or explicit files/directories
+
+run report passes
+  -> hygiene
+  -> comments/docs
+  -> frontend/design when UI files are present
+  -> architecture
+
+merge findings
+  -> assign stable IDs
+  -> score priority/risk/effort
+  -> determine auto-fix eligibility
+
+if report mode
+  -> print full report
+
+if fix mode
+  -> select eligible findings
+  -> produce cleanup plan
+  -> run behavior lock checks or name manual verification
+  -> apply fixes one lane at a time
+  -> run targeted verification after each lane
+  -> report changed files, simplifications, verification, skipped findings, remaining risks
+```
+
+ASCII flow:
+
+```text
+          /unslop args
+               |
+          parse tokens
+               |
+      +--------+---------+
+      |                  |
+   report              fix
+      |                  |
+ run all selected    run report first
+ analysis passes        |
+      |             select eligible
+ print ranked report    |
+                    behavior lock
+                         |
+                    apply lane fixes
+                         |
+                    verify and report
+```
+
+---
+
+## Implementation Units
+
+### U1. Rewrite argument parsing and command contract in the skill doc
+
+**Goal:** Make the command grammar explicit and forgiving.
+
+**Files:**
+
+- Modify: `pkg/scaffold/templates/skills/unslop/SKILL.md`
+- Mirror to:
+  - `plugins/atv-skill-unslop/skills/unslop/SKILL.md`
+  - `plugins/atv-pack-quality/skills/unslop/SKILL.md`
+  - `plugins/atv-everything/skills/unslop/SKILL.md`
+
+**Approach:**
+
+- Replace the current three-token table with the v2 command contract.
+- Add alias table.
+- Add conflict and rejection rules.
+- Add priority selector semantics.
+- Add path and candidate ID rules.
+
+**Verification:**
+
+- Manual read-through confirms every example command resolves to one parse outcome.
+- No command uses `all` with two meanings.
+
+### U2. Add the architecture lane
+
+**Goal:** Add a fourth analysis pass using Matt-style deepening candidates.
+
+**Files:**
+
+- Modify all `unslop/SKILL.md` copies listed in U1.
+
+**Approach:**
+
+- Add "Architecture Slop Detector" alongside existing code/comment/design passes.
+- Define candidate JSON schema.
+- Add architecture smell checklist.
+- Add auto-fix eligibility gate.
+- Add skip rules for high-risk or large architecture candidates.
+
+**Verification:**
+
+- A reader can distinguish architecture findings from hygiene findings.
+- Every architecture finding has priority/risk/effort and a verification path.
+
+### U3. Upgrade the report format
+
+**Goal:** Make `/unslop` a decision surface, not a lint dump.
+
+**Files:**
+
+- Modify all `unslop/SKILL.md` copies.
+
+**Approach:**
+
+- Add executive summary table.
+- Add unified finding table.
+- Add lane-specific detail sections.
+- Require stable IDs.
+- Require "skipped, not eligible" sections for fix mode.
+
+**Verification:**
+
+- Report format shows impact/risk/effort at a glance.
+- Report includes next command for every finding.
+
+### U4. Define fix selection and execution rules
+
+**Goal:** Make mutation safe and predictable.
+
+**Files:**
+
+- Modify all `unslop/SKILL.md` copies.
+
+**Approach:**
+
+- Define `/unslop fix` safe default.
+- Define `/unslop fix all` and `/unslop fix --all`.
+- Define lane-specific priority behavior.
+- Add cleanup plan before edits.
+- Add verification after each lane.
+- Add dry-run/preview support.
+
+**Verification:**
+
+- `/unslop fix` cannot change frontend or architecture.
+- `/unslop fix all` can change frontend and architecture, but only high-priority auto-fix-eligible findings.
+- Multiple lanes without `all` are rejected.
+
+### U5. Fix the prompt shim
+
+**Goal:** Remove the missing `.github/skills/unslop/SKILL.md` path reference.
+
+**Files:**
+
+- Modify: `.github/prompts/unslop.prompt.md`
+
+**Approach:**
+
+- Replace the brittle path instruction with harness-neutral wording:
+  - "Invoke the installed `unslop` skill and forward arguments verbatim."
+- If the harness requires a path, point to a real repo path or document that the prompt assumes installed skill availability.
+
+**Verification:**
+
+- No prompt references a missing `.github/skills/unslop/SKILL.md` path.
+
+### U6. Update pipeline docs and README references
+
+**Goal:** Keep user-facing docs aligned with new semantics.
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `docs/marketplace.md` if needed
+- Modify: `plugins/atv-skill-lfg/skills/lfg/SKILL.md` if the intended LFG behavior changes
+- Modify: `plugins/atv-pack-shipping/skills/lfg/SKILL.md` if needed
+- Modify: `plugins/atv-pack-shipping/skills/slfg/SKILL.md` if needed
+
+**Approach:**
+
+- README should explain:
+  - `/unslop` reports all lanes.
+  - `/unslop fix` safe cleanup.
+  - `/unslop fix all` high-priority eligible cleanup across all lanes.
+  - lane filters and priority examples.
+- Leave LFG using `/unslop fix` unless we explicitly want the autonomous pipeline to mutate frontend and architecture by default.
+
+**Recommendation:** keep LFG on `/unslop fix` for v2. Do not silently expand autonomous shipping pipelines to architecture/frontend changes. Let users opt into `/unslop fix all` manually.
+
+**Verification:**
+
+- README examples match the skill's command contract.
+- LFG semantics are intentionally documented.
+
+### U7. Add or update tests
+
+**Goal:** Protect skill sync and command documentation.
+
+**Files:**
+
+- Modify or add Go tests under `pkg/scaffold/` only if existing tests do not catch drift.
+
+**Approach:**
+
+- Run existing tests first:
+  - `go test ./...`
+- If parity already ensures skill copies, no new test required.
+- If not, add a narrow parity test that asserts all unslop copies match the template.
+- Add a prompt-shim path test only if prompt paths are already tested elsewhere. Otherwise keep verification manual.
+
+**Verification:**
+
+- `go test ./...`
+- `git diff --check`
+- `grep -RIn ".github/skills/unslop/SKILL.md" .github/prompts README.md docs plugins pkg || true`
+
+---
+
+## Test Plan
+
+### Static verification
+
+```bash
+go test ./...
+git diff --check
+```
+
+### Skill copy parity
+
+```bash
+sha256sum \
+  pkg/scaffold/templates/skills/unslop/SKILL.md \
+  plugins/atv-skill-unslop/skills/unslop/SKILL.md \
+  plugins/atv-pack-quality/skills/unslop/SKILL.md \
+  plugins/atv-everything/skills/unslop/SKILL.md
+```
+
+All four hashes should match.
+
+### Command contract smoke matrix
+
+Manually inspect the skill logic against these cases:
+
+| Command | Expected behavior |
+|---------|-------------------|
+| `/unslop` | full report, no edits |
+| `/unslop frontend` | frontend report only |
+| `/unslop architecture` | architecture report only |
+| `/unslop fix` | safe hygiene + comments only |
+| `/unslop fix all` | high-priority eligible fixes across all lanes |
+| `/unslop fix --all` | same as `fix all` |
+| `/unslop fix architecture` | high-priority eligible architecture only |
+| `/unslop fix architecture medium` | medium-priority eligible architecture only |
+| `/unslop fix frontend low` | low-priority eligible frontend only |
+| `/unslop fix frontend architecture` | reject with choose-one-lane message |
+| `/unslop fix all src/components` | high-priority eligible fixes across all lanes inside path scope |
+| `/unslop fix architecture A1` | only architecture candidate A1 |
+
+### Regression checks
+
+- Verify `/lfg` still references `/unslop fix`.
+- Verify `/slfg` read-only parallel report still uses `/unslop`.
+- Verify `/slfg` sequential cleanup still uses `/unslop fix` unless intentionally changed.
+- Verify README command examples do not imply `/unslop fix` mutates architecture/frontend.
+
+---
+
+## Failure Modes
+
+| Failure mode | Impact | Mitigation |
+|--------------|--------|------------|
+| `all` means two different things | User surprises and unsafe cleanup | Reserve `all` for all lanes high-priority eligible fixes only. |
+| Architecture auto-fix changes behavior | Broken app after cleanup | Require auto-fix eligibility, behavior lock, verification, and skip high-risk candidates. |
+| Frontend auto-fix changes visual intent | UI gets worse while "cleaning" | Require visual verification or clear design-system convention. |
+| Prompt shim points to missing path | `/unslop` prompt fails or confuses agent | Fix `.github/prompts/unslop.prompt.md`. |
+| Skill copies drift | Installed plugin behaves differently than scaffold | Edit template first, mirror copies, verify hashes and tests. |
+| LFG becomes too aggressive | Autonomous shipping mutates design/architecture unexpectedly | Keep LFG on `/unslop fix`, not `/unslop fix all`, for v2. |
+
+---
+
+## NOT in Scope
+
+- Building a separate `architecture` skill. This plan keeps architecture inside `/unslop` as a lane.
+- Importing Matt Pocock's skill verbatim. This plan adapts the framework into ATV's slash-command workflow.
+- Adding a runtime parser implementation outside `SKILL.md`. The current skill is instruction-driven, so v2 updates the skill contract and examples.
+- Changing all autonomous pipelines to run `/unslop fix all`. That is too aggressive for default shipping.
+- Supporting lane-local "all priorities" in v2. Add `all-priorities` later if users need it.
+
+---
+
+## What Already Exists
+
+- Existing `/unslop` skill already has code slop, comment rot, and design slop detector prompts.
+- Existing `/unslop fix` already has safe auto-fix language for comments and code hygiene.
+- Existing LFG and SLFG pipelines already call `/unslop` and `/unslop fix`.
+- Existing scaffold parity tests likely catch broad skill-surface drift.
+- Existing README already positions `/unslop` as part of the quality workflow.
+
+---
+
+## Open Decisions
+
+### OD1. Should `/lfg` ever use `/unslop fix all`?
+
+Recommendation: no for v2. Keep autonomous pipelines conservative. Users can manually run `/unslop fix all` after seeing the report.
+
+### OD2. Should skipped architecture findings route to a future `/unslop architecture design A1` command?
+
+Recommendation: not in v2. Use next-command copy in the report, but do not add a new command branch until we see demand.
+
+### OD3. Should frontend auto-fix require browser access every time?
+
+Recommendation: no. Require browser/screenshot verification only when the change affects visual layout, hierarchy, or styling beyond a mechanical accessibility/design-system fix.
+
+---
+
+## Worktree Parallelization Strategy
+
+Sequential implementation is safer. Most units touch the same primary file, `unslop/SKILL.md`, across multiple mirrored copies. Parallel work would create avoidable merge conflicts.
+
+Suggested order:
+
+1. U1 through U4 in the scaffold template.
+2. Mirror template to plugin copies.
+3. U5 prompt shim.
+4. U6 docs and pipeline references.
+5. U7 tests and verification.
+
+---
+
+## Completion Criteria
+
+- `/unslop` docs describe a full four-lane report.
+- `/unslop fix` remains conservative.
+- `/unslop fix all` and `/unslop fix --all` are documented aliases.
+- Architecture lane uses deepening candidate language and eligibility gates.
+- Frontend lane has explicit verification rules.
+- Prompt shim no longer points to a missing path.
+- All unslop copies match.
+- `go test ./...` passes.
+- README examples match the final command contract.

--- a/pkg/scaffold/prompts.go
+++ b/pkg/scaffold/prompts.go
@@ -90,6 +90,22 @@ Forward any arguments or context the user provided in this message verbatim to t
 // The output is byte-for-byte deterministic so it can be parity-checked
 // against dogfooded copies under .github/prompts/.
 func BuildPromptShim(skillName string) []byte {
+	if skillName == "unslop" {
+		// unslop ships as an installer template and plugin skill, not as a
+		// dogfooded .github/skills/unslop/ directory in this repo. The generic
+		// shim path would point at a missing SKILL.md, so delegate to the
+		// installed skill by name instead.
+		return []byte(`---
+mode: agent
+description: Run the unslop skill
+---
+
+Invoke the installed ` + "`unslop`" + ` skill and follow its instructions.
+
+Forward any arguments or context the user provided in this message verbatim to the skill.
+`)
+	}
+
 	tmpl, err := template.New("prompt-shim").Parse(promptShimTemplate)
 	if err != nil {
 		panic(fmt.Sprintf("prompt shim template invalid: %v", err))

--- a/pkg/scaffold/templates/skills/unslop/SKILL.md
+++ b/pkg/scaffold/templates/skills/unslop/SKILL.md
@@ -1,341 +1,548 @@
 ---
 name: unslop
-description: "Unified de-slop pass: code simplification + comment rot detection + design slop check. Run after completing features or before PRs to strip AI-generated generic patterns."
-argument-hint: "[blank for recent changes, or file/directory path]"
+description: "Full-surface de-slop workflow: code hygiene, comments/docs, frontend/design, and architecture. Reports everything by default; fixes safe hygiene by default; `fix all` applies high-priority auto-fix-eligible fixes across all lanes."
+argument-hint: "[fix] [all|hygiene|comments|frontend|architecture] [high|medium|low] [candidate IDs or file/directory paths]"
 ---
 
-# /unslop — Strip AI Slop from Your Codebase
+# /unslop - Full-Surface AI Slop Cleanup
 
-Three parallel analysis passes that detect and report AI-generated "slop" — generic, template-looking, over-enthusiastic output that makes code, comments, and UI feel artificial.
+`/unslop` is the broad X-ray for AI-generated slop. It reports every surface where AI-assisted work tends to leave cheapness behind: **code hygiene**, **comments/docs**, **frontend/design**, and **architecture**.
+
+Default behavior is safe:
+
+- `/unslop` reports across all four lanes and does not edit.
+- `/unslop fix` edits only safe code hygiene and comments/docs issues.
+- `/unslop fix all` and `/unslop fix --all` apply **high-priority, auto-fix-eligible fixes across all four lanes**.
+
+Architecture and frontend fixes are allowed only when they pass explicit eligibility gates. Priority selects importance. Eligibility selects safety. Scope selects where edits are allowed.
 
 ## When to Use
 
-- After completing a feature — check for slop before PR
-- Before code review — pre-clean your changes
-- When code "feels AI-generated" but you can't pinpoint why
-- Periodic codebase hygiene — run on a directory
-- After a long AI-assisted session to audit quality
+Use `/unslop` when:
 
-## Argument Parsing
+- a feature works but feels bloated, repetitive, generic, over-commented, or over-abstracted
+- recent AI-assisted work left dead code, filler comments, stale docs, wrapper layers, weak seams, or generic UI
+- a PR needs a quality pass before review
+- you want a ranked cleanup report with priority, risk, effort, and next commands
+- you want high-priority eligible cleanup via `/unslop fix all`
 
-Parse `$ARGUMENTS` for these tokens:
+## When Not to Use
 
-| Token | Example | Effect |
-|-------|---------|--------|
-| `fix` | `/unslop fix` | Auto-apply safe fixes after reporting |
-| `<path>` | `/unslop src/components/` | Scope to specific file or directory |
-| (none) | `/unslop` | Analyze all files changed since the base branch |
+Do not use `/unslop` when:
+
+- the main task is a new feature or behavior change
+- desired behavior is unclear and cannot be protected by tests or a concrete verification plan
+- the user wants a broad redesign rather than an incremental cleanup pass
+- the request is only formatting or lint trivia
+- the cleanup would require product decisions the user has not made
+
+## Command Contract
+
+The parser should be forgiving. This is a slash-command skill, not a strict Unix binary. Accept flag forms and natural token forms.
+
+### Report Commands
+
+| Command | Behavior |
+|---------|----------|
+| `/unslop` | Full read-only report across all lanes |
+| `/unslop hygiene` or `/unslop --hygiene` | Code hygiene report only |
+| `/unslop comments` or `/unslop --comments` | Comments/docs report only |
+| `/unslop frontend` or `/unslop --frontend` | Frontend/design report only |
+| `/unslop architecture` or `/unslop --architecture` | Architecture report only |
+| `/unslop src/auth` | Full report scoped to a path |
+
+### Fix Commands
+
+| Command | Behavior |
+|---------|----------|
+| `/unslop fix` | Safe default: code hygiene + comments/docs only |
+| `/unslop fix all` or `/unslop fix --all` | High-priority, auto-fix-eligible fixes across all four lanes |
+| `/unslop fix hygiene` or `/unslop fix --hygiene` | High-priority eligible code hygiene fixes only |
+| `/unslop fix comments` or `/unslop fix --comments` | High-priority eligible comments/docs fixes only |
+| `/unslop fix frontend` or `/unslop fix --frontend` | High-priority eligible frontend/design fixes only |
+| `/unslop fix architecture` or `/unslop fix --architecture` | High-priority eligible architecture fixes only |
+| `/unslop fix architecture medium` | Medium-priority eligible architecture fixes only |
+| `/unslop fix frontend low` | Low-priority eligible frontend/design fixes only |
+| `/unslop fix architecture A1` | Candidate-scoped architecture fix |
+| `/unslop fix all app/components` | High-priority eligible fixes across all lanes inside a path |
+| `/unslop fix architecture --dry-run` | Preview selected fixes without editing |
+
+### Aliases
+
+| Canonical token | Accepted aliases |
+|-----------------|------------------|
+| `all` | `--all` |
+| `hygiene` | `--hygiene`, `code-hygiene` |
+| `comments` | `--comments`, `comment`, `docs`, `documentation` |
+| `frontend` | `--frontend`, `front-end`, `design` |
+| `architecture` | `--architecture`, `arch` |
+| `high` | `--high` |
+| `medium` | `--medium` |
+| `low` | `--low` |
+| `dry-run` | `--dry-run`, `preview` |
+
+### Priority Selectors
+
+**Priority selectors are exact**, not cumulative.
+
+| Selector | Meaning |
+|----------|---------|
+| no priority token | high priority only |
+| `high` | high priority only |
+| `medium` | medium priority only |
+| `low` | low priority only |
+
+`all` does not mean all priorities. In v2, `all` means all lanes with high-priority eligible fixes.
+
+### Candidate and Path Scope
+
+Candidate IDs narrow the selected fixes:
+
+- `H1`, `H2` for hygiene
+- `C1`, `C2` for comments/docs
+- `F1`, `F2` for frontend/design
+- `A1`, `A2` for architecture
+
+Examples:
+
+```text
+/unslop fix architecture A1
+/unslop fix frontend F1,F4
+/unslop fix comments C2 src/api
+```
+
+Paths narrow analysis and edits:
+
+```text
+/unslop src/auth
+/unslop fix architecture src/auth
+/unslop fix all app/components
+```
+
+Do not silently expand a path-scoped run into unrelated files except to verify references/usages. If a safe fix requires editing outside scope, skip it and report why.
+
+### Conflict Rule
+
+**Multiple lane selectors are rejected** unless the user chose `all`.
+
+Reject:
+
+```text
+/unslop fix frontend architecture
+/unslop fix --frontend --architecture
+```
+
+Return:
+
+```text
+Choose one lane, or use all.
+
+Examples:
+- /unslop fix frontend
+- /unslop fix architecture
+- /unslop fix all
+```
+
+## Lanes
+
+### Lane 1: Code Hygiene
+
+Find and optionally fix mechanical code slop:
+
+- commented-out code blocks
+- unused imports, variables, functions, or helpers
+- duplicate tiny helpers
+- needless defensive branches that cannot trigger
+- pointless wrappers that add no behavior
+- deep nesting that can be safely flattened with early returns
+- copy-paste branches with identical behavior
+
+Safe fixes are deletion-first. Prefer deleting code over rewriting code. Prefer inlining over a new abstraction. Do not add dependencies during `/unslop` unless the user explicitly asks.
+
+### Lane 2: Comments/docs
+
+Find and optionally fix comment and documentation slop:
+
+- comments that restate the next line of code
+- filler phrases such as "this function is responsible for"
+- stale TODOs or FIXMEs that are already done
+- inaccurate parameter or return docs
+- redundant JSDoc/docstrings on trivial getters or obvious one-liners
+- section divider comments that add noise but no navigation value
+- docs that describe implementation details no caller should know
+
+Safe fixes include deleting obvious restatement comments and stale filler. Do not delete a comment that explains non-obvious intent, edge cases, product constraints, security rationale, or external system behavior.
+
+### Lane 3: Frontend/design
+
+Find and optionally fix UI slop:
+
+- generic AI color palettes, especially default blue/purple gradients without brand rationale
+- uniform 3-column card grids with no hierarchy
+- weak empty/loading/error/success states
+- missing hover/focus/active states on interactive elements
+- design-system bypasses and one-off class soup
+- repetitive eyebrow/title/description stuffing
+- emoji badges or decorative icons with no product voice
+- uniform radius/shadow treatment on every surface
+- overly perfect layouts where rhythm or emphasis would help
+- components whose props expose implementation detail instead of product concepts
+
+Frontend fixes require extra care. Auto-fix only when the change is eligible:
+
+- the fix is mechanical accessibility or interaction-state cleanup, or
+- an existing design-system convention clearly dictates the change, or
+- screenshot/browser verification is possible and included in the report
+
+If visual verification is not possible for a visual/layout change, skip the fix and report the exact command or manual review needed.
+
+### Lane 4: Architecture
+
+Add an **Architecture Slop Detector** pass. It should use Matt-style deepening language and report architecture findings as candidates, not vague refactor opinions.
+
+Look for:
+
+- shallow modules where the interface is almost as complex as the implementation
+- pass-through wrappers that hide nothing
+- fake seams or adapters with one implementation and no real substitutability
+- caller knowledge leakage, where call sites know ordering, invariants, retries, parsing, or lifecycle details
+- duplicated orchestration spread across multiple files
+- modules that fail the deletion test: deleting the module removes complexity instead of moving useful complexity behind a deeper interface
+- frontend component boundaries where props mirror implementation details instead of product concepts
+- tests that mock internals instead of testing through a stable public interface
+- interfaces that make easy things verbose and hard things impossible
+
+Use these terms in findings where relevant:
+
+- module
+- interface
+- implementation
+- depth
+- seam
+- adapter
+- leverage
+- locality
+- test surface
+
+Architecture fixes are eligible only when they are scoped, testable, and low enough risk. High-risk architecture findings must remain report-only unless the user selects a specific candidate and the verification plan is explicit.
 
 ## Execution Flow
 
-### Stage 1: Determine Scope
+### Stage 1: Parse Arguments
 
-**If a file or directory path is provided:**
+Determine:
 
-Scope to that path. Use `find` or glob to list all code files under it.
+1. Mode: report or fix
+2. Lane selector: all lanes, one lane, or safe default
+3. Priority selector: high by default for lane/all fixes, exact `high`/`medium`/`low` when provided
+4. Candidate IDs, if present
+5. Path scope, if present
+6. Dry-run/preview mode, if present
+7. Conflicts, especially multiple lanes without `all`
 
-**If no argument (default):**
+### Stage 2: Determine Scope
 
-Determine changed files since the base branch:
+If path arguments are provided, scope to those files/directories.
+
+If no path is provided, use changed files since the base branch:
 
 ```bash
 BASE=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD origin/master 2>/dev/null || echo "HEAD~10")
-echo "FILES:" && git diff --name-only $BASE
-echo "DIFF:" && git diff -U5 $BASE
+echo "FILES:" && git diff --name-only "$BASE"
+echo "DIFF:" && git diff -U5 "$BASE"
 ```
 
-**Classify files in scope:**
+Skip generated/vendor output such as `dist/`, `build/`, `node_modules/`, `.next/`, `vendor/`, checked-in minified bundles, and generated lockfile chunks unless the user explicitly scoped to them.
 
-| File extensions | Passes to run |
-|----------------|---------------|
-| `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rb`, `.rs`, `.java`, `.cs`, `.swift`, `.kt` | Code Slop + Comment Rot |
-| `.css`, `.scss`, `.less`, `.tsx`, `.jsx`, `.html`, `.vue`, `.svelte` | + Design Slop |
-| `.json`, `.yaml`, `.yml`, `.toml`, `.md` | Code Slop + Comment Rot only |
+### Stage 3: Run Analysis Passes
 
-If no UI/style files are in scope, skip the Design Slop pass entirely.
+Run all selected lanes. For default `/unslop`, run every lane that applies to the scope.
 
-Announce the scope:
+If the harness supports safe read-only delegated analysis, the passes may run in parallel. If not, run them sequentially. The output contract is the same either way.
 
-```
-De-slop scope: 14 files changed since origin/main
-Passes: Code Slop | Comment Rot | Design Slop (3 UI files detected)
-```
+#### Pass 1: Hygiene Detector
 
-### Stage 2: Parallel Analysis
+Return:
 
-Launch three sub-agents IN PARALLEL. Each receives the file list and diff content, and returns structured findings as text.
-
-<parallel_tasks>
-
-#### Pass 1: Code Slop Detector
-
-You are a code simplification expert. Analyze the provided files for AI-generated slop patterns. Focus ONLY on slop — not correctness, security, or architecture.
-
-**What to flag:**
-
-1. **Unnecessary complexity**
-   - Deep nesting (>3 levels) that could use early returns
-   - Nested ternary operators — use if/else or switch
-   - Dense one-liners that sacrifice readability for brevity
-
-2. **Redundant abstractions**
-   - Interfaces/types used only once — inline them
-   - Wrapper functions that add no logic — call the wrapped function directly
-   - Abstract base classes with a single implementation
-   - Premature generalization ("just in case" extensibility points)
-
-3. **YAGNI violations**
-   - Features not required by current use cases
-   - Configuration options nobody uses
-   - Generic solutions for specific problems
-   - "Future-proofing" code that adds complexity now
-
-4. **Dead weight**
-   - Commented-out code blocks (>3 lines)
-   - Unused imports, variables, or functions
-   - Duplicate error checks (caller already validates)
-   - Defensive code that can never trigger (type system prevents it)
-
-5. **Over-engineering**
-   - Factory patterns for creating a single type
-   - Strategy patterns with one strategy
-   - Event systems for synchronous single-consumer flows
-   - Dependency injection where direct instantiation is clearer
-
-**Return format:**
 ```json
 {
-  "pass": "code-slop",
+  "pass": "hygiene",
   "findings": [
     {
+      "id": "H1",
       "file": "src/auth.ts",
       "line": 42,
-      "issue": "Nested ternary — use if/else for readability",
-      "severity": "medium",
-      "fix_safe": true,
-      "suggested_fix": "Replace ternary chain with if/else block"
+      "finding": "Commented-out fallback branch is dead weight.",
+      "priority": "high",
+      "risk": "low",
+      "effort": "small",
+      "auto_fix_eligible": true,
+      "suggested_fix": "Delete the commented block.",
+      "verification": ["go test ./..."]
     }
   ]
 }
 ```
 
-#### Pass 2: Comment Rot Detector
+#### Pass 2: Comments/docs Detector
 
-You are a technical documentation expert specializing in comment quality. Analyze the provided files for comment rot — inaccurate, redundant, or AI-generated filler comments.
+Return:
 
-**What to flag:**
-
-1. **Obvious restatements**
-   - `// increment counter` above `counter++`
-   - `// return the result` above `return result`
-   - `// set the name` above `this.name = name`
-   - Comments that repeat the function/variable name in prose
-
-2. **AI-generated filler phrases** (hard bans — flag these immediately)
-   - "This function is responsible for handling..."
-   - "The following code implements..."
-   - "This is a comprehensive solution that..."
-   - "This method provides a robust and scalable..."
-   - "leverages" or "utilizes" (when "uses" works fine)
-   - "seamlessly integrates"
-   - "In today's rapidly evolving..."
-   - "game-changer", "revolutionary", "cutting-edge"
-   - "This class encapsulates the logic for..."
-   - "Ensures proper handling of..."
-
-3. **Factual inaccuracy**
-   - Documented parameters that don't match the function signature
-   - Return type descriptions that don't match the actual return
-   - Described behavior that doesn't match the code logic
-   - Edge case documentation for cases not actually handled
-
-4. **Stale comments**
-   - TODOs/FIXMEs for work that's already been done
-   - References to removed/renamed functions, classes, or files
-   - Version-specific notes for versions no longer supported
-   - "Temporary" markers on permanent code
-
-5. **Over-documentation**
-   - JSDoc/docstrings on trivial getters/setters
-   - Multi-line comments on self-explanatory one-liners
-   - Repeating type information already in the signature
-   - Section divider comments (`// ==================`)
-
-**Return format:**
 ```json
 {
-  "pass": "comment-rot",
+  "pass": "comments-docs",
   "findings": [
     {
+      "id": "C1",
       "file": "src/auth.ts",
       "line": 10,
-      "issue": "\"This function handles authentication\" — restates the function name",
-      "severity": "low",
-      "fix_safe": true,
-      "suggested_fix": "Remove comment — function name is self-documenting"
+      "finding": "Comment restates the function name instead of explaining intent.",
+      "priority": "low",
+      "risk": "low",
+      "effort": "small",
+      "auto_fix_eligible": true,
+      "suggested_fix": "Remove the comment.",
+      "verification": ["go test ./..."]
     }
   ]
 }
 ```
 
-#### Pass 3: Design Slop Detector
+#### Pass 3: Frontend/design Detector
 
-**Only run this pass when UI/style files are in scope.**
+Return:
 
-You are a design quality expert. Analyze the provided UI files for AI-generated visual slop — generic, template-looking patterns that signal "an AI made this, not a designer."
-
-**What to flag:**
-
-1. **Generic color patterns**
-   - Purple-to-blue gradients (the AI default palette)
-   - Gratuitous gradients on everything (buttons, cards, backgrounds)
-   - Safe gray-on-white with one decorative accent color
-   - Unintentional color usage (decorative, not semantic)
-
-2. **Template layouts**
-   - Default card grids with uniform spacing and no hierarchy
-   - Generic hero: centered headline + subtitle + gradient blob + CTA
-   - Dashboard-by-numbers: sidebar + cards + charts with no point of view
-   - Uniform radius, spacing, and shadows across every component
-
-3. **Missing interaction states**
-   - No hover states on interactive elements
-   - No focus states (accessibility gap)
-   - No active/pressed states
-   - No loading/empty/error states
-
-4. **Lazy defaults**
-   - Unmodified library defaults (default shadcn/Tailwind without customization)
-   - Default font stacks with no intentional pairing
-   - Glassmorphism cards that serve no UI purpose
-   - Rounded corners on elements that shouldn't be rounded (tables, code blocks)
-   - Excessive scroll-triggered animations
-
-5. **No visual hierarchy**
-   - Flat layouts with no layering, depth, or motion
-   - Uniform emphasis on everything (nothing stands out)
-   - No intentional rhythm in spacing
-
-**Return format:**
 ```json
 {
-  "pass": "design-slop",
+  "pass": "frontend-design",
   "findings": [
     {
+      "id": "F1",
       "file": "src/Hero.tsx",
       "line": 22,
-      "issue": "Generic purple-to-blue gradient — replace with brand palette",
-      "severity": "medium",
-      "fix_safe": false,
-      "suggested_fix": "Define an intentional brand gradient in design tokens"
+      "finding": "Generic card grid gives every item equal weight and weakens hierarchy.",
+      "priority": "high",
+      "risk": "medium",
+      "effort": "medium",
+      "auto_fix_eligible": true,
+      "suggested_fix": "Promote the primary card and add a focused empty/error state treatment using existing design tokens.",
+      "verification": ["take before/after screenshots", "run affected frontend tests"]
     }
   ]
 }
 ```
 
-</parallel_tasks>
+#### Pass 4: Architecture Slop Detector
 
-### Stage 3: Merge & Deduplicate
+Return Matt-style deepening candidates:
 
-**WAIT for all Stage 2 sub-agents to complete.**
-
-1. Collect findings from all passes that ran
-2. Deduplicate: if two passes flag the same file+line (within 3 lines), keep the more specific finding and note both passes
-3. Sort by severity: High → Medium → Low
-4. Group by pass for the report
-
-### Stage 4: Present Report
-
-Format the consolidated report using pipe-delimited markdown tables:
-
-```
-De-slop Report
-==============
-Scope: [N] files changed since [base]
-Passes: Code Slop [✓|✗] | Comment Rot [✓|✗] | Design Slop [✓|skipped]
-
-## Code Slop ([N] findings)
-
-| # | File | Line | Issue | Severity |
-|---|------|------|-------|----------|
-| 1 | path | line | description | High/Medium/Low |
-
-## Comment Rot ([N] findings)
-
-| # | File | Line | Issue | Severity |
-|---|------|------|-------|----------|
-| 1 | path | line | description | High/Medium/Low |
-
-## Design Slop ([N] findings)
-
-| # | File | Line | Issue | Severity |
-|---|------|------|-------|----------|
-| 1 | path | line | description | High/Medium/Low |
-
-─────────────────────────────
-Summary: [N] findings ([H] High, [M] Medium, [L] Low)
-Potential LOC reduction: ~[N] lines
+```json
+{
+  "pass": "architecture-slop",
+  "findings": [
+    {
+      "id": "A1",
+      "files": ["src/auth/session.ts", "src/auth/cookies.ts"],
+      "problem": "Callers must know cookie parsing order and session fallback behavior.",
+      "proposed_fix": "Create a deeper Session interface that owns load, refresh, and clear behavior.",
+      "deepening": {
+        "depth": "Callers stop coordinating cookie and session details.",
+        "locality": "Session rules move into one module.",
+        "leverage": "Four callers shrink to one stable interface.",
+        "test_surface": "Tests can exercise session behavior through the public interface."
+      },
+      "priority": "high",
+      "risk": "medium",
+      "effort": "medium",
+      "auto_fix_eligible": true,
+      "verification": ["targeted session tests", "existing auth tests"]
+    }
+  ]
+}
 ```
 
-Omit any pass section with zero findings. If all passes return zero findings:
+### Stage 4: Merge, Score, and Deduplicate
 
+1. Collect findings from all selected passes.
+2. Deduplicate overlapping findings by file + line or shared candidate description.
+3. Assign stable IDs if the detector did not.
+4. Verify priority/risk/effort are present for every finding.
+5. Verify every auto-fix-eligible finding has a concrete verification plan.
+6. Sort by lane, then priority high to low, then risk low to high.
+
+### Stage 5: Present Report
+
+Use this report format:
+
+```markdown
+# /unslop Report
+
+Scope: [N] files changed since [base] or [explicit path]
+Mode: report
+Fix default: safe hygiene + comments/docs only
+Fix all: high-priority eligible fixes across all lanes
+
+## Executive Summary
+
+| Lane | Findings | High | Medium | Low | Auto-fix eligible | Recommended next |
+|------|----------|------|--------|-----|-------------------|------------------|
+| Hygiene | 4 | 1 | 2 | 1 | 3 | /unslop fix hygiene |
+| Comments/docs | 8 | 2 | 4 | 2 | 7 | /unslop fix comments |
+| Frontend/design | 3 | 1 | 2 | 0 | 1 | /unslop fix frontend |
+| Architecture | 3 | 1 | 1 | 1 | 1 | /unslop fix architecture |
+
+## Findings
+
+| ID | Lane | File | Finding | Priority | Risk | Effort | Auto-fix | Next command |
+|----|------|------|---------|----------|------|--------|----------|--------------|
+| H1 | Hygiene | src/foo.ts:42 | Dead helper never used | High | Low | Small | Yes | /unslop fix hygiene H1 |
+| C1 | Comments/docs | src/foo.ts:12 | Comment restates function name | Low | Low | Small | Yes | /unslop fix comments C1 |
+| F1 | Frontend/design | app/card.tsx:70 | Generic card grid lacks hierarchy | High | Medium | Medium | Yes | /unslop fix frontend F1 |
+| A1 | Architecture | src/session.ts | Session rules leak into 4 callers | High | Medium | Medium | Yes | /unslop fix architecture A1 |
 ```
-De-slop Report: Clean! No slop detected in [N] files.
+
+For architecture findings, include a short candidate detail block after the table:
+
+```markdown
+### Architecture Candidate A1
+
+Problem: [problem]
+Proposed deeper interface: [proposed_fix]
+Depth: [depth]
+Locality: [locality]
+Leverage: [leverage]
+Test surface: [test_surface]
+Verification: [commands/checks]
 ```
 
-### Stage 5: Auto-Fix (only if `fix` argument was provided)
+If no findings are present:
 
-If the user invoked `/unslop fix`:
-
-1. Collect all findings where `fix_safe: true`
-2. Apply fixes in file order:
-   - **Code Slop safe fixes:** Remove commented-out code blocks, remove unused imports
-   - **Comment Rot safe fixes:** Delete obvious restatement comments, remove stale TODOs
-3. Do NOT auto-fix:
-   - Design slop (requires design judgment)
-   - Factually inaccurate comments (requires understanding intent)
-   - YAGNI violations (requires knowing the roadmap)
-   - Abstractions (requires understanding the broader architecture)
-4. Report what was fixed:
-
-```
-Auto-fix applied:
-  ✓ Removed 3 commented-out code blocks (42 lines)
-  ✓ Deleted 5 obvious-restatement comments
-  ✓ Removed 2 stale TODOs
-
-  Remaining (manual review needed): 4 findings
+```markdown
+/unslop Report: Clean. No slop detected in [N] files.
 ```
 
-If `fix` was NOT provided but fixable findings exist, suggest it:
+### Stage 6: Fix Selection
 
+For `/unslop fix`, select only auto-fix-eligible code hygiene and comments/docs findings.
+
+For `/unslop fix all` or `/unslop fix --all`, select high-priority, auto-fix-eligible findings across all four lanes.
+
+For lane-specific fixes, select only that lane and the exact priority requested. No priority token means high priority.
+
+Candidate IDs narrow the selected findings after lane and priority selection.
+
+Never apply a finding unless:
+
+- it matches the requested lane/all selection
+- it matches the requested priority selector
+- it is auto-fix eligible
+- it stays within path scope
+- it has a verification plan
+
+### Stage 7: Cleanup Plan Before Edits
+
+Before editing, print a short cleanup plan:
+
+```markdown
+Cleanup plan:
+1. [Lane] [ID] [specific change]
+2. [Lane] [ID] [specific change]
+
+Behavior lock / verification before editing:
+- [command or manual verification]
 ```
-Tip: Run /unslop fix to auto-apply [N] safe fixes
+
+If tests cannot run before editing, record why and name the post-edit verification plan. Do not pretend unverified architecture/frontend work is safe.
+
+### Stage 8: Apply Fixes
+
+Work lane by lane. Prefer deletion before rewriting.
+
+Recommended order:
+
+1. Comments/docs
+2. Hygiene
+3. Frontend/design
+4. Architecture
+
+Run targeted verification after each lane when practical. If verification fails, fix the failure or back out the risky cleanup.
+
+### Stage 9: Final Fix Report
+
+Always report:
+
+```markdown
+## /unslop Fix Report
+
+Changed files:
+- [file]
+
+Simplifications:
+- [ID] [what changed]
+
+Verification run:
+- [command] -> [result]
+
+Skipped findings:
+- [ID] [reason, such as high risk or outside scope]
+
+Remaining risks:
+- [risk or "none known"]
 ```
 
-## Severity Guide
+## Auto-Fix Eligibility Guide
 
-| Level | Meaning | Examples |
-|-------|---------|---------|
-| **High** | Actively misleading or creates maintenance burden | Inaccurate comment, missing hover states, large dead code block |
-| **Medium** | Noticeable slop that reduces quality | Unnecessary abstraction, AI filler phrase, generic gradient |
-| **Low** | Minor quality improvement | Restatement comment, unused import, over-documentation |
+| Lane | Eligible examples | Not eligible by default |
+|------|-------------------|-------------------------|
+| Hygiene | dead comments, unused imports, trivially unused helpers | broad refactors, behavior-changing rewrites |
+| Comments/docs | obvious restatements, stale filler, done TODOs | intent comments, security rationale, external API notes |
+| Frontend/design | missing focus state following existing convention, mechanical token alignment | visual redesign without screenshot verification |
+| Architecture | shallow wrapper deletion, fake seam removal, small deeper interface with tests | high-risk boundary moves, large module migrations |
 
-Slop is never "Critical" — it's a quality concern, not a correctness or security issue.
+## Severity and Scoring
+
+Use **priority** for importance, **risk** for regression chance, and **effort** for implementation size.
+
+Priority:
+
+- High: fixing this materially improves quality or removes real maintenance drag
+- Medium: noticeable quality improvement, but not blocking
+- Low: small cleanup or polish
+
+Risk:
+
+- Low: mechanical or deletion-only with clear verification
+- Medium: modest behavior or visual surface, protected by tests or screenshots
+- High: could change behavior, product semantics, layout intent, or public interfaces
+
+Effort:
+
+- Small: one file or a tiny local edit
+- Medium: several related files, targeted tests
+- Large: cross-module migration or broad redesign
 
 ## Quality Gates
 
 Before presenting findings:
 
-1. **Every finding must be actionable.** Don't say "could be simpler" — say what to change and where.
-2. **No false positives from skimming.** Verify the abstraction isn't used elsewhere before flagging it. Verify the comment is truly redundant.
-3. **Line numbers must be accurate.** Check each cited line against file content.
-4. **Respect project conventions.** If the project uses JSDoc everywhere, don't flag JSDoc as over-documentation.
-5. **Don't flag generated code.** Skip files in `dist/`, `build/`, `node_modules/`, `.next/`, `vendor/`, or similar generated directories.
+1. Every finding must be actionable.
+2. Line numbers must be accurate when line numbers are cited.
+3. Do not flag generated code unless explicitly scoped.
+4. Verify unused/dead code before flagging it as safe.
+5. Respect project conventions.
+6. Do not mark architecture/frontend fixes auto-fix eligible without a verification plan.
+7. Report skipped fixes instead of forcing them.
+
+## Relationship to Other ATV Skills
+
+- Pair with `/ce-review`: correctness and safety review.
+- Pair with `/frontend-design` or design review workflows when frontend findings require real visual judgment.
+- Keep `/lfg` and `/slfg` conservative by default. They should continue to use `/unslop fix` unless the user explicitly asks for `/unslop fix all`.
 
 ## Notes
 
-- This skill is read-only by default. It reports but does not edit files unless `fix` is specified.
-- Design Slop pass is automatically skipped for backend-only projects.
-- Works on any language/framework — the slop patterns are universal.
-- Pairs well with `/ce-review` (which checks correctness) — `/unslop` checks aesthetics and quality.
+- `/unslop` is read-only by default.
+- `/unslop fix` is conservative by default.
+- `/unslop fix all` is intentionally stronger, but still only applies high-priority auto-fix-eligible findings.
+- Architecture reports should use Matt-style deepening candidates, but this skill does not import another skill verbatim.
+- Frontend visual changes need evidence, not just class-name vibes.

--- a/pkg/scaffold/unslop_skill_test.go
+++ b/pkg/scaffold/unslop_skill_test.go
@@ -1,0 +1,115 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUnslopSkillDocumentsFullSurfaceWorkflow(t *testing.T) {
+	root := repoRoot(t)
+	skillPath := filepath.Join(root, "pkg", "scaffold", "templates", "skills", "unslop", "SKILL.md")
+	contentBytes, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read unslop skill template: %v", err)
+	}
+	content := string(contentBytes)
+
+	required := []string{
+		"code hygiene",
+		"comments/docs",
+		"frontend/design",
+		"architecture",
+		"Architecture Slop Detector",
+		"Matt-style",
+		"depth",
+		"seam",
+		"locality",
+		"leverage",
+		"/unslop fix all",
+		"/unslop fix --all",
+		"high-priority, auto-fix-eligible fixes across all four lanes",
+		"Priority selectors are exact",
+		"risk",
+		"effort",
+		"candidate",
+		"Multiple lane selectors",
+	}
+	for _, want := range required {
+		if !strings.Contains(content, want) {
+			t.Errorf("unslop skill is missing required v2 contract text %q", want)
+		}
+	}
+}
+
+func TestUnslopSkillCopiesStayInSync(t *testing.T) {
+	root := repoRoot(t)
+	templatePath := filepath.Join(root, "pkg", "scaffold", "templates", "skills", "unslop", "SKILL.md")
+	template, err := os.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("read template: %v", err)
+	}
+
+	copyPaths := []string{
+		filepath.Join(root, "plugins", "atv-skill-unslop", "skills", "unslop", "SKILL.md"),
+		filepath.Join(root, "plugins", "atv-pack-quality", "skills", "unslop", "SKILL.md"),
+		filepath.Join(root, "plugins", "atv-everything", "skills", "unslop", "SKILL.md"),
+	}
+	for _, path := range copyPaths {
+		got, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("read %s: %v", path, readErr)
+		}
+		if string(got) != string(template) {
+			t.Errorf("%s drifted from pkg/scaffold/templates/skills/unslop/SKILL.md", path)
+		}
+	}
+}
+
+func TestUnslopPromptShimDoesNotPointAtMissingSkillPath(t *testing.T) {
+	root := repoRoot(t)
+	promptPath := filepath.Join(root, ".github", "prompts", "unslop.prompt.md")
+	contentBytes, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("read unslop prompt shim: %v", err)
+	}
+	content := string(contentBytes)
+
+	missingPath := ".github/skills/unslop/SKILL.md"
+	if strings.Contains(content, missingPath) {
+		t.Fatalf("unslop prompt shim references missing path %q; it should invoke the installed unslop skill without a brittle missing path", missingPath)
+	}
+	if !strings.Contains(content, "installed `unslop` skill") {
+		t.Fatalf("unslop prompt shim should tell the harness to invoke the installed `unslop` skill")
+	}
+
+	generated := string(BuildPromptShim("unslop"))
+	if strings.Contains(generated, missingPath) {
+		t.Fatalf("generated unslop prompt shim references missing path %q", missingPath)
+	}
+	if !strings.Contains(generated, "installed `unslop` skill") {
+		t.Fatalf("generated unslop prompt shim should tell the harness to invoke the installed `unslop` skill")
+	}
+}
+
+func TestReadmeDocumentsUnslopV2Commands(t *testing.T) {
+	root := repoRoot(t)
+	readmePath := filepath.Join(root, "README.md")
+	contentBytes, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	content := string(contentBytes)
+
+	required := []string{
+		"`/unslop` reports code hygiene, comments/docs, frontend/design, and architecture slop",
+		"`/unslop fix` applies safe hygiene and comments/docs cleanup",
+		"`/unslop fix all` applies high-priority eligible fixes across all lanes",
+	}
+	for _, want := range required {
+		if !strings.Contains(content, want) {
+			t.Errorf("README missing unslop v2 documentation %q", want)
+		}
+	}
+}

--- a/plugins/atv-everything/skills/unslop/SKILL.md
+++ b/plugins/atv-everything/skills/unslop/SKILL.md
@@ -1,341 +1,548 @@
 ---
 name: unslop
-description: "Unified de-slop pass: code simplification + comment rot detection + design slop check. Run after completing features or before PRs to strip AI-generated generic patterns."
-argument-hint: "[blank for recent changes, or file/directory path]"
+description: "Full-surface de-slop workflow: code hygiene, comments/docs, frontend/design, and architecture. Reports everything by default; fixes safe hygiene by default; `fix all` applies high-priority auto-fix-eligible fixes across all lanes."
+argument-hint: "[fix] [all|hygiene|comments|frontend|architecture] [high|medium|low] [candidate IDs or file/directory paths]"
 ---
 
-# /unslop — Strip AI Slop from Your Codebase
+# /unslop - Full-Surface AI Slop Cleanup
 
-Three parallel analysis passes that detect and report AI-generated "slop" — generic, template-looking, over-enthusiastic output that makes code, comments, and UI feel artificial.
+`/unslop` is the broad X-ray for AI-generated slop. It reports every surface where AI-assisted work tends to leave cheapness behind: **code hygiene**, **comments/docs**, **frontend/design**, and **architecture**.
+
+Default behavior is safe:
+
+- `/unslop` reports across all four lanes and does not edit.
+- `/unslop fix` edits only safe code hygiene and comments/docs issues.
+- `/unslop fix all` and `/unslop fix --all` apply **high-priority, auto-fix-eligible fixes across all four lanes**.
+
+Architecture and frontend fixes are allowed only when they pass explicit eligibility gates. Priority selects importance. Eligibility selects safety. Scope selects where edits are allowed.
 
 ## When to Use
 
-- After completing a feature — check for slop before PR
-- Before code review — pre-clean your changes
-- When code "feels AI-generated" but you can't pinpoint why
-- Periodic codebase hygiene — run on a directory
-- After a long AI-assisted session to audit quality
+Use `/unslop` when:
 
-## Argument Parsing
+- a feature works but feels bloated, repetitive, generic, over-commented, or over-abstracted
+- recent AI-assisted work left dead code, filler comments, stale docs, wrapper layers, weak seams, or generic UI
+- a PR needs a quality pass before review
+- you want a ranked cleanup report with priority, risk, effort, and next commands
+- you want high-priority eligible cleanup via `/unslop fix all`
 
-Parse `$ARGUMENTS` for these tokens:
+## When Not to Use
 
-| Token | Example | Effect |
-|-------|---------|--------|
-| `fix` | `/unslop fix` | Auto-apply safe fixes after reporting |
-| `<path>` | `/unslop src/components/` | Scope to specific file or directory |
-| (none) | `/unslop` | Analyze all files changed since the base branch |
+Do not use `/unslop` when:
+
+- the main task is a new feature or behavior change
+- desired behavior is unclear and cannot be protected by tests or a concrete verification plan
+- the user wants a broad redesign rather than an incremental cleanup pass
+- the request is only formatting or lint trivia
+- the cleanup would require product decisions the user has not made
+
+## Command Contract
+
+The parser should be forgiving. This is a slash-command skill, not a strict Unix binary. Accept flag forms and natural token forms.
+
+### Report Commands
+
+| Command | Behavior |
+|---------|----------|
+| `/unslop` | Full read-only report across all lanes |
+| `/unslop hygiene` or `/unslop --hygiene` | Code hygiene report only |
+| `/unslop comments` or `/unslop --comments` | Comments/docs report only |
+| `/unslop frontend` or `/unslop --frontend` | Frontend/design report only |
+| `/unslop architecture` or `/unslop --architecture` | Architecture report only |
+| `/unslop src/auth` | Full report scoped to a path |
+
+### Fix Commands
+
+| Command | Behavior |
+|---------|----------|
+| `/unslop fix` | Safe default: code hygiene + comments/docs only |
+| `/unslop fix all` or `/unslop fix --all` | High-priority, auto-fix-eligible fixes across all four lanes |
+| `/unslop fix hygiene` or `/unslop fix --hygiene` | High-priority eligible code hygiene fixes only |
+| `/unslop fix comments` or `/unslop fix --comments` | High-priority eligible comments/docs fixes only |
+| `/unslop fix frontend` or `/unslop fix --frontend` | High-priority eligible frontend/design fixes only |
+| `/unslop fix architecture` or `/unslop fix --architecture` | High-priority eligible architecture fixes only |
+| `/unslop fix architecture medium` | Medium-priority eligible architecture fixes only |
+| `/unslop fix frontend low` | Low-priority eligible frontend/design fixes only |
+| `/unslop fix architecture A1` | Candidate-scoped architecture fix |
+| `/unslop fix all app/components` | High-priority eligible fixes across all lanes inside a path |
+| `/unslop fix architecture --dry-run` | Preview selected fixes without editing |
+
+### Aliases
+
+| Canonical token | Accepted aliases |
+|-----------------|------------------|
+| `all` | `--all` |
+| `hygiene` | `--hygiene`, `code-hygiene` |
+| `comments` | `--comments`, `comment`, `docs`, `documentation` |
+| `frontend` | `--frontend`, `front-end`, `design` |
+| `architecture` | `--architecture`, `arch` |
+| `high` | `--high` |
+| `medium` | `--medium` |
+| `low` | `--low` |
+| `dry-run` | `--dry-run`, `preview` |
+
+### Priority Selectors
+
+**Priority selectors are exact**, not cumulative.
+
+| Selector | Meaning |
+|----------|---------|
+| no priority token | high priority only |
+| `high` | high priority only |
+| `medium` | medium priority only |
+| `low` | low priority only |
+
+`all` does not mean all priorities. In v2, `all` means all lanes with high-priority eligible fixes.
+
+### Candidate and Path Scope
+
+Candidate IDs narrow the selected fixes:
+
+- `H1`, `H2` for hygiene
+- `C1`, `C2` for comments/docs
+- `F1`, `F2` for frontend/design
+- `A1`, `A2` for architecture
+
+Examples:
+
+```text
+/unslop fix architecture A1
+/unslop fix frontend F1,F4
+/unslop fix comments C2 src/api
+```
+
+Paths narrow analysis and edits:
+
+```text
+/unslop src/auth
+/unslop fix architecture src/auth
+/unslop fix all app/components
+```
+
+Do not silently expand a path-scoped run into unrelated files except to verify references/usages. If a safe fix requires editing outside scope, skip it and report why.
+
+### Conflict Rule
+
+**Multiple lane selectors are rejected** unless the user chose `all`.
+
+Reject:
+
+```text
+/unslop fix frontend architecture
+/unslop fix --frontend --architecture
+```
+
+Return:
+
+```text
+Choose one lane, or use all.
+
+Examples:
+- /unslop fix frontend
+- /unslop fix architecture
+- /unslop fix all
+```
+
+## Lanes
+
+### Lane 1: Code Hygiene
+
+Find and optionally fix mechanical code slop:
+
+- commented-out code blocks
+- unused imports, variables, functions, or helpers
+- duplicate tiny helpers
+- needless defensive branches that cannot trigger
+- pointless wrappers that add no behavior
+- deep nesting that can be safely flattened with early returns
+- copy-paste branches with identical behavior
+
+Safe fixes are deletion-first. Prefer deleting code over rewriting code. Prefer inlining over a new abstraction. Do not add dependencies during `/unslop` unless the user explicitly asks.
+
+### Lane 2: Comments/docs
+
+Find and optionally fix comment and documentation slop:
+
+- comments that restate the next line of code
+- filler phrases such as "this function is responsible for"
+- stale TODOs or FIXMEs that are already done
+- inaccurate parameter or return docs
+- redundant JSDoc/docstrings on trivial getters or obvious one-liners
+- section divider comments that add noise but no navigation value
+- docs that describe implementation details no caller should know
+
+Safe fixes include deleting obvious restatement comments and stale filler. Do not delete a comment that explains non-obvious intent, edge cases, product constraints, security rationale, or external system behavior.
+
+### Lane 3: Frontend/design
+
+Find and optionally fix UI slop:
+
+- generic AI color palettes, especially default blue/purple gradients without brand rationale
+- uniform 3-column card grids with no hierarchy
+- weak empty/loading/error/success states
+- missing hover/focus/active states on interactive elements
+- design-system bypasses and one-off class soup
+- repetitive eyebrow/title/description stuffing
+- emoji badges or decorative icons with no product voice
+- uniform radius/shadow treatment on every surface
+- overly perfect layouts where rhythm or emphasis would help
+- components whose props expose implementation detail instead of product concepts
+
+Frontend fixes require extra care. Auto-fix only when the change is eligible:
+
+- the fix is mechanical accessibility or interaction-state cleanup, or
+- an existing design-system convention clearly dictates the change, or
+- screenshot/browser verification is possible and included in the report
+
+If visual verification is not possible for a visual/layout change, skip the fix and report the exact command or manual review needed.
+
+### Lane 4: Architecture
+
+Add an **Architecture Slop Detector** pass. It should use Matt-style deepening language and report architecture findings as candidates, not vague refactor opinions.
+
+Look for:
+
+- shallow modules where the interface is almost as complex as the implementation
+- pass-through wrappers that hide nothing
+- fake seams or adapters with one implementation and no real substitutability
+- caller knowledge leakage, where call sites know ordering, invariants, retries, parsing, or lifecycle details
+- duplicated orchestration spread across multiple files
+- modules that fail the deletion test: deleting the module removes complexity instead of moving useful complexity behind a deeper interface
+- frontend component boundaries where props mirror implementation details instead of product concepts
+- tests that mock internals instead of testing through a stable public interface
+- interfaces that make easy things verbose and hard things impossible
+
+Use these terms in findings where relevant:
+
+- module
+- interface
+- implementation
+- depth
+- seam
+- adapter
+- leverage
+- locality
+- test surface
+
+Architecture fixes are eligible only when they are scoped, testable, and low enough risk. High-risk architecture findings must remain report-only unless the user selects a specific candidate and the verification plan is explicit.
 
 ## Execution Flow
 
-### Stage 1: Determine Scope
+### Stage 1: Parse Arguments
 
-**If a file or directory path is provided:**
+Determine:
 
-Scope to that path. Use `find` or glob to list all code files under it.
+1. Mode: report or fix
+2. Lane selector: all lanes, one lane, or safe default
+3. Priority selector: high by default for lane/all fixes, exact `high`/`medium`/`low` when provided
+4. Candidate IDs, if present
+5. Path scope, if present
+6. Dry-run/preview mode, if present
+7. Conflicts, especially multiple lanes without `all`
 
-**If no argument (default):**
+### Stage 2: Determine Scope
 
-Determine changed files since the base branch:
+If path arguments are provided, scope to those files/directories.
+
+If no path is provided, use changed files since the base branch:
 
 ```bash
 BASE=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD origin/master 2>/dev/null || echo "HEAD~10")
-echo "FILES:" && git diff --name-only $BASE
-echo "DIFF:" && git diff -U5 $BASE
+echo "FILES:" && git diff --name-only "$BASE"
+echo "DIFF:" && git diff -U5 "$BASE"
 ```
 
-**Classify files in scope:**
+Skip generated/vendor output such as `dist/`, `build/`, `node_modules/`, `.next/`, `vendor/`, checked-in minified bundles, and generated lockfile chunks unless the user explicitly scoped to them.
 
-| File extensions | Passes to run |
-|----------------|---------------|
-| `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rb`, `.rs`, `.java`, `.cs`, `.swift`, `.kt` | Code Slop + Comment Rot |
-| `.css`, `.scss`, `.less`, `.tsx`, `.jsx`, `.html`, `.vue`, `.svelte` | + Design Slop |
-| `.json`, `.yaml`, `.yml`, `.toml`, `.md` | Code Slop + Comment Rot only |
+### Stage 3: Run Analysis Passes
 
-If no UI/style files are in scope, skip the Design Slop pass entirely.
+Run all selected lanes. For default `/unslop`, run every lane that applies to the scope.
 
-Announce the scope:
+If the harness supports safe read-only delegated analysis, the passes may run in parallel. If not, run them sequentially. The output contract is the same either way.
 
-```
-De-slop scope: 14 files changed since origin/main
-Passes: Code Slop | Comment Rot | Design Slop (3 UI files detected)
-```
+#### Pass 1: Hygiene Detector
 
-### Stage 2: Parallel Analysis
+Return:
 
-Launch three sub-agents IN PARALLEL. Each receives the file list and diff content, and returns structured findings as text.
-
-<parallel_tasks>
-
-#### Pass 1: Code Slop Detector
-
-You are a code simplification expert. Analyze the provided files for AI-generated slop patterns. Focus ONLY on slop — not correctness, security, or architecture.
-
-**What to flag:**
-
-1. **Unnecessary complexity**
-   - Deep nesting (>3 levels) that could use early returns
-   - Nested ternary operators — use if/else or switch
-   - Dense one-liners that sacrifice readability for brevity
-
-2. **Redundant abstractions**
-   - Interfaces/types used only once — inline them
-   - Wrapper functions that add no logic — call the wrapped function directly
-   - Abstract base classes with a single implementation
-   - Premature generalization ("just in case" extensibility points)
-
-3. **YAGNI violations**
-   - Features not required by current use cases
-   - Configuration options nobody uses
-   - Generic solutions for specific problems
-   - "Future-proofing" code that adds complexity now
-
-4. **Dead weight**
-   - Commented-out code blocks (>3 lines)
-   - Unused imports, variables, or functions
-   - Duplicate error checks (caller already validates)
-   - Defensive code that can never trigger (type system prevents it)
-
-5. **Over-engineering**
-   - Factory patterns for creating a single type
-   - Strategy patterns with one strategy
-   - Event systems for synchronous single-consumer flows
-   - Dependency injection where direct instantiation is clearer
-
-**Return format:**
 ```json
 {
-  "pass": "code-slop",
+  "pass": "hygiene",
   "findings": [
     {
+      "id": "H1",
       "file": "src/auth.ts",
       "line": 42,
-      "issue": "Nested ternary — use if/else for readability",
-      "severity": "medium",
-      "fix_safe": true,
-      "suggested_fix": "Replace ternary chain with if/else block"
+      "finding": "Commented-out fallback branch is dead weight.",
+      "priority": "high",
+      "risk": "low",
+      "effort": "small",
+      "auto_fix_eligible": true,
+      "suggested_fix": "Delete the commented block.",
+      "verification": ["go test ./..."]
     }
   ]
 }
 ```
 
-#### Pass 2: Comment Rot Detector
+#### Pass 2: Comments/docs Detector
 
-You are a technical documentation expert specializing in comment quality. Analyze the provided files for comment rot — inaccurate, redundant, or AI-generated filler comments.
+Return:
 
-**What to flag:**
-
-1. **Obvious restatements**
-   - `// increment counter` above `counter++`
-   - `// return the result` above `return result`
-   - `// set the name` above `this.name = name`
-   - Comments that repeat the function/variable name in prose
-
-2. **AI-generated filler phrases** (hard bans — flag these immediately)
-   - "This function is responsible for handling..."
-   - "The following code implements..."
-   - "This is a comprehensive solution that..."
-   - "This method provides a robust and scalable..."
-   - "leverages" or "utilizes" (when "uses" works fine)
-   - "seamlessly integrates"
-   - "In today's rapidly evolving..."
-   - "game-changer", "revolutionary", "cutting-edge"
-   - "This class encapsulates the logic for..."
-   - "Ensures proper handling of..."
-
-3. **Factual inaccuracy**
-   - Documented parameters that don't match the function signature
-   - Return type descriptions that don't match the actual return
-   - Described behavior that doesn't match the code logic
-   - Edge case documentation for cases not actually handled
-
-4. **Stale comments**
-   - TODOs/FIXMEs for work that's already been done
-   - References to removed/renamed functions, classes, or files
-   - Version-specific notes for versions no longer supported
-   - "Temporary" markers on permanent code
-
-5. **Over-documentation**
-   - JSDoc/docstrings on trivial getters/setters
-   - Multi-line comments on self-explanatory one-liners
-   - Repeating type information already in the signature
-   - Section divider comments (`// ==================`)
-
-**Return format:**
 ```json
 {
-  "pass": "comment-rot",
+  "pass": "comments-docs",
   "findings": [
     {
+      "id": "C1",
       "file": "src/auth.ts",
       "line": 10,
-      "issue": "\"This function handles authentication\" — restates the function name",
-      "severity": "low",
-      "fix_safe": true,
-      "suggested_fix": "Remove comment — function name is self-documenting"
+      "finding": "Comment restates the function name instead of explaining intent.",
+      "priority": "low",
+      "risk": "low",
+      "effort": "small",
+      "auto_fix_eligible": true,
+      "suggested_fix": "Remove the comment.",
+      "verification": ["go test ./..."]
     }
   ]
 }
 ```
 
-#### Pass 3: Design Slop Detector
+#### Pass 3: Frontend/design Detector
 
-**Only run this pass when UI/style files are in scope.**
+Return:
 
-You are a design quality expert. Analyze the provided UI files for AI-generated visual slop — generic, template-looking patterns that signal "an AI made this, not a designer."
-
-**What to flag:**
-
-1. **Generic color patterns**
-   - Purple-to-blue gradients (the AI default palette)
-   - Gratuitous gradients on everything (buttons, cards, backgrounds)
-   - Safe gray-on-white with one decorative accent color
-   - Unintentional color usage (decorative, not semantic)
-
-2. **Template layouts**
-   - Default card grids with uniform spacing and no hierarchy
-   - Generic hero: centered headline + subtitle + gradient blob + CTA
-   - Dashboard-by-numbers: sidebar + cards + charts with no point of view
-   - Uniform radius, spacing, and shadows across every component
-
-3. **Missing interaction states**
-   - No hover states on interactive elements
-   - No focus states (accessibility gap)
-   - No active/pressed states
-   - No loading/empty/error states
-
-4. **Lazy defaults**
-   - Unmodified library defaults (default shadcn/Tailwind without customization)
-   - Default font stacks with no intentional pairing
-   - Glassmorphism cards that serve no UI purpose
-   - Rounded corners on elements that shouldn't be rounded (tables, code blocks)
-   - Excessive scroll-triggered animations
-
-5. **No visual hierarchy**
-   - Flat layouts with no layering, depth, or motion
-   - Uniform emphasis on everything (nothing stands out)
-   - No intentional rhythm in spacing
-
-**Return format:**
 ```json
 {
-  "pass": "design-slop",
+  "pass": "frontend-design",
   "findings": [
     {
+      "id": "F1",
       "file": "src/Hero.tsx",
       "line": 22,
-      "issue": "Generic purple-to-blue gradient — replace with brand palette",
-      "severity": "medium",
-      "fix_safe": false,
-      "suggested_fix": "Define an intentional brand gradient in design tokens"
+      "finding": "Generic card grid gives every item equal weight and weakens hierarchy.",
+      "priority": "high",
+      "risk": "medium",
+      "effort": "medium",
+      "auto_fix_eligible": true,
+      "suggested_fix": "Promote the primary card and add a focused empty/error state treatment using existing design tokens.",
+      "verification": ["take before/after screenshots", "run affected frontend tests"]
     }
   ]
 }
 ```
 
-</parallel_tasks>
+#### Pass 4: Architecture Slop Detector
 
-### Stage 3: Merge & Deduplicate
+Return Matt-style deepening candidates:
 
-**WAIT for all Stage 2 sub-agents to complete.**
-
-1. Collect findings from all passes that ran
-2. Deduplicate: if two passes flag the same file+line (within 3 lines), keep the more specific finding and note both passes
-3. Sort by severity: High → Medium → Low
-4. Group by pass for the report
-
-### Stage 4: Present Report
-
-Format the consolidated report using pipe-delimited markdown tables:
-
-```
-De-slop Report
-==============
-Scope: [N] files changed since [base]
-Passes: Code Slop [✓|✗] | Comment Rot [✓|✗] | Design Slop [✓|skipped]
-
-## Code Slop ([N] findings)
-
-| # | File | Line | Issue | Severity |
-|---|------|------|-------|----------|
-| 1 | path | line | description | High/Medium/Low |
-
-## Comment Rot ([N] findings)
-
-| # | File | Line | Issue | Severity |
-|---|------|------|-------|----------|
-| 1 | path | line | description | High/Medium/Low |
-
-## Design Slop ([N] findings)
-
-| # | File | Line | Issue | Severity |
-|---|------|------|-------|----------|
-| 1 | path | line | description | High/Medium/Low |
-
-─────────────────────────────
-Summary: [N] findings ([H] High, [M] Medium, [L] Low)
-Potential LOC reduction: ~[N] lines
+```json
+{
+  "pass": "architecture-slop",
+  "findings": [
+    {
+      "id": "A1",
+      "files": ["src/auth/session.ts", "src/auth/cookies.ts"],
+      "problem": "Callers must know cookie parsing order and session fallback behavior.",
+      "proposed_fix": "Create a deeper Session interface that owns load, refresh, and clear behavior.",
+      "deepening": {
+        "depth": "Callers stop coordinating cookie and session details.",
+        "locality": "Session rules move into one module.",
+        "leverage": "Four callers shrink to one stable interface.",
+        "test_surface": "Tests can exercise session behavior through the public interface."
+      },
+      "priority": "high",
+      "risk": "medium",
+      "effort": "medium",
+      "auto_fix_eligible": true,
+      "verification": ["targeted session tests", "existing auth tests"]
+    }
+  ]
+}
 ```
 
-Omit any pass section with zero findings. If all passes return zero findings:
+### Stage 4: Merge, Score, and Deduplicate
 
+1. Collect findings from all selected passes.
+2. Deduplicate overlapping findings by file + line or shared candidate description.
+3. Assign stable IDs if the detector did not.
+4. Verify priority/risk/effort are present for every finding.
+5. Verify every auto-fix-eligible finding has a concrete verification plan.
+6. Sort by lane, then priority high to low, then risk low to high.
+
+### Stage 5: Present Report
+
+Use this report format:
+
+```markdown
+# /unslop Report
+
+Scope: [N] files changed since [base] or [explicit path]
+Mode: report
+Fix default: safe hygiene + comments/docs only
+Fix all: high-priority eligible fixes across all lanes
+
+## Executive Summary
+
+| Lane | Findings | High | Medium | Low | Auto-fix eligible | Recommended next |
+|------|----------|------|--------|-----|-------------------|------------------|
+| Hygiene | 4 | 1 | 2 | 1 | 3 | /unslop fix hygiene |
+| Comments/docs | 8 | 2 | 4 | 2 | 7 | /unslop fix comments |
+| Frontend/design | 3 | 1 | 2 | 0 | 1 | /unslop fix frontend |
+| Architecture | 3 | 1 | 1 | 1 | 1 | /unslop fix architecture |
+
+## Findings
+
+| ID | Lane | File | Finding | Priority | Risk | Effort | Auto-fix | Next command |
+|----|------|------|---------|----------|------|--------|----------|--------------|
+| H1 | Hygiene | src/foo.ts:42 | Dead helper never used | High | Low | Small | Yes | /unslop fix hygiene H1 |
+| C1 | Comments/docs | src/foo.ts:12 | Comment restates function name | Low | Low | Small | Yes | /unslop fix comments C1 |
+| F1 | Frontend/design | app/card.tsx:70 | Generic card grid lacks hierarchy | High | Medium | Medium | Yes | /unslop fix frontend F1 |
+| A1 | Architecture | src/session.ts | Session rules leak into 4 callers | High | Medium | Medium | Yes | /unslop fix architecture A1 |
 ```
-De-slop Report: Clean! No slop detected in [N] files.
+
+For architecture findings, include a short candidate detail block after the table:
+
+```markdown
+### Architecture Candidate A1
+
+Problem: [problem]
+Proposed deeper interface: [proposed_fix]
+Depth: [depth]
+Locality: [locality]
+Leverage: [leverage]
+Test surface: [test_surface]
+Verification: [commands/checks]
 ```
 
-### Stage 5: Auto-Fix (only if `fix` argument was provided)
+If no findings are present:
 
-If the user invoked `/unslop fix`:
-
-1. Collect all findings where `fix_safe: true`
-2. Apply fixes in file order:
-   - **Code Slop safe fixes:** Remove commented-out code blocks, remove unused imports
-   - **Comment Rot safe fixes:** Delete obvious restatement comments, remove stale TODOs
-3. Do NOT auto-fix:
-   - Design slop (requires design judgment)
-   - Factually inaccurate comments (requires understanding intent)
-   - YAGNI violations (requires knowing the roadmap)
-   - Abstractions (requires understanding the broader architecture)
-4. Report what was fixed:
-
-```
-Auto-fix applied:
-  ✓ Removed 3 commented-out code blocks (42 lines)
-  ✓ Deleted 5 obvious-restatement comments
-  ✓ Removed 2 stale TODOs
-
-  Remaining (manual review needed): 4 findings
+```markdown
+/unslop Report: Clean. No slop detected in [N] files.
 ```
 
-If `fix` was NOT provided but fixable findings exist, suggest it:
+### Stage 6: Fix Selection
 
+For `/unslop fix`, select only auto-fix-eligible code hygiene and comments/docs findings.
+
+For `/unslop fix all` or `/unslop fix --all`, select high-priority, auto-fix-eligible findings across all four lanes.
+
+For lane-specific fixes, select only that lane and the exact priority requested. No priority token means high priority.
+
+Candidate IDs narrow the selected findings after lane and priority selection.
+
+Never apply a finding unless:
+
+- it matches the requested lane/all selection
+- it matches the requested priority selector
+- it is auto-fix eligible
+- it stays within path scope
+- it has a verification plan
+
+### Stage 7: Cleanup Plan Before Edits
+
+Before editing, print a short cleanup plan:
+
+```markdown
+Cleanup plan:
+1. [Lane] [ID] [specific change]
+2. [Lane] [ID] [specific change]
+
+Behavior lock / verification before editing:
+- [command or manual verification]
 ```
-Tip: Run /unslop fix to auto-apply [N] safe fixes
+
+If tests cannot run before editing, record why and name the post-edit verification plan. Do not pretend unverified architecture/frontend work is safe.
+
+### Stage 8: Apply Fixes
+
+Work lane by lane. Prefer deletion before rewriting.
+
+Recommended order:
+
+1. Comments/docs
+2. Hygiene
+3. Frontend/design
+4. Architecture
+
+Run targeted verification after each lane when practical. If verification fails, fix the failure or back out the risky cleanup.
+
+### Stage 9: Final Fix Report
+
+Always report:
+
+```markdown
+## /unslop Fix Report
+
+Changed files:
+- [file]
+
+Simplifications:
+- [ID] [what changed]
+
+Verification run:
+- [command] -> [result]
+
+Skipped findings:
+- [ID] [reason, such as high risk or outside scope]
+
+Remaining risks:
+- [risk or "none known"]
 ```
 
-## Severity Guide
+## Auto-Fix Eligibility Guide
 
-| Level | Meaning | Examples |
-|-------|---------|---------|
-| **High** | Actively misleading or creates maintenance burden | Inaccurate comment, missing hover states, large dead code block |
-| **Medium** | Noticeable slop that reduces quality | Unnecessary abstraction, AI filler phrase, generic gradient |
-| **Low** | Minor quality improvement | Restatement comment, unused import, over-documentation |
+| Lane | Eligible examples | Not eligible by default |
+|------|-------------------|-------------------------|
+| Hygiene | dead comments, unused imports, trivially unused helpers | broad refactors, behavior-changing rewrites |
+| Comments/docs | obvious restatements, stale filler, done TODOs | intent comments, security rationale, external API notes |
+| Frontend/design | missing focus state following existing convention, mechanical token alignment | visual redesign without screenshot verification |
+| Architecture | shallow wrapper deletion, fake seam removal, small deeper interface with tests | high-risk boundary moves, large module migrations |
 
-Slop is never "Critical" — it's a quality concern, not a correctness or security issue.
+## Severity and Scoring
+
+Use **priority** for importance, **risk** for regression chance, and **effort** for implementation size.
+
+Priority:
+
+- High: fixing this materially improves quality or removes real maintenance drag
+- Medium: noticeable quality improvement, but not blocking
+- Low: small cleanup or polish
+
+Risk:
+
+- Low: mechanical or deletion-only with clear verification
+- Medium: modest behavior or visual surface, protected by tests or screenshots
+- High: could change behavior, product semantics, layout intent, or public interfaces
+
+Effort:
+
+- Small: one file or a tiny local edit
+- Medium: several related files, targeted tests
+- Large: cross-module migration or broad redesign
 
 ## Quality Gates
 
 Before presenting findings:
 
-1. **Every finding must be actionable.** Don't say "could be simpler" — say what to change and where.
-2. **No false positives from skimming.** Verify the abstraction isn't used elsewhere before flagging it. Verify the comment is truly redundant.
-3. **Line numbers must be accurate.** Check each cited line against file content.
-4. **Respect project conventions.** If the project uses JSDoc everywhere, don't flag JSDoc as over-documentation.
-5. **Don't flag generated code.** Skip files in `dist/`, `build/`, `node_modules/`, `.next/`, `vendor/`, or similar generated directories.
+1. Every finding must be actionable.
+2. Line numbers must be accurate when line numbers are cited.
+3. Do not flag generated code unless explicitly scoped.
+4. Verify unused/dead code before flagging it as safe.
+5. Respect project conventions.
+6. Do not mark architecture/frontend fixes auto-fix eligible without a verification plan.
+7. Report skipped fixes instead of forcing them.
+
+## Relationship to Other ATV Skills
+
+- Pair with `/ce-review`: correctness and safety review.
+- Pair with `/frontend-design` or design review workflows when frontend findings require real visual judgment.
+- Keep `/lfg` and `/slfg` conservative by default. They should continue to use `/unslop fix` unless the user explicitly asks for `/unslop fix all`.
 
 ## Notes
 
-- This skill is read-only by default. It reports but does not edit files unless `fix` is specified.
-- Design Slop pass is automatically skipped for backend-only projects.
-- Works on any language/framework — the slop patterns are universal.
-- Pairs well with `/ce-review` (which checks correctness) — `/unslop` checks aesthetics and quality.
+- `/unslop` is read-only by default.
+- `/unslop fix` is conservative by default.
+- `/unslop fix all` is intentionally stronger, but still only applies high-priority auto-fix-eligible findings.
+- Architecture reports should use Matt-style deepening candidates, but this skill does not import another skill verbatim.
+- Frontend visual changes need evidence, not just class-name vibes.

--- a/plugins/atv-pack-quality/skills/unslop/SKILL.md
+++ b/plugins/atv-pack-quality/skills/unslop/SKILL.md
@@ -1,341 +1,548 @@
 ---
 name: unslop
-description: "Unified de-slop pass: code simplification + comment rot detection + design slop check. Run after completing features or before PRs to strip AI-generated generic patterns."
-argument-hint: "[blank for recent changes, or file/directory path]"
+description: "Full-surface de-slop workflow: code hygiene, comments/docs, frontend/design, and architecture. Reports everything by default; fixes safe hygiene by default; `fix all` applies high-priority auto-fix-eligible fixes across all lanes."
+argument-hint: "[fix] [all|hygiene|comments|frontend|architecture] [high|medium|low] [candidate IDs or file/directory paths]"
 ---
 
-# /unslop — Strip AI Slop from Your Codebase
+# /unslop - Full-Surface AI Slop Cleanup
 
-Three parallel analysis passes that detect and report AI-generated "slop" — generic, template-looking, over-enthusiastic output that makes code, comments, and UI feel artificial.
+`/unslop` is the broad X-ray for AI-generated slop. It reports every surface where AI-assisted work tends to leave cheapness behind: **code hygiene**, **comments/docs**, **frontend/design**, and **architecture**.
+
+Default behavior is safe:
+
+- `/unslop` reports across all four lanes and does not edit.
+- `/unslop fix` edits only safe code hygiene and comments/docs issues.
+- `/unslop fix all` and `/unslop fix --all` apply **high-priority, auto-fix-eligible fixes across all four lanes**.
+
+Architecture and frontend fixes are allowed only when they pass explicit eligibility gates. Priority selects importance. Eligibility selects safety. Scope selects where edits are allowed.
 
 ## When to Use
 
-- After completing a feature — check for slop before PR
-- Before code review — pre-clean your changes
-- When code "feels AI-generated" but you can't pinpoint why
-- Periodic codebase hygiene — run on a directory
-- After a long AI-assisted session to audit quality
+Use `/unslop` when:
 
-## Argument Parsing
+- a feature works but feels bloated, repetitive, generic, over-commented, or over-abstracted
+- recent AI-assisted work left dead code, filler comments, stale docs, wrapper layers, weak seams, or generic UI
+- a PR needs a quality pass before review
+- you want a ranked cleanup report with priority, risk, effort, and next commands
+- you want high-priority eligible cleanup via `/unslop fix all`
 
-Parse `$ARGUMENTS` for these tokens:
+## When Not to Use
 
-| Token | Example | Effect |
-|-------|---------|--------|
-| `fix` | `/unslop fix` | Auto-apply safe fixes after reporting |
-| `<path>` | `/unslop src/components/` | Scope to specific file or directory |
-| (none) | `/unslop` | Analyze all files changed since the base branch |
+Do not use `/unslop` when:
+
+- the main task is a new feature or behavior change
+- desired behavior is unclear and cannot be protected by tests or a concrete verification plan
+- the user wants a broad redesign rather than an incremental cleanup pass
+- the request is only formatting or lint trivia
+- the cleanup would require product decisions the user has not made
+
+## Command Contract
+
+The parser should be forgiving. This is a slash-command skill, not a strict Unix binary. Accept flag forms and natural token forms.
+
+### Report Commands
+
+| Command | Behavior |
+|---------|----------|
+| `/unslop` | Full read-only report across all lanes |
+| `/unslop hygiene` or `/unslop --hygiene` | Code hygiene report only |
+| `/unslop comments` or `/unslop --comments` | Comments/docs report only |
+| `/unslop frontend` or `/unslop --frontend` | Frontend/design report only |
+| `/unslop architecture` or `/unslop --architecture` | Architecture report only |
+| `/unslop src/auth` | Full report scoped to a path |
+
+### Fix Commands
+
+| Command | Behavior |
+|---------|----------|
+| `/unslop fix` | Safe default: code hygiene + comments/docs only |
+| `/unslop fix all` or `/unslop fix --all` | High-priority, auto-fix-eligible fixes across all four lanes |
+| `/unslop fix hygiene` or `/unslop fix --hygiene` | High-priority eligible code hygiene fixes only |
+| `/unslop fix comments` or `/unslop fix --comments` | High-priority eligible comments/docs fixes only |
+| `/unslop fix frontend` or `/unslop fix --frontend` | High-priority eligible frontend/design fixes only |
+| `/unslop fix architecture` or `/unslop fix --architecture` | High-priority eligible architecture fixes only |
+| `/unslop fix architecture medium` | Medium-priority eligible architecture fixes only |
+| `/unslop fix frontend low` | Low-priority eligible frontend/design fixes only |
+| `/unslop fix architecture A1` | Candidate-scoped architecture fix |
+| `/unslop fix all app/components` | High-priority eligible fixes across all lanes inside a path |
+| `/unslop fix architecture --dry-run` | Preview selected fixes without editing |
+
+### Aliases
+
+| Canonical token | Accepted aliases |
+|-----------------|------------------|
+| `all` | `--all` |
+| `hygiene` | `--hygiene`, `code-hygiene` |
+| `comments` | `--comments`, `comment`, `docs`, `documentation` |
+| `frontend` | `--frontend`, `front-end`, `design` |
+| `architecture` | `--architecture`, `arch` |
+| `high` | `--high` |
+| `medium` | `--medium` |
+| `low` | `--low` |
+| `dry-run` | `--dry-run`, `preview` |
+
+### Priority Selectors
+
+**Priority selectors are exact**, not cumulative.
+
+| Selector | Meaning |
+|----------|---------|
+| no priority token | high priority only |
+| `high` | high priority only |
+| `medium` | medium priority only |
+| `low` | low priority only |
+
+`all` does not mean all priorities. In v2, `all` means all lanes with high-priority eligible fixes.
+
+### Candidate and Path Scope
+
+Candidate IDs narrow the selected fixes:
+
+- `H1`, `H2` for hygiene
+- `C1`, `C2` for comments/docs
+- `F1`, `F2` for frontend/design
+- `A1`, `A2` for architecture
+
+Examples:
+
+```text
+/unslop fix architecture A1
+/unslop fix frontend F1,F4
+/unslop fix comments C2 src/api
+```
+
+Paths narrow analysis and edits:
+
+```text
+/unslop src/auth
+/unslop fix architecture src/auth
+/unslop fix all app/components
+```
+
+Do not silently expand a path-scoped run into unrelated files except to verify references/usages. If a safe fix requires editing outside scope, skip it and report why.
+
+### Conflict Rule
+
+**Multiple lane selectors are rejected** unless the user chose `all`.
+
+Reject:
+
+```text
+/unslop fix frontend architecture
+/unslop fix --frontend --architecture
+```
+
+Return:
+
+```text
+Choose one lane, or use all.
+
+Examples:
+- /unslop fix frontend
+- /unslop fix architecture
+- /unslop fix all
+```
+
+## Lanes
+
+### Lane 1: Code Hygiene
+
+Find and optionally fix mechanical code slop:
+
+- commented-out code blocks
+- unused imports, variables, functions, or helpers
+- duplicate tiny helpers
+- needless defensive branches that cannot trigger
+- pointless wrappers that add no behavior
+- deep nesting that can be safely flattened with early returns
+- copy-paste branches with identical behavior
+
+Safe fixes are deletion-first. Prefer deleting code over rewriting code. Prefer inlining over a new abstraction. Do not add dependencies during `/unslop` unless the user explicitly asks.
+
+### Lane 2: Comments/docs
+
+Find and optionally fix comment and documentation slop:
+
+- comments that restate the next line of code
+- filler phrases such as "this function is responsible for"
+- stale TODOs or FIXMEs that are already done
+- inaccurate parameter or return docs
+- redundant JSDoc/docstrings on trivial getters or obvious one-liners
+- section divider comments that add noise but no navigation value
+- docs that describe implementation details no caller should know
+
+Safe fixes include deleting obvious restatement comments and stale filler. Do not delete a comment that explains non-obvious intent, edge cases, product constraints, security rationale, or external system behavior.
+
+### Lane 3: Frontend/design
+
+Find and optionally fix UI slop:
+
+- generic AI color palettes, especially default blue/purple gradients without brand rationale
+- uniform 3-column card grids with no hierarchy
+- weak empty/loading/error/success states
+- missing hover/focus/active states on interactive elements
+- design-system bypasses and one-off class soup
+- repetitive eyebrow/title/description stuffing
+- emoji badges or decorative icons with no product voice
+- uniform radius/shadow treatment on every surface
+- overly perfect layouts where rhythm or emphasis would help
+- components whose props expose implementation detail instead of product concepts
+
+Frontend fixes require extra care. Auto-fix only when the change is eligible:
+
+- the fix is mechanical accessibility or interaction-state cleanup, or
+- an existing design-system convention clearly dictates the change, or
+- screenshot/browser verification is possible and included in the report
+
+If visual verification is not possible for a visual/layout change, skip the fix and report the exact command or manual review needed.
+
+### Lane 4: Architecture
+
+Add an **Architecture Slop Detector** pass. It should use Matt-style deepening language and report architecture findings as candidates, not vague refactor opinions.
+
+Look for:
+
+- shallow modules where the interface is almost as complex as the implementation
+- pass-through wrappers that hide nothing
+- fake seams or adapters with one implementation and no real substitutability
+- caller knowledge leakage, where call sites know ordering, invariants, retries, parsing, or lifecycle details
+- duplicated orchestration spread across multiple files
+- modules that fail the deletion test: deleting the module removes complexity instead of moving useful complexity behind a deeper interface
+- frontend component boundaries where props mirror implementation details instead of product concepts
+- tests that mock internals instead of testing through a stable public interface
+- interfaces that make easy things verbose and hard things impossible
+
+Use these terms in findings where relevant:
+
+- module
+- interface
+- implementation
+- depth
+- seam
+- adapter
+- leverage
+- locality
+- test surface
+
+Architecture fixes are eligible only when they are scoped, testable, and low enough risk. High-risk architecture findings must remain report-only unless the user selects a specific candidate and the verification plan is explicit.
 
 ## Execution Flow
 
-### Stage 1: Determine Scope
+### Stage 1: Parse Arguments
 
-**If a file or directory path is provided:**
+Determine:
 
-Scope to that path. Use `find` or glob to list all code files under it.
+1. Mode: report or fix
+2. Lane selector: all lanes, one lane, or safe default
+3. Priority selector: high by default for lane/all fixes, exact `high`/`medium`/`low` when provided
+4. Candidate IDs, if present
+5. Path scope, if present
+6. Dry-run/preview mode, if present
+7. Conflicts, especially multiple lanes without `all`
 
-**If no argument (default):**
+### Stage 2: Determine Scope
 
-Determine changed files since the base branch:
+If path arguments are provided, scope to those files/directories.
+
+If no path is provided, use changed files since the base branch:
 
 ```bash
 BASE=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD origin/master 2>/dev/null || echo "HEAD~10")
-echo "FILES:" && git diff --name-only $BASE
-echo "DIFF:" && git diff -U5 $BASE
+echo "FILES:" && git diff --name-only "$BASE"
+echo "DIFF:" && git diff -U5 "$BASE"
 ```
 
-**Classify files in scope:**
+Skip generated/vendor output such as `dist/`, `build/`, `node_modules/`, `.next/`, `vendor/`, checked-in minified bundles, and generated lockfile chunks unless the user explicitly scoped to them.
 
-| File extensions | Passes to run |
-|----------------|---------------|
-| `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rb`, `.rs`, `.java`, `.cs`, `.swift`, `.kt` | Code Slop + Comment Rot |
-| `.css`, `.scss`, `.less`, `.tsx`, `.jsx`, `.html`, `.vue`, `.svelte` | + Design Slop |
-| `.json`, `.yaml`, `.yml`, `.toml`, `.md` | Code Slop + Comment Rot only |
+### Stage 3: Run Analysis Passes
 
-If no UI/style files are in scope, skip the Design Slop pass entirely.
+Run all selected lanes. For default `/unslop`, run every lane that applies to the scope.
 
-Announce the scope:
+If the harness supports safe read-only delegated analysis, the passes may run in parallel. If not, run them sequentially. The output contract is the same either way.
 
-```
-De-slop scope: 14 files changed since origin/main
-Passes: Code Slop | Comment Rot | Design Slop (3 UI files detected)
-```
+#### Pass 1: Hygiene Detector
 
-### Stage 2: Parallel Analysis
+Return:
 
-Launch three sub-agents IN PARALLEL. Each receives the file list and diff content, and returns structured findings as text.
-
-<parallel_tasks>
-
-#### Pass 1: Code Slop Detector
-
-You are a code simplification expert. Analyze the provided files for AI-generated slop patterns. Focus ONLY on slop — not correctness, security, or architecture.
-
-**What to flag:**
-
-1. **Unnecessary complexity**
-   - Deep nesting (>3 levels) that could use early returns
-   - Nested ternary operators — use if/else or switch
-   - Dense one-liners that sacrifice readability for brevity
-
-2. **Redundant abstractions**
-   - Interfaces/types used only once — inline them
-   - Wrapper functions that add no logic — call the wrapped function directly
-   - Abstract base classes with a single implementation
-   - Premature generalization ("just in case" extensibility points)
-
-3. **YAGNI violations**
-   - Features not required by current use cases
-   - Configuration options nobody uses
-   - Generic solutions for specific problems
-   - "Future-proofing" code that adds complexity now
-
-4. **Dead weight**
-   - Commented-out code blocks (>3 lines)
-   - Unused imports, variables, or functions
-   - Duplicate error checks (caller already validates)
-   - Defensive code that can never trigger (type system prevents it)
-
-5. **Over-engineering**
-   - Factory patterns for creating a single type
-   - Strategy patterns with one strategy
-   - Event systems for synchronous single-consumer flows
-   - Dependency injection where direct instantiation is clearer
-
-**Return format:**
 ```json
 {
-  "pass": "code-slop",
+  "pass": "hygiene",
   "findings": [
     {
+      "id": "H1",
       "file": "src/auth.ts",
       "line": 42,
-      "issue": "Nested ternary — use if/else for readability",
-      "severity": "medium",
-      "fix_safe": true,
-      "suggested_fix": "Replace ternary chain with if/else block"
+      "finding": "Commented-out fallback branch is dead weight.",
+      "priority": "high",
+      "risk": "low",
+      "effort": "small",
+      "auto_fix_eligible": true,
+      "suggested_fix": "Delete the commented block.",
+      "verification": ["go test ./..."]
     }
   ]
 }
 ```
 
-#### Pass 2: Comment Rot Detector
+#### Pass 2: Comments/docs Detector
 
-You are a technical documentation expert specializing in comment quality. Analyze the provided files for comment rot — inaccurate, redundant, or AI-generated filler comments.
+Return:
 
-**What to flag:**
-
-1. **Obvious restatements**
-   - `// increment counter` above `counter++`
-   - `// return the result` above `return result`
-   - `// set the name` above `this.name = name`
-   - Comments that repeat the function/variable name in prose
-
-2. **AI-generated filler phrases** (hard bans — flag these immediately)
-   - "This function is responsible for handling..."
-   - "The following code implements..."
-   - "This is a comprehensive solution that..."
-   - "This method provides a robust and scalable..."
-   - "leverages" or "utilizes" (when "uses" works fine)
-   - "seamlessly integrates"
-   - "In today's rapidly evolving..."
-   - "game-changer", "revolutionary", "cutting-edge"
-   - "This class encapsulates the logic for..."
-   - "Ensures proper handling of..."
-
-3. **Factual inaccuracy**
-   - Documented parameters that don't match the function signature
-   - Return type descriptions that don't match the actual return
-   - Described behavior that doesn't match the code logic
-   - Edge case documentation for cases not actually handled
-
-4. **Stale comments**
-   - TODOs/FIXMEs for work that's already been done
-   - References to removed/renamed functions, classes, or files
-   - Version-specific notes for versions no longer supported
-   - "Temporary" markers on permanent code
-
-5. **Over-documentation**
-   - JSDoc/docstrings on trivial getters/setters
-   - Multi-line comments on self-explanatory one-liners
-   - Repeating type information already in the signature
-   - Section divider comments (`// ==================`)
-
-**Return format:**
 ```json
 {
-  "pass": "comment-rot",
+  "pass": "comments-docs",
   "findings": [
     {
+      "id": "C1",
       "file": "src/auth.ts",
       "line": 10,
-      "issue": "\"This function handles authentication\" — restates the function name",
-      "severity": "low",
-      "fix_safe": true,
-      "suggested_fix": "Remove comment — function name is self-documenting"
+      "finding": "Comment restates the function name instead of explaining intent.",
+      "priority": "low",
+      "risk": "low",
+      "effort": "small",
+      "auto_fix_eligible": true,
+      "suggested_fix": "Remove the comment.",
+      "verification": ["go test ./..."]
     }
   ]
 }
 ```
 
-#### Pass 3: Design Slop Detector
+#### Pass 3: Frontend/design Detector
 
-**Only run this pass when UI/style files are in scope.**
+Return:
 
-You are a design quality expert. Analyze the provided UI files for AI-generated visual slop — generic, template-looking patterns that signal "an AI made this, not a designer."
-
-**What to flag:**
-
-1. **Generic color patterns**
-   - Purple-to-blue gradients (the AI default palette)
-   - Gratuitous gradients on everything (buttons, cards, backgrounds)
-   - Safe gray-on-white with one decorative accent color
-   - Unintentional color usage (decorative, not semantic)
-
-2. **Template layouts**
-   - Default card grids with uniform spacing and no hierarchy
-   - Generic hero: centered headline + subtitle + gradient blob + CTA
-   - Dashboard-by-numbers: sidebar + cards + charts with no point of view
-   - Uniform radius, spacing, and shadows across every component
-
-3. **Missing interaction states**
-   - No hover states on interactive elements
-   - No focus states (accessibility gap)
-   - No active/pressed states
-   - No loading/empty/error states
-
-4. **Lazy defaults**
-   - Unmodified library defaults (default shadcn/Tailwind without customization)
-   - Default font stacks with no intentional pairing
-   - Glassmorphism cards that serve no UI purpose
-   - Rounded corners on elements that shouldn't be rounded (tables, code blocks)
-   - Excessive scroll-triggered animations
-
-5. **No visual hierarchy**
-   - Flat layouts with no layering, depth, or motion
-   - Uniform emphasis on everything (nothing stands out)
-   - No intentional rhythm in spacing
-
-**Return format:**
 ```json
 {
-  "pass": "design-slop",
+  "pass": "frontend-design",
   "findings": [
     {
+      "id": "F1",
       "file": "src/Hero.tsx",
       "line": 22,
-      "issue": "Generic purple-to-blue gradient — replace with brand palette",
-      "severity": "medium",
-      "fix_safe": false,
-      "suggested_fix": "Define an intentional brand gradient in design tokens"
+      "finding": "Generic card grid gives every item equal weight and weakens hierarchy.",
+      "priority": "high",
+      "risk": "medium",
+      "effort": "medium",
+      "auto_fix_eligible": true,
+      "suggested_fix": "Promote the primary card and add a focused empty/error state treatment using existing design tokens.",
+      "verification": ["take before/after screenshots", "run affected frontend tests"]
     }
   ]
 }
 ```
 
-</parallel_tasks>
+#### Pass 4: Architecture Slop Detector
 
-### Stage 3: Merge & Deduplicate
+Return Matt-style deepening candidates:
 
-**WAIT for all Stage 2 sub-agents to complete.**
-
-1. Collect findings from all passes that ran
-2. Deduplicate: if two passes flag the same file+line (within 3 lines), keep the more specific finding and note both passes
-3. Sort by severity: High → Medium → Low
-4. Group by pass for the report
-
-### Stage 4: Present Report
-
-Format the consolidated report using pipe-delimited markdown tables:
-
-```
-De-slop Report
-==============
-Scope: [N] files changed since [base]
-Passes: Code Slop [✓|✗] | Comment Rot [✓|✗] | Design Slop [✓|skipped]
-
-## Code Slop ([N] findings)
-
-| # | File | Line | Issue | Severity |
-|---|------|------|-------|----------|
-| 1 | path | line | description | High/Medium/Low |
-
-## Comment Rot ([N] findings)
-
-| # | File | Line | Issue | Severity |
-|---|------|------|-------|----------|
-| 1 | path | line | description | High/Medium/Low |
-
-## Design Slop ([N] findings)
-
-| # | File | Line | Issue | Severity |
-|---|------|------|-------|----------|
-| 1 | path | line | description | High/Medium/Low |
-
-─────────────────────────────
-Summary: [N] findings ([H] High, [M] Medium, [L] Low)
-Potential LOC reduction: ~[N] lines
+```json
+{
+  "pass": "architecture-slop",
+  "findings": [
+    {
+      "id": "A1",
+      "files": ["src/auth/session.ts", "src/auth/cookies.ts"],
+      "problem": "Callers must know cookie parsing order and session fallback behavior.",
+      "proposed_fix": "Create a deeper Session interface that owns load, refresh, and clear behavior.",
+      "deepening": {
+        "depth": "Callers stop coordinating cookie and session details.",
+        "locality": "Session rules move into one module.",
+        "leverage": "Four callers shrink to one stable interface.",
+        "test_surface": "Tests can exercise session behavior through the public interface."
+      },
+      "priority": "high",
+      "risk": "medium",
+      "effort": "medium",
+      "auto_fix_eligible": true,
+      "verification": ["targeted session tests", "existing auth tests"]
+    }
+  ]
+}
 ```
 
-Omit any pass section with zero findings. If all passes return zero findings:
+### Stage 4: Merge, Score, and Deduplicate
 
+1. Collect findings from all selected passes.
+2. Deduplicate overlapping findings by file + line or shared candidate description.
+3. Assign stable IDs if the detector did not.
+4. Verify priority/risk/effort are present for every finding.
+5. Verify every auto-fix-eligible finding has a concrete verification plan.
+6. Sort by lane, then priority high to low, then risk low to high.
+
+### Stage 5: Present Report
+
+Use this report format:
+
+```markdown
+# /unslop Report
+
+Scope: [N] files changed since [base] or [explicit path]
+Mode: report
+Fix default: safe hygiene + comments/docs only
+Fix all: high-priority eligible fixes across all lanes
+
+## Executive Summary
+
+| Lane | Findings | High | Medium | Low | Auto-fix eligible | Recommended next |
+|------|----------|------|--------|-----|-------------------|------------------|
+| Hygiene | 4 | 1 | 2 | 1 | 3 | /unslop fix hygiene |
+| Comments/docs | 8 | 2 | 4 | 2 | 7 | /unslop fix comments |
+| Frontend/design | 3 | 1 | 2 | 0 | 1 | /unslop fix frontend |
+| Architecture | 3 | 1 | 1 | 1 | 1 | /unslop fix architecture |
+
+## Findings
+
+| ID | Lane | File | Finding | Priority | Risk | Effort | Auto-fix | Next command |
+|----|------|------|---------|----------|------|--------|----------|--------------|
+| H1 | Hygiene | src/foo.ts:42 | Dead helper never used | High | Low | Small | Yes | /unslop fix hygiene H1 |
+| C1 | Comments/docs | src/foo.ts:12 | Comment restates function name | Low | Low | Small | Yes | /unslop fix comments C1 |
+| F1 | Frontend/design | app/card.tsx:70 | Generic card grid lacks hierarchy | High | Medium | Medium | Yes | /unslop fix frontend F1 |
+| A1 | Architecture | src/session.ts | Session rules leak into 4 callers | High | Medium | Medium | Yes | /unslop fix architecture A1 |
 ```
-De-slop Report: Clean! No slop detected in [N] files.
+
+For architecture findings, include a short candidate detail block after the table:
+
+```markdown
+### Architecture Candidate A1
+
+Problem: [problem]
+Proposed deeper interface: [proposed_fix]
+Depth: [depth]
+Locality: [locality]
+Leverage: [leverage]
+Test surface: [test_surface]
+Verification: [commands/checks]
 ```
 
-### Stage 5: Auto-Fix (only if `fix` argument was provided)
+If no findings are present:
 
-If the user invoked `/unslop fix`:
-
-1. Collect all findings where `fix_safe: true`
-2. Apply fixes in file order:
-   - **Code Slop safe fixes:** Remove commented-out code blocks, remove unused imports
-   - **Comment Rot safe fixes:** Delete obvious restatement comments, remove stale TODOs
-3. Do NOT auto-fix:
-   - Design slop (requires design judgment)
-   - Factually inaccurate comments (requires understanding intent)
-   - YAGNI violations (requires knowing the roadmap)
-   - Abstractions (requires understanding the broader architecture)
-4. Report what was fixed:
-
-```
-Auto-fix applied:
-  ✓ Removed 3 commented-out code blocks (42 lines)
-  ✓ Deleted 5 obvious-restatement comments
-  ✓ Removed 2 stale TODOs
-
-  Remaining (manual review needed): 4 findings
+```markdown
+/unslop Report: Clean. No slop detected in [N] files.
 ```
 
-If `fix` was NOT provided but fixable findings exist, suggest it:
+### Stage 6: Fix Selection
 
+For `/unslop fix`, select only auto-fix-eligible code hygiene and comments/docs findings.
+
+For `/unslop fix all` or `/unslop fix --all`, select high-priority, auto-fix-eligible findings across all four lanes.
+
+For lane-specific fixes, select only that lane and the exact priority requested. No priority token means high priority.
+
+Candidate IDs narrow the selected findings after lane and priority selection.
+
+Never apply a finding unless:
+
+- it matches the requested lane/all selection
+- it matches the requested priority selector
+- it is auto-fix eligible
+- it stays within path scope
+- it has a verification plan
+
+### Stage 7: Cleanup Plan Before Edits
+
+Before editing, print a short cleanup plan:
+
+```markdown
+Cleanup plan:
+1. [Lane] [ID] [specific change]
+2. [Lane] [ID] [specific change]
+
+Behavior lock / verification before editing:
+- [command or manual verification]
 ```
-Tip: Run /unslop fix to auto-apply [N] safe fixes
+
+If tests cannot run before editing, record why and name the post-edit verification plan. Do not pretend unverified architecture/frontend work is safe.
+
+### Stage 8: Apply Fixes
+
+Work lane by lane. Prefer deletion before rewriting.
+
+Recommended order:
+
+1. Comments/docs
+2. Hygiene
+3. Frontend/design
+4. Architecture
+
+Run targeted verification after each lane when practical. If verification fails, fix the failure or back out the risky cleanup.
+
+### Stage 9: Final Fix Report
+
+Always report:
+
+```markdown
+## /unslop Fix Report
+
+Changed files:
+- [file]
+
+Simplifications:
+- [ID] [what changed]
+
+Verification run:
+- [command] -> [result]
+
+Skipped findings:
+- [ID] [reason, such as high risk or outside scope]
+
+Remaining risks:
+- [risk or "none known"]
 ```
 
-## Severity Guide
+## Auto-Fix Eligibility Guide
 
-| Level | Meaning | Examples |
-|-------|---------|---------|
-| **High** | Actively misleading or creates maintenance burden | Inaccurate comment, missing hover states, large dead code block |
-| **Medium** | Noticeable slop that reduces quality | Unnecessary abstraction, AI filler phrase, generic gradient |
-| **Low** | Minor quality improvement | Restatement comment, unused import, over-documentation |
+| Lane | Eligible examples | Not eligible by default |
+|------|-------------------|-------------------------|
+| Hygiene | dead comments, unused imports, trivially unused helpers | broad refactors, behavior-changing rewrites |
+| Comments/docs | obvious restatements, stale filler, done TODOs | intent comments, security rationale, external API notes |
+| Frontend/design | missing focus state following existing convention, mechanical token alignment | visual redesign without screenshot verification |
+| Architecture | shallow wrapper deletion, fake seam removal, small deeper interface with tests | high-risk boundary moves, large module migrations |
 
-Slop is never "Critical" — it's a quality concern, not a correctness or security issue.
+## Severity and Scoring
+
+Use **priority** for importance, **risk** for regression chance, and **effort** for implementation size.
+
+Priority:
+
+- High: fixing this materially improves quality or removes real maintenance drag
+- Medium: noticeable quality improvement, but not blocking
+- Low: small cleanup or polish
+
+Risk:
+
+- Low: mechanical or deletion-only with clear verification
+- Medium: modest behavior or visual surface, protected by tests or screenshots
+- High: could change behavior, product semantics, layout intent, or public interfaces
+
+Effort:
+
+- Small: one file or a tiny local edit
+- Medium: several related files, targeted tests
+- Large: cross-module migration or broad redesign
 
 ## Quality Gates
 
 Before presenting findings:
 
-1. **Every finding must be actionable.** Don't say "could be simpler" — say what to change and where.
-2. **No false positives from skimming.** Verify the abstraction isn't used elsewhere before flagging it. Verify the comment is truly redundant.
-3. **Line numbers must be accurate.** Check each cited line against file content.
-4. **Respect project conventions.** If the project uses JSDoc everywhere, don't flag JSDoc as over-documentation.
-5. **Don't flag generated code.** Skip files in `dist/`, `build/`, `node_modules/`, `.next/`, `vendor/`, or similar generated directories.
+1. Every finding must be actionable.
+2. Line numbers must be accurate when line numbers are cited.
+3. Do not flag generated code unless explicitly scoped.
+4. Verify unused/dead code before flagging it as safe.
+5. Respect project conventions.
+6. Do not mark architecture/frontend fixes auto-fix eligible without a verification plan.
+7. Report skipped fixes instead of forcing them.
+
+## Relationship to Other ATV Skills
+
+- Pair with `/ce-review`: correctness and safety review.
+- Pair with `/frontend-design` or design review workflows when frontend findings require real visual judgment.
+- Keep `/lfg` and `/slfg` conservative by default. They should continue to use `/unslop fix` unless the user explicitly asks for `/unslop fix all`.
 
 ## Notes
 
-- This skill is read-only by default. It reports but does not edit files unless `fix` is specified.
-- Design Slop pass is automatically skipped for backend-only projects.
-- Works on any language/framework — the slop patterns are universal.
-- Pairs well with `/ce-review` (which checks correctness) — `/unslop` checks aesthetics and quality.
+- `/unslop` is read-only by default.
+- `/unslop fix` is conservative by default.
+- `/unslop fix all` is intentionally stronger, but still only applies high-priority auto-fix-eligible findings.
+- Architecture reports should use Matt-style deepening candidates, but this skill does not import another skill verbatim.
+- Frontend visual changes need evidence, not just class-name vibes.

--- a/plugins/atv-skill-unslop/skills/unslop/SKILL.md
+++ b/plugins/atv-skill-unslop/skills/unslop/SKILL.md
@@ -1,341 +1,548 @@
 ---
 name: unslop
-description: "Unified de-slop pass: code simplification + comment rot detection + design slop check. Run after completing features or before PRs to strip AI-generated generic patterns."
-argument-hint: "[blank for recent changes, or file/directory path]"
+description: "Full-surface de-slop workflow: code hygiene, comments/docs, frontend/design, and architecture. Reports everything by default; fixes safe hygiene by default; `fix all` applies high-priority auto-fix-eligible fixes across all lanes."
+argument-hint: "[fix] [all|hygiene|comments|frontend|architecture] [high|medium|low] [candidate IDs or file/directory paths]"
 ---
 
-# /unslop — Strip AI Slop from Your Codebase
+# /unslop - Full-Surface AI Slop Cleanup
 
-Three parallel analysis passes that detect and report AI-generated "slop" — generic, template-looking, over-enthusiastic output that makes code, comments, and UI feel artificial.
+`/unslop` is the broad X-ray for AI-generated slop. It reports every surface where AI-assisted work tends to leave cheapness behind: **code hygiene**, **comments/docs**, **frontend/design**, and **architecture**.
+
+Default behavior is safe:
+
+- `/unslop` reports across all four lanes and does not edit.
+- `/unslop fix` edits only safe code hygiene and comments/docs issues.
+- `/unslop fix all` and `/unslop fix --all` apply **high-priority, auto-fix-eligible fixes across all four lanes**.
+
+Architecture and frontend fixes are allowed only when they pass explicit eligibility gates. Priority selects importance. Eligibility selects safety. Scope selects where edits are allowed.
 
 ## When to Use
 
-- After completing a feature — check for slop before PR
-- Before code review — pre-clean your changes
-- When code "feels AI-generated" but you can't pinpoint why
-- Periodic codebase hygiene — run on a directory
-- After a long AI-assisted session to audit quality
+Use `/unslop` when:
 
-## Argument Parsing
+- a feature works but feels bloated, repetitive, generic, over-commented, or over-abstracted
+- recent AI-assisted work left dead code, filler comments, stale docs, wrapper layers, weak seams, or generic UI
+- a PR needs a quality pass before review
+- you want a ranked cleanup report with priority, risk, effort, and next commands
+- you want high-priority eligible cleanup via `/unslop fix all`
 
-Parse `$ARGUMENTS` for these tokens:
+## When Not to Use
 
-| Token | Example | Effect |
-|-------|---------|--------|
-| `fix` | `/unslop fix` | Auto-apply safe fixes after reporting |
-| `<path>` | `/unslop src/components/` | Scope to specific file or directory |
-| (none) | `/unslop` | Analyze all files changed since the base branch |
+Do not use `/unslop` when:
+
+- the main task is a new feature or behavior change
+- desired behavior is unclear and cannot be protected by tests or a concrete verification plan
+- the user wants a broad redesign rather than an incremental cleanup pass
+- the request is only formatting or lint trivia
+- the cleanup would require product decisions the user has not made
+
+## Command Contract
+
+The parser should be forgiving. This is a slash-command skill, not a strict Unix binary. Accept flag forms and natural token forms.
+
+### Report Commands
+
+| Command | Behavior |
+|---------|----------|
+| `/unslop` | Full read-only report across all lanes |
+| `/unslop hygiene` or `/unslop --hygiene` | Code hygiene report only |
+| `/unslop comments` or `/unslop --comments` | Comments/docs report only |
+| `/unslop frontend` or `/unslop --frontend` | Frontend/design report only |
+| `/unslop architecture` or `/unslop --architecture` | Architecture report only |
+| `/unslop src/auth` | Full report scoped to a path |
+
+### Fix Commands
+
+| Command | Behavior |
+|---------|----------|
+| `/unslop fix` | Safe default: code hygiene + comments/docs only |
+| `/unslop fix all` or `/unslop fix --all` | High-priority, auto-fix-eligible fixes across all four lanes |
+| `/unslop fix hygiene` or `/unslop fix --hygiene` | High-priority eligible code hygiene fixes only |
+| `/unslop fix comments` or `/unslop fix --comments` | High-priority eligible comments/docs fixes only |
+| `/unslop fix frontend` or `/unslop fix --frontend` | High-priority eligible frontend/design fixes only |
+| `/unslop fix architecture` or `/unslop fix --architecture` | High-priority eligible architecture fixes only |
+| `/unslop fix architecture medium` | Medium-priority eligible architecture fixes only |
+| `/unslop fix frontend low` | Low-priority eligible frontend/design fixes only |
+| `/unslop fix architecture A1` | Candidate-scoped architecture fix |
+| `/unslop fix all app/components` | High-priority eligible fixes across all lanes inside a path |
+| `/unslop fix architecture --dry-run` | Preview selected fixes without editing |
+
+### Aliases
+
+| Canonical token | Accepted aliases |
+|-----------------|------------------|
+| `all` | `--all` |
+| `hygiene` | `--hygiene`, `code-hygiene` |
+| `comments` | `--comments`, `comment`, `docs`, `documentation` |
+| `frontend` | `--frontend`, `front-end`, `design` |
+| `architecture` | `--architecture`, `arch` |
+| `high` | `--high` |
+| `medium` | `--medium` |
+| `low` | `--low` |
+| `dry-run` | `--dry-run`, `preview` |
+
+### Priority Selectors
+
+**Priority selectors are exact**, not cumulative.
+
+| Selector | Meaning |
+|----------|---------|
+| no priority token | high priority only |
+| `high` | high priority only |
+| `medium` | medium priority only |
+| `low` | low priority only |
+
+`all` does not mean all priorities. In v2, `all` means all lanes with high-priority eligible fixes.
+
+### Candidate and Path Scope
+
+Candidate IDs narrow the selected fixes:
+
+- `H1`, `H2` for hygiene
+- `C1`, `C2` for comments/docs
+- `F1`, `F2` for frontend/design
+- `A1`, `A2` for architecture
+
+Examples:
+
+```text
+/unslop fix architecture A1
+/unslop fix frontend F1,F4
+/unslop fix comments C2 src/api
+```
+
+Paths narrow analysis and edits:
+
+```text
+/unslop src/auth
+/unslop fix architecture src/auth
+/unslop fix all app/components
+```
+
+Do not silently expand a path-scoped run into unrelated files except to verify references/usages. If a safe fix requires editing outside scope, skip it and report why.
+
+### Conflict Rule
+
+**Multiple lane selectors are rejected** unless the user chose `all`.
+
+Reject:
+
+```text
+/unslop fix frontend architecture
+/unslop fix --frontend --architecture
+```
+
+Return:
+
+```text
+Choose one lane, or use all.
+
+Examples:
+- /unslop fix frontend
+- /unslop fix architecture
+- /unslop fix all
+```
+
+## Lanes
+
+### Lane 1: Code Hygiene
+
+Find and optionally fix mechanical code slop:
+
+- commented-out code blocks
+- unused imports, variables, functions, or helpers
+- duplicate tiny helpers
+- needless defensive branches that cannot trigger
+- pointless wrappers that add no behavior
+- deep nesting that can be safely flattened with early returns
+- copy-paste branches with identical behavior
+
+Safe fixes are deletion-first. Prefer deleting code over rewriting code. Prefer inlining over a new abstraction. Do not add dependencies during `/unslop` unless the user explicitly asks.
+
+### Lane 2: Comments/docs
+
+Find and optionally fix comment and documentation slop:
+
+- comments that restate the next line of code
+- filler phrases such as "this function is responsible for"
+- stale TODOs or FIXMEs that are already done
+- inaccurate parameter or return docs
+- redundant JSDoc/docstrings on trivial getters or obvious one-liners
+- section divider comments that add noise but no navigation value
+- docs that describe implementation details no caller should know
+
+Safe fixes include deleting obvious restatement comments and stale filler. Do not delete a comment that explains non-obvious intent, edge cases, product constraints, security rationale, or external system behavior.
+
+### Lane 3: Frontend/design
+
+Find and optionally fix UI slop:
+
+- generic AI color palettes, especially default blue/purple gradients without brand rationale
+- uniform 3-column card grids with no hierarchy
+- weak empty/loading/error/success states
+- missing hover/focus/active states on interactive elements
+- design-system bypasses and one-off class soup
+- repetitive eyebrow/title/description stuffing
+- emoji badges or decorative icons with no product voice
+- uniform radius/shadow treatment on every surface
+- overly perfect layouts where rhythm or emphasis would help
+- components whose props expose implementation detail instead of product concepts
+
+Frontend fixes require extra care. Auto-fix only when the change is eligible:
+
+- the fix is mechanical accessibility or interaction-state cleanup, or
+- an existing design-system convention clearly dictates the change, or
+- screenshot/browser verification is possible and included in the report
+
+If visual verification is not possible for a visual/layout change, skip the fix and report the exact command or manual review needed.
+
+### Lane 4: Architecture
+
+Add an **Architecture Slop Detector** pass. It should use Matt-style deepening language and report architecture findings as candidates, not vague refactor opinions.
+
+Look for:
+
+- shallow modules where the interface is almost as complex as the implementation
+- pass-through wrappers that hide nothing
+- fake seams or adapters with one implementation and no real substitutability
+- caller knowledge leakage, where call sites know ordering, invariants, retries, parsing, or lifecycle details
+- duplicated orchestration spread across multiple files
+- modules that fail the deletion test: deleting the module removes complexity instead of moving useful complexity behind a deeper interface
+- frontend component boundaries where props mirror implementation details instead of product concepts
+- tests that mock internals instead of testing through a stable public interface
+- interfaces that make easy things verbose and hard things impossible
+
+Use these terms in findings where relevant:
+
+- module
+- interface
+- implementation
+- depth
+- seam
+- adapter
+- leverage
+- locality
+- test surface
+
+Architecture fixes are eligible only when they are scoped, testable, and low enough risk. High-risk architecture findings must remain report-only unless the user selects a specific candidate and the verification plan is explicit.
 
 ## Execution Flow
 
-### Stage 1: Determine Scope
+### Stage 1: Parse Arguments
 
-**If a file or directory path is provided:**
+Determine:
 
-Scope to that path. Use `find` or glob to list all code files under it.
+1. Mode: report or fix
+2. Lane selector: all lanes, one lane, or safe default
+3. Priority selector: high by default for lane/all fixes, exact `high`/`medium`/`low` when provided
+4. Candidate IDs, if present
+5. Path scope, if present
+6. Dry-run/preview mode, if present
+7. Conflicts, especially multiple lanes without `all`
 
-**If no argument (default):**
+### Stage 2: Determine Scope
 
-Determine changed files since the base branch:
+If path arguments are provided, scope to those files/directories.
+
+If no path is provided, use changed files since the base branch:
 
 ```bash
 BASE=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD origin/master 2>/dev/null || echo "HEAD~10")
-echo "FILES:" && git diff --name-only $BASE
-echo "DIFF:" && git diff -U5 $BASE
+echo "FILES:" && git diff --name-only "$BASE"
+echo "DIFF:" && git diff -U5 "$BASE"
 ```
 
-**Classify files in scope:**
+Skip generated/vendor output such as `dist/`, `build/`, `node_modules/`, `.next/`, `vendor/`, checked-in minified bundles, and generated lockfile chunks unless the user explicitly scoped to them.
 
-| File extensions | Passes to run |
-|----------------|---------------|
-| `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rb`, `.rs`, `.java`, `.cs`, `.swift`, `.kt` | Code Slop + Comment Rot |
-| `.css`, `.scss`, `.less`, `.tsx`, `.jsx`, `.html`, `.vue`, `.svelte` | + Design Slop |
-| `.json`, `.yaml`, `.yml`, `.toml`, `.md` | Code Slop + Comment Rot only |
+### Stage 3: Run Analysis Passes
 
-If no UI/style files are in scope, skip the Design Slop pass entirely.
+Run all selected lanes. For default `/unslop`, run every lane that applies to the scope.
 
-Announce the scope:
+If the harness supports safe read-only delegated analysis, the passes may run in parallel. If not, run them sequentially. The output contract is the same either way.
 
-```
-De-slop scope: 14 files changed since origin/main
-Passes: Code Slop | Comment Rot | Design Slop (3 UI files detected)
-```
+#### Pass 1: Hygiene Detector
 
-### Stage 2: Parallel Analysis
+Return:
 
-Launch three sub-agents IN PARALLEL. Each receives the file list and diff content, and returns structured findings as text.
-
-<parallel_tasks>
-
-#### Pass 1: Code Slop Detector
-
-You are a code simplification expert. Analyze the provided files for AI-generated slop patterns. Focus ONLY on slop — not correctness, security, or architecture.
-
-**What to flag:**
-
-1. **Unnecessary complexity**
-   - Deep nesting (>3 levels) that could use early returns
-   - Nested ternary operators — use if/else or switch
-   - Dense one-liners that sacrifice readability for brevity
-
-2. **Redundant abstractions**
-   - Interfaces/types used only once — inline them
-   - Wrapper functions that add no logic — call the wrapped function directly
-   - Abstract base classes with a single implementation
-   - Premature generalization ("just in case" extensibility points)
-
-3. **YAGNI violations**
-   - Features not required by current use cases
-   - Configuration options nobody uses
-   - Generic solutions for specific problems
-   - "Future-proofing" code that adds complexity now
-
-4. **Dead weight**
-   - Commented-out code blocks (>3 lines)
-   - Unused imports, variables, or functions
-   - Duplicate error checks (caller already validates)
-   - Defensive code that can never trigger (type system prevents it)
-
-5. **Over-engineering**
-   - Factory patterns for creating a single type
-   - Strategy patterns with one strategy
-   - Event systems for synchronous single-consumer flows
-   - Dependency injection where direct instantiation is clearer
-
-**Return format:**
 ```json
 {
-  "pass": "code-slop",
+  "pass": "hygiene",
   "findings": [
     {
+      "id": "H1",
       "file": "src/auth.ts",
       "line": 42,
-      "issue": "Nested ternary — use if/else for readability",
-      "severity": "medium",
-      "fix_safe": true,
-      "suggested_fix": "Replace ternary chain with if/else block"
+      "finding": "Commented-out fallback branch is dead weight.",
+      "priority": "high",
+      "risk": "low",
+      "effort": "small",
+      "auto_fix_eligible": true,
+      "suggested_fix": "Delete the commented block.",
+      "verification": ["go test ./..."]
     }
   ]
 }
 ```
 
-#### Pass 2: Comment Rot Detector
+#### Pass 2: Comments/docs Detector
 
-You are a technical documentation expert specializing in comment quality. Analyze the provided files for comment rot — inaccurate, redundant, or AI-generated filler comments.
+Return:
 
-**What to flag:**
-
-1. **Obvious restatements**
-   - `// increment counter` above `counter++`
-   - `// return the result` above `return result`
-   - `// set the name` above `this.name = name`
-   - Comments that repeat the function/variable name in prose
-
-2. **AI-generated filler phrases** (hard bans — flag these immediately)
-   - "This function is responsible for handling..."
-   - "The following code implements..."
-   - "This is a comprehensive solution that..."
-   - "This method provides a robust and scalable..."
-   - "leverages" or "utilizes" (when "uses" works fine)
-   - "seamlessly integrates"
-   - "In today's rapidly evolving..."
-   - "game-changer", "revolutionary", "cutting-edge"
-   - "This class encapsulates the logic for..."
-   - "Ensures proper handling of..."
-
-3. **Factual inaccuracy**
-   - Documented parameters that don't match the function signature
-   - Return type descriptions that don't match the actual return
-   - Described behavior that doesn't match the code logic
-   - Edge case documentation for cases not actually handled
-
-4. **Stale comments**
-   - TODOs/FIXMEs for work that's already been done
-   - References to removed/renamed functions, classes, or files
-   - Version-specific notes for versions no longer supported
-   - "Temporary" markers on permanent code
-
-5. **Over-documentation**
-   - JSDoc/docstrings on trivial getters/setters
-   - Multi-line comments on self-explanatory one-liners
-   - Repeating type information already in the signature
-   - Section divider comments (`// ==================`)
-
-**Return format:**
 ```json
 {
-  "pass": "comment-rot",
+  "pass": "comments-docs",
   "findings": [
     {
+      "id": "C1",
       "file": "src/auth.ts",
       "line": 10,
-      "issue": "\"This function handles authentication\" — restates the function name",
-      "severity": "low",
-      "fix_safe": true,
-      "suggested_fix": "Remove comment — function name is self-documenting"
+      "finding": "Comment restates the function name instead of explaining intent.",
+      "priority": "low",
+      "risk": "low",
+      "effort": "small",
+      "auto_fix_eligible": true,
+      "suggested_fix": "Remove the comment.",
+      "verification": ["go test ./..."]
     }
   ]
 }
 ```
 
-#### Pass 3: Design Slop Detector
+#### Pass 3: Frontend/design Detector
 
-**Only run this pass when UI/style files are in scope.**
+Return:
 
-You are a design quality expert. Analyze the provided UI files for AI-generated visual slop — generic, template-looking patterns that signal "an AI made this, not a designer."
-
-**What to flag:**
-
-1. **Generic color patterns**
-   - Purple-to-blue gradients (the AI default palette)
-   - Gratuitous gradients on everything (buttons, cards, backgrounds)
-   - Safe gray-on-white with one decorative accent color
-   - Unintentional color usage (decorative, not semantic)
-
-2. **Template layouts**
-   - Default card grids with uniform spacing and no hierarchy
-   - Generic hero: centered headline + subtitle + gradient blob + CTA
-   - Dashboard-by-numbers: sidebar + cards + charts with no point of view
-   - Uniform radius, spacing, and shadows across every component
-
-3. **Missing interaction states**
-   - No hover states on interactive elements
-   - No focus states (accessibility gap)
-   - No active/pressed states
-   - No loading/empty/error states
-
-4. **Lazy defaults**
-   - Unmodified library defaults (default shadcn/Tailwind without customization)
-   - Default font stacks with no intentional pairing
-   - Glassmorphism cards that serve no UI purpose
-   - Rounded corners on elements that shouldn't be rounded (tables, code blocks)
-   - Excessive scroll-triggered animations
-
-5. **No visual hierarchy**
-   - Flat layouts with no layering, depth, or motion
-   - Uniform emphasis on everything (nothing stands out)
-   - No intentional rhythm in spacing
-
-**Return format:**
 ```json
 {
-  "pass": "design-slop",
+  "pass": "frontend-design",
   "findings": [
     {
+      "id": "F1",
       "file": "src/Hero.tsx",
       "line": 22,
-      "issue": "Generic purple-to-blue gradient — replace with brand palette",
-      "severity": "medium",
-      "fix_safe": false,
-      "suggested_fix": "Define an intentional brand gradient in design tokens"
+      "finding": "Generic card grid gives every item equal weight and weakens hierarchy.",
+      "priority": "high",
+      "risk": "medium",
+      "effort": "medium",
+      "auto_fix_eligible": true,
+      "suggested_fix": "Promote the primary card and add a focused empty/error state treatment using existing design tokens.",
+      "verification": ["take before/after screenshots", "run affected frontend tests"]
     }
   ]
 }
 ```
 
-</parallel_tasks>
+#### Pass 4: Architecture Slop Detector
 
-### Stage 3: Merge & Deduplicate
+Return Matt-style deepening candidates:
 
-**WAIT for all Stage 2 sub-agents to complete.**
-
-1. Collect findings from all passes that ran
-2. Deduplicate: if two passes flag the same file+line (within 3 lines), keep the more specific finding and note both passes
-3. Sort by severity: High → Medium → Low
-4. Group by pass for the report
-
-### Stage 4: Present Report
-
-Format the consolidated report using pipe-delimited markdown tables:
-
-```
-De-slop Report
-==============
-Scope: [N] files changed since [base]
-Passes: Code Slop [✓|✗] | Comment Rot [✓|✗] | Design Slop [✓|skipped]
-
-## Code Slop ([N] findings)
-
-| # | File | Line | Issue | Severity |
-|---|------|------|-------|----------|
-| 1 | path | line | description | High/Medium/Low |
-
-## Comment Rot ([N] findings)
-
-| # | File | Line | Issue | Severity |
-|---|------|------|-------|----------|
-| 1 | path | line | description | High/Medium/Low |
-
-## Design Slop ([N] findings)
-
-| # | File | Line | Issue | Severity |
-|---|------|------|-------|----------|
-| 1 | path | line | description | High/Medium/Low |
-
-─────────────────────────────
-Summary: [N] findings ([H] High, [M] Medium, [L] Low)
-Potential LOC reduction: ~[N] lines
+```json
+{
+  "pass": "architecture-slop",
+  "findings": [
+    {
+      "id": "A1",
+      "files": ["src/auth/session.ts", "src/auth/cookies.ts"],
+      "problem": "Callers must know cookie parsing order and session fallback behavior.",
+      "proposed_fix": "Create a deeper Session interface that owns load, refresh, and clear behavior.",
+      "deepening": {
+        "depth": "Callers stop coordinating cookie and session details.",
+        "locality": "Session rules move into one module.",
+        "leverage": "Four callers shrink to one stable interface.",
+        "test_surface": "Tests can exercise session behavior through the public interface."
+      },
+      "priority": "high",
+      "risk": "medium",
+      "effort": "medium",
+      "auto_fix_eligible": true,
+      "verification": ["targeted session tests", "existing auth tests"]
+    }
+  ]
+}
 ```
 
-Omit any pass section with zero findings. If all passes return zero findings:
+### Stage 4: Merge, Score, and Deduplicate
 
+1. Collect findings from all selected passes.
+2. Deduplicate overlapping findings by file + line or shared candidate description.
+3. Assign stable IDs if the detector did not.
+4. Verify priority/risk/effort are present for every finding.
+5. Verify every auto-fix-eligible finding has a concrete verification plan.
+6. Sort by lane, then priority high to low, then risk low to high.
+
+### Stage 5: Present Report
+
+Use this report format:
+
+```markdown
+# /unslop Report
+
+Scope: [N] files changed since [base] or [explicit path]
+Mode: report
+Fix default: safe hygiene + comments/docs only
+Fix all: high-priority eligible fixes across all lanes
+
+## Executive Summary
+
+| Lane | Findings | High | Medium | Low | Auto-fix eligible | Recommended next |
+|------|----------|------|--------|-----|-------------------|------------------|
+| Hygiene | 4 | 1 | 2 | 1 | 3 | /unslop fix hygiene |
+| Comments/docs | 8 | 2 | 4 | 2 | 7 | /unslop fix comments |
+| Frontend/design | 3 | 1 | 2 | 0 | 1 | /unslop fix frontend |
+| Architecture | 3 | 1 | 1 | 1 | 1 | /unslop fix architecture |
+
+## Findings
+
+| ID | Lane | File | Finding | Priority | Risk | Effort | Auto-fix | Next command |
+|----|------|------|---------|----------|------|--------|----------|--------------|
+| H1 | Hygiene | src/foo.ts:42 | Dead helper never used | High | Low | Small | Yes | /unslop fix hygiene H1 |
+| C1 | Comments/docs | src/foo.ts:12 | Comment restates function name | Low | Low | Small | Yes | /unslop fix comments C1 |
+| F1 | Frontend/design | app/card.tsx:70 | Generic card grid lacks hierarchy | High | Medium | Medium | Yes | /unslop fix frontend F1 |
+| A1 | Architecture | src/session.ts | Session rules leak into 4 callers | High | Medium | Medium | Yes | /unslop fix architecture A1 |
 ```
-De-slop Report: Clean! No slop detected in [N] files.
+
+For architecture findings, include a short candidate detail block after the table:
+
+```markdown
+### Architecture Candidate A1
+
+Problem: [problem]
+Proposed deeper interface: [proposed_fix]
+Depth: [depth]
+Locality: [locality]
+Leverage: [leverage]
+Test surface: [test_surface]
+Verification: [commands/checks]
 ```
 
-### Stage 5: Auto-Fix (only if `fix` argument was provided)
+If no findings are present:
 
-If the user invoked `/unslop fix`:
-
-1. Collect all findings where `fix_safe: true`
-2. Apply fixes in file order:
-   - **Code Slop safe fixes:** Remove commented-out code blocks, remove unused imports
-   - **Comment Rot safe fixes:** Delete obvious restatement comments, remove stale TODOs
-3. Do NOT auto-fix:
-   - Design slop (requires design judgment)
-   - Factually inaccurate comments (requires understanding intent)
-   - YAGNI violations (requires knowing the roadmap)
-   - Abstractions (requires understanding the broader architecture)
-4. Report what was fixed:
-
-```
-Auto-fix applied:
-  ✓ Removed 3 commented-out code blocks (42 lines)
-  ✓ Deleted 5 obvious-restatement comments
-  ✓ Removed 2 stale TODOs
-
-  Remaining (manual review needed): 4 findings
+```markdown
+/unslop Report: Clean. No slop detected in [N] files.
 ```
 
-If `fix` was NOT provided but fixable findings exist, suggest it:
+### Stage 6: Fix Selection
 
+For `/unslop fix`, select only auto-fix-eligible code hygiene and comments/docs findings.
+
+For `/unslop fix all` or `/unslop fix --all`, select high-priority, auto-fix-eligible findings across all four lanes.
+
+For lane-specific fixes, select only that lane and the exact priority requested. No priority token means high priority.
+
+Candidate IDs narrow the selected findings after lane and priority selection.
+
+Never apply a finding unless:
+
+- it matches the requested lane/all selection
+- it matches the requested priority selector
+- it is auto-fix eligible
+- it stays within path scope
+- it has a verification plan
+
+### Stage 7: Cleanup Plan Before Edits
+
+Before editing, print a short cleanup plan:
+
+```markdown
+Cleanup plan:
+1. [Lane] [ID] [specific change]
+2. [Lane] [ID] [specific change]
+
+Behavior lock / verification before editing:
+- [command or manual verification]
 ```
-Tip: Run /unslop fix to auto-apply [N] safe fixes
+
+If tests cannot run before editing, record why and name the post-edit verification plan. Do not pretend unverified architecture/frontend work is safe.
+
+### Stage 8: Apply Fixes
+
+Work lane by lane. Prefer deletion before rewriting.
+
+Recommended order:
+
+1. Comments/docs
+2. Hygiene
+3. Frontend/design
+4. Architecture
+
+Run targeted verification after each lane when practical. If verification fails, fix the failure or back out the risky cleanup.
+
+### Stage 9: Final Fix Report
+
+Always report:
+
+```markdown
+## /unslop Fix Report
+
+Changed files:
+- [file]
+
+Simplifications:
+- [ID] [what changed]
+
+Verification run:
+- [command] -> [result]
+
+Skipped findings:
+- [ID] [reason, such as high risk or outside scope]
+
+Remaining risks:
+- [risk or "none known"]
 ```
 
-## Severity Guide
+## Auto-Fix Eligibility Guide
 
-| Level | Meaning | Examples |
-|-------|---------|---------|
-| **High** | Actively misleading or creates maintenance burden | Inaccurate comment, missing hover states, large dead code block |
-| **Medium** | Noticeable slop that reduces quality | Unnecessary abstraction, AI filler phrase, generic gradient |
-| **Low** | Minor quality improvement | Restatement comment, unused import, over-documentation |
+| Lane | Eligible examples | Not eligible by default |
+|------|-------------------|-------------------------|
+| Hygiene | dead comments, unused imports, trivially unused helpers | broad refactors, behavior-changing rewrites |
+| Comments/docs | obvious restatements, stale filler, done TODOs | intent comments, security rationale, external API notes |
+| Frontend/design | missing focus state following existing convention, mechanical token alignment | visual redesign without screenshot verification |
+| Architecture | shallow wrapper deletion, fake seam removal, small deeper interface with tests | high-risk boundary moves, large module migrations |
 
-Slop is never "Critical" — it's a quality concern, not a correctness or security issue.
+## Severity and Scoring
+
+Use **priority** for importance, **risk** for regression chance, and **effort** for implementation size.
+
+Priority:
+
+- High: fixing this materially improves quality or removes real maintenance drag
+- Medium: noticeable quality improvement, but not blocking
+- Low: small cleanup or polish
+
+Risk:
+
+- Low: mechanical or deletion-only with clear verification
+- Medium: modest behavior or visual surface, protected by tests or screenshots
+- High: could change behavior, product semantics, layout intent, or public interfaces
+
+Effort:
+
+- Small: one file or a tiny local edit
+- Medium: several related files, targeted tests
+- Large: cross-module migration or broad redesign
 
 ## Quality Gates
 
 Before presenting findings:
 
-1. **Every finding must be actionable.** Don't say "could be simpler" — say what to change and where.
-2. **No false positives from skimming.** Verify the abstraction isn't used elsewhere before flagging it. Verify the comment is truly redundant.
-3. **Line numbers must be accurate.** Check each cited line against file content.
-4. **Respect project conventions.** If the project uses JSDoc everywhere, don't flag JSDoc as over-documentation.
-5. **Don't flag generated code.** Skip files in `dist/`, `build/`, `node_modules/`, `.next/`, `vendor/`, or similar generated directories.
+1. Every finding must be actionable.
+2. Line numbers must be accurate when line numbers are cited.
+3. Do not flag generated code unless explicitly scoped.
+4. Verify unused/dead code before flagging it as safe.
+5. Respect project conventions.
+6. Do not mark architecture/frontend fixes auto-fix eligible without a verification plan.
+7. Report skipped fixes instead of forcing them.
+
+## Relationship to Other ATV Skills
+
+- Pair with `/ce-review`: correctness and safety review.
+- Pair with `/frontend-design` or design review workflows when frontend findings require real visual judgment.
+- Keep `/lfg` and `/slfg` conservative by default. They should continue to use `/unslop fix` unless the user explicitly asks for `/unslop fix all`.
 
 ## Notes
 
-- This skill is read-only by default. It reports but does not edit files unless `fix` is specified.
-- Design Slop pass is automatically skipped for backend-only projects.
-- Works on any language/framework — the slop patterns are universal.
-- Pairs well with `/ce-review` (which checks correctness) — `/unslop` checks aesthetics and quality.
+- `/unslop` is read-only by default.
+- `/unslop fix` is conservative by default.
+- `/unslop fix all` is intentionally stronger, but still only applies high-priority auto-fix-eligible findings.
+- Architecture reports should use Matt-style deepening candidates, but this skill does not import another skill verbatim.
+- Frontend visual changes need evidence, not just class-name vibes.


### PR DESCRIPTION
## Summary

- Upgrades `/unslop` into a full-surface cleanup workflow across code hygiene, comments/docs, frontend/design, and architecture.
- Adds Matt-style architecture slop/deepening candidate language: depth, seam, locality, leverage, and test surface.
- Defines forgiving slash-command parsing for `fix all`, lane aliases, priority selectors, candidate IDs, path scope, conflict handling, and verification gates.
- Fixes the `/unslop` prompt shim so it no longer points at missing `.github/skills/unslop/SKILL.md`.
- Adds regression tests for the v2 contract, mirrored skill copies, prompt shim behavior, and README docs.
- Adds PNG screenshot evidence for the red/green test sequence directly to the PR.

## Review

Pre-Landing Review: No issues found.

Checked against the GStack pre-landing checklist: no SQL/data safety, race/concurrency, LLM trust boundary, shell injection, enum completeness, CI/distribution, or doc-staleness issues. This change is skill/docs/test scaffolding only.

## Test evidence

- `go test ./pkg/scaffold -run "TestUnslop|TestDogfoodPromptParity|TestReadmeDocumentsUnslopV2Commands" -count=1`
- `go test ./...`
- `git diff --check`
- `sha256sum pkg/scaffold/templates/skills/unslop/SKILL.md plugins/atv-skill-unslop/skills/unslop/SKILL.md plugins/atv-pack-quality/skills/unslop/SKILL.md plugins/atv-everything/skills/unslop/SKILL.md`

## Screenshot evidence

1. RED, unslop v2 contract test fails against old skill

![RED 1](https://github.com/All-The-Vibes/ATV-StarterKit/blob/codex/unslop-v2-full-surface-cleanup/docs/plans/artifacts/2026-05-16-unslop-v2-tests/01-red-unslop-contract-test.png?raw=true)

2. RED, prompt shim test fails against old missing-path shim

![RED 2](https://github.com/All-The-Vibes/ATV-StarterKit/blob/codex/unslop-v2-full-surface-cleanup/docs/plans/artifacts/2026-05-16-unslop-v2-tests/02-red-prompt-shim-test.png?raw=true)

3. RED, README docs test fails before docs update

![RED 3](https://github.com/All-The-Vibes/ATV-StarterKit/blob/codex/unslop-v2-full-surface-cleanup/docs/plans/artifacts/2026-05-16-unslop-v2-tests/03-red-readme-docs-test.png?raw=true)

4. GREEN, targeted unslop tests pass

![GREEN 1](https://github.com/All-The-Vibes/ATV-StarterKit/blob/codex/unslop-v2-full-surface-cleanup/docs/plans/artifacts/2026-05-16-unslop-v2-tests/04-green-targeted-unslop-tests.png?raw=true)

5. GREEN, full `go test ./...` passes

![GREEN 2](https://github.com/All-The-Vibes/ATV-StarterKit/blob/codex/unslop-v2-full-surface-cleanup/docs/plans/artifacts/2026-05-16-unslop-v2-tests/05-green-full-go-test.png?raw=true)

6. GREEN, `git diff --check` passes

![GREEN 3](https://github.com/All-The-Vibes/ATV-StarterKit/blob/codex/unslop-v2-full-surface-cleanup/docs/plans/artifacts/2026-05-16-unslop-v2-tests/06-green-diff-check.png?raw=true)

7. GREEN, unslop skill copies have identical hashes

![GREEN 4](https://github.com/All-The-Vibes/ATV-StarterKit/blob/codex/unslop-v2-full-surface-cleanup/docs/plans/artifacts/2026-05-16-unslop-v2-tests/07-green-unslop-copy-hashes.png?raw=true)
