### PR TITLE
ci: pin GitHub Actions to commit SHAs + enforce in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26.1"
 
@@ -29,15 +29,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26.1"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
           version: latest
           install-mode: goinstall

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,17 +12,17 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26.1"
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: "~> v2"
           args: release --clean
@@ -36,10 +36,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,54 @@
+name: Supply Chain
+
+# Governance gate ported from the Copilot Agents Dojo "Supply Chain Policy"
+# (https://github.com/andreaswasita/copilot-agents-dojo). Adopted after the
+# litellm / Shai-Hulud / tj-actions incidents: a mutable tag (e.g. `@v4`) can be
+# re-pointed at a malicious commit, so every third-party GitHub Action must be
+# pinned to an immutable 40-char commit SHA, with the human-readable version in
+# a trailing comment.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  enforce-action-pinning:
+    name: Enforce GitHub Action SHA pinning
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: "Reject unpinned uses: in any workflow"
+        run: |
+          set -euo pipefail
+          status=0
+          while IFS= read -r wf; do
+            while IFS= read -r line; do
+              # Extract the value token after "uses:" (drop any trailing comment).
+              ref=$(printf '%s\n' "$line" \
+                    | sed -E 's/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*//; s/[[:space:]].*$//')
+              # Exempt local composite/reusable workflows and docker refs.
+              case "$ref" in
+                ./*|../*|docker://*) continue ;;
+              esac
+              # Only remote "owner/repo...@ref" entries are subject to the policy.
+              case "$ref" in
+                *@*) : ;;
+                *) continue ;;
+              esac
+              sha="${ref##*@}"
+              if ! printf '%s' "$sha" | grep -Eq '^[0-9a-f]{40}$'; then
+                echo "::error file=$wf::Unpinned action '$ref' - pin to a 40-char commit SHA with a '# vX.Y.Z' version comment."
+                status=1
+              fi
+            done < <(grep -E '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]' "$wf" || true)
+          done < <(find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \))
+          if [ "$status" -eq 0 ]; then
+            echo "All GitHub Actions are pinned to commit SHAs."
+          fi
+          exit $status


### PR DESCRIPTION
## Summary

Hardens the workflow **supply chain** by pinning every third-party GitHub Action to an immutable commit SHA, and adds a small CI gate so it can't regress.

A mutable major tag like `actions/checkout@v4` can be silently re-pointed at a malicious commit — exactly how the **tj-actions/changed-files** and **Shai-Hulud** compromises spread. A 40-char commit SHA is immutable, so a poisoned upstream tag can't change what your CI runs.

## What changed

**1. Pinned all actions in ci.yml and elease.yml** to a commit SHA + a `# vX.Y.Z` version comment. Pins target the **latest patch within each action's current major**, so runtime behavior is unchanged (no major bumps — those stay a deliberate Dependabot decision):

| Action | Tag → pinned | Commit SHA |
|---|---|---|
| actions/checkout | v4 → v4.3.1 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| actions/setup-go | v5 → v5.6.0 | `40f1582b2485089dde7abd97c1529aa768e1baff` |
| actions/setup-node | v4 → v4.4.0 | `49933ea5288caeca8642d1e84afbd3f7d6820020` |
| golangci/golangci-lint-action | v6 → v6.5.2 | `55c2c1448f86e01eaae002a5a3a9624417608d84` |
| goreleaser/goreleaser-action | v6 → v6.4.0 | `e435ccd777264be153ace6237001ef4d979d3a7a` |

Tool versions (`golangci-lint version: latest`, goreleaser `~> v2`) are **left untouched** — they're not action refs and are out of scope here.

**2. Added .github/workflows/supply-chain.yml** — a lightweight gate that fails any PR introducing an unpinned third-party action. Local (`uses: ./...`) and `docker://` refs are exempt; only the 40-char SHA is enforced (comments are for humans).

## Verification

Validated locally (the new gate may not run on this fork PR until it exists on `main`):

- ✅ **Positive:** gate against the pinned workflows → exit 0.
- ✅ **Negative:** injected `uses: actions/stale@v9` → flagged, exit 1.
- ✅ All three workflows parse as valid YAML.
- ✅ No major-version bumps, so build/test, `plugingen -check`, golangci-lint, and GoReleaser behavior are unchanged.

## Scope / follow-ups

Intentionally narrow first PR. Natural next steps (happy to send as separate PRs if welcome): a **Dependabot** config to keep the pinned SHAs current automatically, plus `SECURITY.md` / `CODEOWNERS`.

The pattern is ported from the [Copilot Agents Dojo](https://github.com/andreaswasita/copilot-agents-dojo) "Supply Chain Policy" — sharing it back as a small governance contribution. 🙏
