### PR TITLE
fix: rename downloaded binary to avoid Windows UAC installer-detection

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -32,7 +32,7 @@ One command. Full agentic coding setup. 45 skills, 29 agents, and a memory syste
 
 ```bash
 npx atv-starterkit init              # quick: ATV core only
-atv-installer init --guided          # choose: Starter / Pro / Full
+atv-starterkit init --guided         # choose: Starter / Pro / Full
 ```
 
 ### Links

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ PROGRESS.md
 # Local build/output artifacts
 atv-installer
 atv-installer.exe
+atv-inst-tool
+atv-inst-tool.exe
 banner-block.txt
 
 # Node

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,10 @@
 version: 2
 
-project_name: atv-installer
+project_name: atv-inst-tool
 
 builds:
   - main: .
-    binary: atv-installer
+    binary: atv-inst-tool
     env:
       - CGO_ENABLED=0
     goos:

--- a/DOCS.md
+++ b/DOCS.md
@@ -382,7 +382,7 @@ All templates are embedded at compile time — no runtime network calls for the 
 ## Development
 
 ```bash
-go build -o atv-installer .             # build
+go build -o atv-inst-tool .             # build
 go test ./...                            # all tests
 go test ./pkg/installstate/ -v           # manifest + recommendations tests
 go test ./pkg/monitor/ -v                # watcher + drift detection tests

--- a/DOCS.md
+++ b/DOCS.md
@@ -350,7 +350,7 @@ Over weeks, your repo develops a memory that makes every Copilot session more ef
 ## How It Works Under the Hood
 
 ```text
-atv-installer init --guided
+atv-starterkit init --guided
         │
         ▼
  Detect stack + prerequisites (git, bun, node)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The npm package downloads the correct platform binary from [GitHub Releases](htt
 
 ```bash
 git clone https://github.com/All-The-Vibes/ATV-StarterKit.git
-cd ATV-StarterKit && go build -o atv-installer .
+cd ATV-StarterKit && go build -o atv-inst-tool .
 ```
 
 ### Install — Windows

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ func SetVersion(version, commit string) {
 }
 
 var rootCmd = &cobra.Command{
-	Use:     "atv-installer",
+	Use:     "atv-inst-tool",
 	Short:   "ATV Starter Kit — All The Vibes 2.0",
 	Long:    "Scaffold a complete GitHub Copilot agentic coding environment into any directory.",
 	Version: "dev",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ func SetVersion(version, commit string) {
 }
 
 var rootCmd = &cobra.Command{
-	Use:     "atv-inst-tool",
+	Use:     "atv-starterkit",
 	Short:   "ATV Starter Kit — All The Vibes 2.0",
 	Long:    "Scaffold a complete GitHub Copilot agentic coding environment into any directory.",
 	Version: "dev",

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -15,7 +15,7 @@ var forceUninstall bool
 var uninstallCmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Remove all ATV-installed files from current directory",
-	Long: `Remove all ATV Starter Kit files scaffolded by 'atv-installer init'.
+	Long: `Remove all ATV Starter Kit files scaffolded by 'atv-inst-tool init'.
 
 Files that you've modified since installation are preserved by default.
 Use --force to remove everything regardless of modifications.

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -15,7 +15,7 @@ var forceUninstall bool
 var uninstallCmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Remove all ATV-installed files from current directory",
-	Long: `Remove all ATV Starter Kit files scaffolded by 'atv-inst-tool init'.
+	Long: `Remove all ATV Starter Kit files scaffolded by 'atv-starterkit init'.
 
 Files that you've modified since installation are preserved by default.
 Use --force to remove everything regardless of modifications.

--- a/docs/brainstorms/2026-03-11-agentic-coding-starter-kit-installer-brainstorm.md
+++ b/docs/brainstorms/2026-03-11-agentic-coding-starter-kit-installer-brainstorm.md
@@ -5,6 +5,12 @@ topic: atv-starter-kit
 
 # ATV Starter Kit
 
+> **Historical note (2026-07):** This brainstorm predates the binary rename in
+> PR #58. The shipped binary file is now `atv-inst-tool` (renamed from
+> `atv-installer` to avoid a Windows UAC installer-detection heuristic). The
+> `atv-installer` "wizard name" recorded below is retained as the original
+> record; it also survives as an npm `bin` alias.
+
 ## What We're Building
 
 **ATV** = **A**gentic **T**ool & **W**orkflow

--- a/docs/plans/2026-03-11-002-feat-atv-starter-kit-guided-installer-plan.md
+++ b/docs/plans/2026-03-11-002-feat-atv-starter-kit-guided-installer-plan.md
@@ -8,6 +8,12 @@ origin: docs/brainstorms/2026-03-11-agentic-coding-starter-kit-installer-brainst
 
 # feat: ATV Starter Kit — Guided CLI Installer
 
+> **Historical note (2026-07):** This plan predates the binary rename in PR #58.
+> The shipped binary file is now `atv-inst-tool` (renamed from `atv-installer`
+> to avoid a Windows UAC installer-detection heuristic). References to
+> `atv-installer` as the binary name below are retained as the original record;
+> the `atv-installer` command name also survives as an npm `bin` alias.
+
 ## Overview
 
 Build `atv-installer init` — a Go CLI command that scaffolds a complete GitHub Copilot agentic coding environment into any directory. One command, zero questions by default, all 6 Copilot lifecycle hooks configured. (see brainstorm: docs/brainstorms/2026-03-11-agentic-coding-starter-kit-installer-brainstorm.md)

--- a/docs/plans/2026-03-29-001-feat-gstack-integration-plan.md
+++ b/docs/plans/2026-03-29-001-feat-gstack-integration-plan.md
@@ -8,6 +8,13 @@ origin: docs/brainstorms/2026-03-29-gstack-integration-brainstorm.md
 
 # feat: Integrate gstack into ATV StarterKit Unified Installer
 
+> **Historical note (2026-07):** This plan predates the binary rename in PR #58.
+> The shipped binary file is now `atv-inst-tool` (renamed from `atv-installer`
+> to avoid a Windows UAC installer-detection heuristic), and the user-facing
+> command is `atv-starterkit`. References to `atv-installer` below are retained
+> as the original record; the `atv-installer` command name also survives as an
+> npm `bin` alias.
+
 ## Overview
 
 Add [garrytan/gstack](https://github.com/garrytan/gstack) as a bundled skill source in the ATV StarterKit installer. The guided TUI wizard presents a single categorized list of skills organized by **function** (Planning, Review, QA, Security, etc.) — mixing ATV and gstack skills together. Users don't need to know which system a skill came from. ATV skills take priority where both provide overlapping functionality.

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,3 +1,5 @@
 # Downloaded binary (created by postinstall)
 bin/atv-installer
 bin/atv-installer.exe
+bin/atv-inst-tool
+bin/atv-inst-tool.exe

--- a/npm/README.md
+++ b/npm/README.md
@@ -110,7 +110,7 @@ Plus: `.vscode/extensions.json` and `docs/` structure.
 
 ## How It Works
 
-This npm package downloads the pre-built `atv-installer` binary for your platform (macOS, Linux, or Windows) from [GitHub Releases](https://github.com/All-The-Vibes/ATV-StarterKit/releases) during `npm install`. The `atv-starterkit` command then delegates to that binary.
+This npm package downloads the pre-built `atv-inst-tool` binary for your platform (macOS, Linux, or Windows) from [GitHub Releases](https://github.com/All-The-Vibes/ATV-StarterKit/releases) during `npm install`. The `atv-starterkit` command then delegates to that binary.
 
 ## Alternative Installation
 

--- a/npm/bin/cli.js
+++ b/npm/bin/cli.js
@@ -7,7 +7,7 @@ const os = require("os");
 const { execFileSync } = require("child_process");
 const fs = require("fs");
 
-const BINARY_NAME = "atv-installer";
+const BINARY_NAME = "atv-inst-tool";
 const binaryExt = os.platform() === "win32" ? ".exe" : "";
 const binaryPath = path.join(__dirname, `${BINARY_NAME}${binaryExt}`);
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -11,7 +11,7 @@ const zlib = require("zlib");
 
 const REPO_OWNER = "All-The-Vibes";
 const REPO_NAME = "ATV-StarterKit";
-const BINARY_NAME = "atv-installer";
+const BINARY_NAME = "atv-inst-tool";
 
 /**
  * Resolve the platform and architecture to match goreleaser naming.

--- a/pkg/monitor/executor.go
+++ b/pkg/monitor/executor.go
@@ -13,6 +13,7 @@ import (
 // allowedPrefixes is the command allowlist. Only commands starting with these
 // prefixes may be executed. This prevents arbitrary command execution.
 var allowedPrefixes = []string{
+	"atv-inst-tool ",
 	"atv-installer ",
 	"atv ",
 	"gstack ",

--- a/pkg/monitor/executor_test.go
+++ b/pkg/monitor/executor_test.go
@@ -10,6 +10,7 @@ func TestValidateAction_Allowed(t *testing.T) {
 		name string
 		cmd  string
 	}{
+		{"atv-inst-tool", "atv-inst-tool init"},
 		{"atv-installer", "atv-installer init"},
 		{"atv", "atv dashboard"},
 		{"gstack", "gstack build"},


### PR DESCRIPTION
## Problem

On Windows, `npx atv-starterkit@latest init` (and `--guided`) does nothing and exits with code `1` and **no output**.

### Root cause

The npm package downloads a Go binary named **`atv-installer.exe`** and runs it via `execFileSync` in `npm/bin/cli.js`. Windows UAC has an **installer-detection heuristic** that automatically flags any executable whose filename contains `install` (also `setup`, `update`, `patch`) as an installer requiring **administrator elevation**. Launched non-elevated, Windows refuses to start it:

```
The requested operation requires elevation
```

`cli.js` catches the thrown error and does `process.exit(err.status || 1)` without re-printing the message, so the user just sees a silent exit `1`.

### Proof

Running the downloaded binary directly returns `The requested operation requires elevation`. Copying the **exact same bytes** to a name without `install` (e.g. `atv-tool.exe`) runs perfectly with no elevation. Only the filename differs.

## Fix

Rename the downloaded binary `atv-installer` → **`atv-inst-tool`** (verified locally to not trigger the heuristic):

- `.goreleaser.yml` — `project_name` + `builds[].binary`
- `npm/install.js` — `BINARY_NAME`
- `npm/bin/cli.js` — `BINARY_NAME`
- `.gitignore`, `npm/.gitignore` — ignore the new artifact name
- `npm/README.md` — doc reference

## Testing

- `go build` + ran the full npm wrapper (`node npm/bin/cli.js init`) end-to-end on Windows → scaffolded all files, exit `0`, **no elevation error**.
- `go test ./...` passes except a pre-existing `TestDogfoodPromptParity` failure that also fails on clean `main` (unrelated to this change).

## Note for maintainers — release sequencing

`install.js` fetches the **latest** GitHub release and downloads `<BINARY_NAME>_<ver>_<os>_<arch>`, with `BINARY_NAME` now `atv-inst-tool`. To ship this safely:

1. Cut a **new GitHub release** built from the updated goreleaser config so it carries `atv-inst-tool_*` archives.
2. For a **one-cycle deprecation window**, keep publishing `atv-installer_*` archives on that release too, so already-published npm versions (which fetch `releases/latest` and still request `atv-installer_*`) keep resolving.
3. **Publish the GitHub release before the npm package version** that points at `atv-inst-tool` — never the other way around, or users hit a silent download 404.

Chosen over pinning `install.js` to a version-matched release (a reasonable future follow-up) to keep this PR filename-only.

### Follow-up review changes (commit `765e62c`)

Addresses the CHANGES REQUESTED dual review:
- `pkg/monitor/executor.go` — added `atv-inst-tool ` to the command allowlist (kept `atv-installer ` for the npm `bin` alias); test updated.
- `cmd/root.go` — `Use:` is now `atv-inst-tool` so `--help` matches the shipped binary; also fixed a stray reference in `cmd/uninstall.go` help text.

