### PR TITLE
feat: resumable phase state + artifact-by-reference for /lfg and /slfg

### DIFF
--- a/.github/hooks/scripts/lfg-state.js
+++ b/.github/hooks/scripts/lfg-state.js
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+// ATV LFG/SLFG run-state helper.
+//
+// Backs the resumability + artifact-by-reference features of the `lfg` and
+// `slfg` skills. State lives under `.atv/runs/<run-id>/`:
+//
+//   meta.json                 written once at init, then only the parent binds
+//                             the plan path (single writer) — two-stage identity
+//   phases/<phase>.done.json  one atomic sentinel per completed phase, written
+//                             via temp-file + rename so parallel SLFG agents
+//                             never corrupt or lose each other's updates
+//
+// Design notes:
+//   * The consumer is an LLM measuring cost in tokens + tool round-trips, not
+//     disk microseconds, so plain JSON files (readable, git-diffable, zero
+//     dependencies) beat a SQLite/binary store. Mirrors observe.js.
+//   * Per-phase sentinels avoid read-modify-write races entirely; "is this
+//     phase done?" is just "does the sentinel exist?".
+//
+// Usable two ways:
+//   * require('./lfg-state') — exported pure + fs-backed functions (tested)
+//   * node lfg-state.js <command> ...                          — CLI for skills
+
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const crypto = require("node:crypto");
+
+const MAX_SLUG = 50;
+
+// --- pure helpers ----------------------------------------------------------
+
+function slugify(text) {
+  return String(text == null ? "" : text)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_SLUG)
+    .replace(/-+$/g, "");
+}
+
+function runIdFromPlan(planPath) {
+  const base = path.basename(String(planPath || ""));
+  return base.replace(/\.md$/i, "").replace(/-plan$/i, "");
+}
+
+function provisionalRunId({ feature, repo, branch }) {
+  const hash = crypto
+    .createHash("sha1")
+    .update(`${repo}|${branch}|${feature}`)
+    .digest("hex")
+    .slice(0, 8);
+  const slug = slugify(feature) || "run";
+  return `prov-${slug}-${hash}`.slice(0, MAX_SLUG + 16);
+}
+
+function sanitizePhase(name) {
+  const safe = String(name || "");
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(safe)) {
+    throw new Error(`invalid phase name: ${JSON.stringify(name)}`);
+  }
+  return safe;
+}
+
+function parseRunToken(args) {
+  const text = String(args || "");
+  const match = text.match(/(?:^|\s)run:(\S+)/);
+  if (!match) return { runId: null, rest: text.trim() };
+  const rest = (text.slice(0, match.index) + text.slice(match.index + match[0].length))
+    .replace(/\s+/g, " ")
+    .trim();
+  return { runId: match[1], rest };
+}
+
+// --- filesystem helpers ----------------------------------------------------
+
+function runDir(runsDir, runId) {
+  return path.join(runsDir, runId);
+}
+
+function phasesDir(runsDir, runId) {
+  return path.join(runDir(runsDir, runId), "phases");
+}
+
+function atomicWriteJson(filePath, obj) {
+  const tmp = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(obj, null, 2) + "\n");
+  fs.renameSync(tmp, filePath);
+}
+
+function init(runsDir, { runId, skill, feature, plan }) {
+  fs.mkdirSync(phasesDir(runsDir, runId), { recursive: true });
+  const metaPath = path.join(runDir(runsDir, runId), "meta.json");
+  if (fs.existsSync(metaPath)) {
+    return JSON.parse(fs.readFileSync(metaPath, "utf8"));
+  }
+  const meta = {
+    run_id: runId,
+    skill: skill || null,
+    feature: feature || null,
+    plan_path: plan || null,
+    created_at: new Date().toISOString(),
+  };
+  atomicWriteJson(metaPath, meta);
+  return meta;
+}
+
+function bindPlan(runsDir, runId, planPath) {
+  const metaPath = path.join(runDir(runsDir, runId), "meta.json");
+  const meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+  meta.plan_path = planPath;
+  atomicWriteJson(metaPath, meta);
+  return meta;
+}
+
+function markDone(runsDir, runId, phase, opts) {
+  const safe = sanitizePhase(phase);
+  const options = opts || {};
+  fs.mkdirSync(phasesDir(runsDir, runId), { recursive: true });
+  const sentinel = {
+    phase: safe,
+    status: "done",
+    artifact: options.artifact == null ? null : options.artifact,
+    ended_at: new Date().toISOString(),
+  };
+  atomicWriteJson(path.join(phasesDir(runsDir, runId), `${safe}.done.json`), sentinel);
+  return sentinel;
+}
+
+function isDone(runsDir, runId, phase) {
+  const safe = sanitizePhase(phase);
+  return fs.existsSync(path.join(phasesDir(runsDir, runId), `${safe}.done.json`));
+}
+
+function status(runsDir, runId) {
+  const metaPath = path.join(runDir(runsDir, runId), "meta.json");
+  let meta = null;
+  if (fs.existsSync(metaPath)) {
+    meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+  }
+  const pdir = phasesDir(runsDir, runId);
+  let phases = [];
+  if (fs.existsSync(pdir)) {
+    phases = fs
+      .readdirSync(pdir)
+      .filter((f) => f.endsWith(".done.json"))
+      .map((f) => JSON.parse(fs.readFileSync(path.join(pdir, f), "utf8")))
+      .sort((a, b) => String(a.ended_at).localeCompare(String(b.ended_at)));
+  }
+  return { run_id: runId, meta, phases };
+}
+
+// --- CLI -------------------------------------------------------------------
+
+function defaultRunsDir() {
+  return process.env.LFG_RUNS_DIR || path.join(process.cwd(), ".atv", "runs");
+}
+
+function parseFlags(argv) {
+  const flags = {};
+  const positional = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const val = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : "true";
+      flags[key] = val;
+    } else {
+      positional.push(a);
+    }
+  }
+  return { flags, positional };
+}
+
+function main(argv) {
+  const [command, ...rest] = argv;
+  const { flags, positional } = parseFlags(rest);
+  const runsDir = flags["runs-dir"] || defaultRunsDir();
+  let out;
+  switch (command) {
+    case "init": {
+      const runId =
+        flags["run-id"] ||
+        (flags.plan
+          ? runIdFromPlan(flags.plan)
+          : provisionalRunId({
+              feature: flags.feature || "",
+              repo: flags.repo || "",
+              branch: flags.branch || "",
+            }));
+      out = init(runsDir, {
+        runId,
+        skill: flags.skill,
+        feature: flags.feature,
+        plan: flags.plan,
+      });
+      break;
+    }
+    case "bind-plan":
+      out = bindPlan(runsDir, flags["run-id"], flags.plan);
+      break;
+    case "done":
+      out = markDone(runsDir, flags["run-id"], positional[0] || flags.phase, {
+        artifact: flags.artifact,
+      });
+      break;
+    case "is-done":
+      out = { phase: positional[0], done: isDone(runsDir, flags["run-id"], positional[0]) };
+      break;
+    case "status":
+      out = status(runsDir, flags["run-id"]);
+      break;
+    case "run-id-from-plan":
+      out = { run_id: runIdFromPlan(flags.plan || positional[0]) };
+      break;
+    default:
+      process.stderr.write(
+        "usage: lfg-state.js <init|bind-plan|done|is-done|status|run-id-from-plan> [--run-id id] [--plan path] [--skill s] [--feature f] [--repo r] [--branch b] [--artifact path]\n"
+      );
+      process.exit(2);
+  }
+  process.stdout.write(JSON.stringify(out, null, 2) + "\n");
+}
+
+module.exports = {
+  slugify,
+  runIdFromPlan,
+  provisionalRunId,
+  sanitizePhase,
+  parseRunToken,
+  init,
+  bindPlan,
+  markDone,
+  isDone,
+  status,
+};
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}

--- a/.github/hooks/scripts/tests/lfg-state.test.js
+++ b/.github/hooks/scripts/tests/lfg-state.test.js
@@ -1,0 +1,178 @@
+// Unit tests for the LFG/SLFG run-state helper.
+// Run with: node --test .github/hooks/scripts/tests/lfg-state.test.js
+//
+// The helper backs the resumability + artifact-by-reference features of the
+// `lfg` and `slfg` skills. Tests use the real filesystem in a temp dir — no
+// mocks — per the project's testing conventions.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const S = require('../lfg-state');
+
+function tmpRuns() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lfg-runs-'));
+  return path.join(dir, '.atv', 'runs');
+}
+
+// ---------------------------------------------------------------------------
+// slugify — pure
+// ---------------------------------------------------------------------------
+
+test('slugify lowercases and hyphenates', () => {
+  assert.equal(S.slugify('Add Resume Support'), 'add-resume-support');
+});
+
+test('slugify collapses runs of non-alphanumerics and trims edges', () => {
+  assert.equal(S.slugify('  Foo___Bar !! baz  '), 'foo-bar-baz');
+});
+
+test('slugify caps length to keep ids small', () => {
+  const out = S.slugify('x'.repeat(200));
+  assert.ok(out.length <= 50, `expected <=50, got ${out.length}`);
+});
+
+// ---------------------------------------------------------------------------
+// run-id derivation — pure & deterministic
+// ---------------------------------------------------------------------------
+
+test('runIdFromPlan strips directory and -plan.md suffix', () => {
+  assert.equal(
+    S.runIdFromPlan('docs/plans/2026-06-01-001-feat-foo-plan.md'),
+    '2026-06-01-001-feat-foo'
+  );
+});
+
+test('runIdFromPlan strips a plain .md suffix when no -plan suffix present', () => {
+  assert.equal(S.runIdFromPlan('docs/plans/some-notes.md'), 'some-notes');
+});
+
+test('provisionalRunId is deterministic for the same inputs', () => {
+  const a = S.provisionalRunId({ feature: 'Add resume', repo: 'atv', branch: 'main' });
+  const b = S.provisionalRunId({ feature: 'Add resume', repo: 'atv', branch: 'main' });
+  assert.equal(a, b);
+});
+
+test('provisionalRunId differs when the branch differs', () => {
+  const a = S.provisionalRunId({ feature: 'Add resume', repo: 'atv', branch: 'main' });
+  const b = S.provisionalRunId({ feature: 'Add resume', repo: 'atv', branch: 'feature-x' });
+  assert.notEqual(a, b);
+});
+
+test('provisionalRunId is filesystem-safe (no slashes or spaces)', () => {
+  const id = S.provisionalRunId({ feature: 'A/B test: spaces', repo: 'x', branch: 'y' });
+  assert.doesNotMatch(id, /[^a-z0-9-]/);
+});
+
+// ---------------------------------------------------------------------------
+// init — creates immutable meta + phases dir, idempotent
+// ---------------------------------------------------------------------------
+
+test('init creates meta.json and a phases directory', () => {
+  const runs = tmpRuns();
+  const meta = S.init(runs, { runId: 'r1', skill: 'lfg', feature: 'demo' });
+  assert.equal(meta.run_id, 'r1');
+  assert.equal(meta.skill, 'lfg');
+  assert.equal(meta.feature, 'demo');
+  assert.ok(meta.created_at, 'created_at should be set');
+  assert.ok(fs.existsSync(path.join(runs, 'r1', 'meta.json')));
+  assert.ok(fs.statSync(path.join(runs, 'r1', 'phases')).isDirectory());
+});
+
+test('init is idempotent — re-init does not overwrite meta (resume safety)', () => {
+  const runs = tmpRuns();
+  const first = S.init(runs, { runId: 'r1', skill: 'lfg', feature: 'demo' });
+  const second = S.init(runs, { runId: 'r1', skill: 'lfg', feature: 'CHANGED' });
+  assert.equal(second.created_at, first.created_at);
+  assert.equal(second.feature, 'demo', 'feature must not be overwritten on resume');
+});
+
+// ---------------------------------------------------------------------------
+// bindPlan — two-stage identity (parent-only single writer)
+// ---------------------------------------------------------------------------
+
+test('bindPlan records the plan path on the run meta after planning', () => {
+  const runs = tmpRuns();
+  S.init(runs, { runId: 'r1', skill: 'lfg', feature: 'demo' });
+  const meta = S.bindPlan(runs, 'r1', 'docs/plans/2026-06-01-001-feat-demo-plan.md');
+  assert.equal(meta.plan_path, 'docs/plans/2026-06-01-001-feat-demo-plan.md');
+  const onDisk = JSON.parse(fs.readFileSync(path.join(runs, 'r1', 'meta.json'), 'utf8'));
+  assert.equal(onDisk.plan_path, 'docs/plans/2026-06-01-001-feat-demo-plan.md');
+});
+
+// ---------------------------------------------------------------------------
+// markDone / isDone — atomic per-phase sentinels (SLFG concurrency safety)
+// ---------------------------------------------------------------------------
+
+test('isDone is false before a phase completes, true after markDone', () => {
+  const runs = tmpRuns();
+  S.init(runs, { runId: 'r1', skill: 'lfg', feature: 'demo' });
+  assert.equal(S.isDone(runs, 'r1', 'ce-work'), false);
+  S.markDone(runs, 'r1', 'ce-work', { artifact: null });
+  assert.equal(S.isDone(runs, 'r1', 'ce-work'), true);
+});
+
+test('markDone records the artifact path by reference', () => {
+  const runs = tmpRuns();
+  S.init(runs, { runId: 'r1', skill: 'lfg', feature: 'demo' });
+  S.markDone(runs, 'r1', 'ce-review', {
+    artifact: '.context/compound-engineering/ce-review/abc/report.md',
+  });
+  const sentinel = JSON.parse(
+    fs.readFileSync(path.join(runs, 'r1', 'phases', 'ce-review.done.json'), 'utf8')
+  );
+  assert.equal(sentinel.phase, 'ce-review');
+  assert.equal(sentinel.status, 'done');
+  assert.equal(sentinel.artifact, '.context/compound-engineering/ce-review/abc/report.md');
+  assert.ok(sentinel.ended_at, 'ended_at should be set');
+});
+
+test('markDone rejects phase names containing path traversal', () => {
+  const runs = tmpRuns();
+  S.init(runs, { runId: 'r1', skill: 'lfg', feature: 'demo' });
+  assert.throws(() => S.markDone(runs, 'r1', '../escape', {}), /invalid phase/i);
+});
+
+// ---------------------------------------------------------------------------
+// status — compact view for the orchestrator (paths, not content)
+// ---------------------------------------------------------------------------
+
+test('status returns done phases with their artifact paths', () => {
+  const runs = tmpRuns();
+  S.init(runs, { runId: 'r1', skill: 'lfg', feature: 'demo' });
+  S.markDone(runs, 'r1', 'ce-plan', { artifact: 'docs/plans/p.md' });
+  S.markDone(runs, 'r1', 'ce-work', { artifact: null });
+  const st = S.status(runs, 'r1');
+  assert.equal(st.run_id, 'r1');
+  const byPhase = Object.fromEntries(st.phases.map((p) => [p.phase, p]));
+  assert.equal(byPhase['ce-plan'].status, 'done');
+  assert.equal(byPhase['ce-plan'].artifact, 'docs/plans/p.md');
+  assert.equal(byPhase['ce-work'].status, 'done');
+});
+
+test('status on a non-existent run returns an empty phase list, not an error', () => {
+  const runs = tmpRuns();
+  const st = S.status(runs, 'ghost');
+  assert.equal(st.run_id, 'ghost');
+  assert.deepEqual(st.phases, []);
+  assert.equal(st.meta, null);
+});
+
+// ---------------------------------------------------------------------------
+// parseRunToken — shared `run:<id>` argument convention for sub-skills
+// ---------------------------------------------------------------------------
+
+test('parseRunToken extracts run:<id> and returns remaining args', () => {
+  const { runId, rest } = S.parseRunToken('mode:autofix run:2026-06-01-001-feat-foo plan:docs/p.md');
+  assert.equal(runId, '2026-06-01-001-feat-foo');
+  assert.equal(rest, 'mode:autofix plan:docs/p.md');
+});
+
+test('parseRunToken returns null runId when no token present', () => {
+  const { runId, rest } = S.parseRunToken('mode:autofix plan:docs/p.md');
+  assert.equal(runId, null);
+  assert.equal(rest, 'mode:autofix plan:docs/p.md');
+});

--- a/.github/hooks/scripts/tests/skill-contract.test.js
+++ b/.github/hooks/scripts/tests/skill-contract.test.js
@@ -1,0 +1,110 @@
+// Contract tests for the LFG/SLFG resumability + artifact-by-reference wiring.
+// Run with: node --test .github/hooks/scripts/tests/skill-contract.test.js
+//
+// These assert that the *skills themselves* adopt the new features — not just
+// that the helper exists. They cover both the dogfood install (.github/skills)
+// and the shipped templates (pkg/scaffold/templates/skills) so the two copies
+// cannot silently drift on the resume protocol.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+
+function read(rel) {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+const LFG_COPIES = [
+  '.github/skills/lfg/SKILL.md',
+  'pkg/scaffold/templates/skills/lfg/SKILL.md',
+];
+const SLFG_COPIES = [
+  '.github/skills/slfg/SKILL.md',
+  'pkg/scaffold/templates/skills/slfg/SKILL.md',
+];
+const HELPER_COPIES = [
+  '.github/hooks/scripts/lfg-state.js',
+  'pkg/scaffold/templates/hooks/scripts/lfg-state.js',
+];
+
+// ---------------------------------------------------------------------------
+// helper ships in both the dogfood and template locations
+// ---------------------------------------------------------------------------
+
+for (const rel of HELPER_COPIES) {
+  test(`helper exists and exports run-state API: ${rel}`, () => {
+    const src = read(rel);
+    for (const fn of ['markDone', 'isDone', 'status', 'runIdFromPlan', 'parseRunToken']) {
+      assert.ok(src.includes(fn), `${rel} should define ${fn}`);
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// LFG wires in the resume protocol
+// ---------------------------------------------------------------------------
+
+for (const rel of LFG_COPIES) {
+  test(`LFG references the run-state helper: ${rel}`, () => {
+    assert.match(read(rel), /lfg-state\.js/);
+  });
+
+  test(`LFG documents resume / skip-completed-phases: ${rel}`, () => {
+    assert.match(read(rel), /resume/i);
+    assert.match(read(rel), /status|is-done/i);
+  });
+
+  test(`LFG threads a run id through sub-skills: ${rel}`, () => {
+    assert.match(read(rel), /run:</);
+  });
+
+  test(`LFG marks phases done by reference: ${rel}`, () => {
+    assert.match(read(rel), /done .*--artifact|--artifact/);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// SLFG wires in the resume protocol AND parent-only writes for the parallel
+// phase (the concurrency-safety requirement)
+// ---------------------------------------------------------------------------
+
+for (const rel of SLFG_COPIES) {
+  test(`SLFG references the run-state helper: ${rel}`, () => {
+    assert.match(read(rel), /lfg-state\.js/);
+  });
+
+  test(`SLFG documents parent-only state writes for the parallel phase: ${rel}`, () => {
+    assert.match(read(rel), /parent/i);
+    assert.match(read(rel), /run:</);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Sub-skills must recognize-and-strip `run:<id>` before it is threaded to
+// them (otherwise an unknown token is mis-read as a PR/branch arg), and
+// ce-work must expose an orchestrated mode so resume does not duplicate work.
+// ---------------------------------------------------------------------------
+
+const SUBSKILL_COPIES = [
+  '.github/skills/ce-plan/SKILL.md',
+  '.github/skills/ce-work/SKILL.md',
+  '.github/skills/ce-review/SKILL.md',
+  'pkg/scaffold/templates/skills/ce-plan/SKILL.md',
+  'pkg/scaffold/templates/skills/ce-work/SKILL.md',
+  'pkg/scaffold/templates/skills/ce-review/SKILL.md',
+];
+
+for (const rel of SUBSKILL_COPIES) {
+  test(`sub-skill recognizes the run: orchestration token: ${rel}`, () => {
+    assert.match(read(rel), /run:<[^>]*id[^>]*>/i);
+  });
+}
+
+for (const rel of SUBSKILL_COPIES.filter((r) => r.includes('ce-work'))) {
+  test(`ce-work exposes mode:orchestrated for resume safety: ${rel}`, () => {
+    assert.match(read(rel), /mode:orchestrated/);
+  });
+}

--- a/.github/skills/ce-plan/SKILL.md
+++ b/.github/skills/ce-plan/SKILL.md
@@ -22,6 +22,8 @@ Ask one question at a time. Prefer a concise single-select choice when natural o
 
 <feature_description> #$ARGUMENTS </feature_description>
 
+**Orchestration arguments:** If `$ARGUMENTS` contains a `run:<run-id>` token (passed by `/lfg` or `/slfg`), recognize and strip it before interpreting the remainder as the feature description. It associates this plan with a shared orchestrated run; you do not need to act on it further. Ignore any other unrecognized `key:value` tokens.
+
 **If the feature description above is empty, ask the user:** "What would you like to plan? Please describe the feature, bug fix, or improvement you have in mind."
 
 Do not proceed until you have a clear planning input.

--- a/.github/skills/ce-review/SKILL.md
+++ b/.github/skills/ce-review/SKILL.md
@@ -27,6 +27,7 @@ Parse `$ARGUMENTS` for the following optional tokens. Strip each recognized toke
 | `mode:headless` | `mode:headless` | Select headless mode for programmatic callers (see Mode Detection below) |
 | `base:<sha-or-ref>` | `base:abc1234` or `base:origin/main` | Skip scope detection — use this as the diff base directly |
 | `plan:<path>` | `plan:docs/plans/2026-03-25-001-feat-foo-plan.md` | Load this plan for requirements verification |
+| `run:<run-id>` | `run:2026-06-01-001-feat-foo` | Associate this invocation with an orchestrated `/lfg` or `/slfg` run so artifacts co-locate under the shared run id. Recognize and strip it; it does not change review behavior. Ignore any other unrecognized `key:value` tokens |
 
 All tokens are optional. Each one present means one less thing to infer. When absent, fall back to existing behavior for that stage.
 

--- a/.github/skills/ce-work/SKILL.md
+++ b/.github/skills/ce-work/SKILL.md
@@ -16,6 +16,11 @@ This command takes a work document (plan, specification, or todo file) or a bare
 
 <input_document> #$ARGUMENTS </input_document>
 
+**Orchestration arguments:** `$ARGUMENTS` may include tokens passed by `/lfg` or `/slfg`. Recognize and strip these before triaging the remainder as the work input; ignore other unrecognized `key:value` tokens:
+
+- `run:<run-id>` — associates this invocation with a shared orchestrated run (for artifact co-location). No further action needed.
+- `mode:orchestrated` — **resume-safe execution for orchestrators.** Do NOT create a PR or run shipping/finalize steps; the parent workflow owns those. On entry, reconcile existing state first — inspect the current `git diff`, plan checkboxes, and open todos — and continue incomplete units instead of restarting. This makes re-entry after an interruption idempotent (no duplicated commits or branches).
+
 ## Execution Workflow
 
 ### Phase 0: Input Triage

--- a/.github/skills/lfg/SKILL.md
+++ b/.github/skills/lfg/SKILL.md
@@ -7,25 +7,37 @@ disable-model-invocation: true
 
 CRITICAL: You MUST execute every step below IN ORDER. Do NOT skip any required step. Do NOT jump ahead to coding or implementation. The plan phase (step 2) MUST be completed and verified BEFORE any work begins. Violating this order produces bad output.
 
+## Run State (resumability + artifact passing)
+
+This workflow is **resumable**. A tiny helper tracks which phases are `done` and where each phase's output lives, so re-invoking `/lfg` continues from the first unfinished phase instead of restarting.
+
+- **Helper:** `node .github/hooks/scripts/lfg-state.js` — commands `init`, `bind-plan`, `done <phase> --run-id <id> [--artifact <repo-relative-path>]`, `status --run-id <id>`, `run-id-from-plan --plan <path>`. It writes `.atv/runs/<run-id>/` (gitignored, local-only).
+- **On start (resume check):**
+  1. If a recent plan for this feature already exists in `docs/plans/`, derive `RUN_ID` from it: `node .github/hooks/scripts/lfg-state.js run-id-from-plan --plan <plan-path>`. Otherwise create a provisional id: run `init --skill lfg --feature "$ARGUMENTS" --repo <repo> --branch <branch>` and read `run_id`.
+  2. Run `status --run-id <RUN_ID>` and **skip every phase whose sentinel is already `done`**; resume at the first not-done phase.
+- **After each phase passes its gate:** record it with `done <phase> --run-id <RUN_ID> [--artifact <path>]` (pass the artifact path the phase produced; omit when it produced none).
+- **Pass `run:<RUN_ID>`** to every sub-skill so artifacts co-locate and downstream phases read paths, not full content.
+- **Re-entry safety:** local state is only valid in this worktree; if `.atv/runs/` is absent, infer progress from the plan, branch, and any open PR. Non-`done` phases are re-entered from the start, so `ce-work` MUST be called with `mode:orchestrated` to reconcile existing work instead of duplicating commits/PRs.
+
 1. **Optional:** If the `ralph-loop` skill is available, run `/ralph-loop-ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
 
-2. `/ce-plan $ARGUMENTS`
+2. `/ce-plan $ARGUMENTS run:<RUN_ID>`
 
-   GATE: STOP. Verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, run `/ce-plan $ARGUMENTS` again. Do NOT proceed to step 3 until a written plan exists. **Record the plan file path** — it will be passed to ce-review in step 4.
+   GATE: STOP. Verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, run `/ce-plan $ARGUMENTS run:<RUN_ID>` again. Do NOT proceed to step 3 until a written plan exists. **Record the plan file path**, then bind it and mark the phase done: `lfg-state.js bind-plan --run-id <RUN_ID> --plan <plan-path>` and `lfg-state.js done ce-plan --run-id <RUN_ID> --artifact <plan-path>`.
 
-3. `/ce-work`
+3. `/ce-work mode:orchestrated plan:<plan-path-from-step-2> run:<RUN_ID>`
 
-   GATE: STOP. Verify that implementation work was performed - files were created or modified beyond the plan. Do NOT proceed to step 4 if no code changes were made.
+   GATE: STOP. Verify that implementation work was performed - files were created or modified beyond the plan. Do NOT proceed to step 4 if no code changes were made. Then `lfg-state.js done ce-work --run-id <RUN_ID>`.
 
-4. `/ce-review mode:autofix plan:<plan-path-from-step-2>`
+4. `/ce-review mode:autofix plan:<plan-path-from-step-2> run:<RUN_ID>`
 
-   Pass the plan file path from step 2 so ce-review can verify requirements completeness.
+   Pass the plan file path from step 2 so ce-review can verify requirements completeness. Then `lfg-state.js done ce-review --run-id <RUN_ID> --artifact <review-artifact-path>`.
 
-5. `/compound-engineering-todo-resolve`
+5. `/compound-engineering-todo-resolve` — then `lfg-state.js done todo-resolve --run-id <RUN_ID>`
 
-6. `/compound-engineering-test-browser`
+6. `/compound-engineering-test-browser` — then `lfg-state.js done test-browser --run-id <RUN_ID> --artifact <report-path>`
 
-7. `/compound-engineering-feature-video`
+7. `/compound-engineering-feature-video` — then `lfg-state.js done feature-video --run-id <RUN_ID>`
 
 8. Output `<promise>DONE</promise>` when video is in PR
 

--- a/.github/skills/slfg/SKILL.md
+++ b/.github/skills/slfg/SKILL.md
@@ -7,29 +7,39 @@ disable-model-invocation: true
 
 Swarm-enabled LFG. Run these steps in order, parallelizing where indicated. Do not stop between steps — complete every step through to the end.
 
+## Run State (resumability + artifact passing)
+
+This workflow is **resumable**. A tiny helper tracks which phases are `done` and where each phase's output lives, so re-invoking `/slfg` continues from the first unfinished phase instead of restarting.
+
+- **Helper:** `node .github/hooks/scripts/lfg-state.js` — commands `init`, `bind-plan`, `done <phase> --run-id <id> [--artifact <repo-relative-path>]`, `status --run-id <id>`, `run-id-from-plan --plan <path>`. It writes `.atv/runs/<run-id>/` (gitignored, local-only).
+- **On start:** derive `RUN_ID` from an existing `docs/plans/` plan via `run-id-from-plan`, else `init` a provisional id. Run `status --run-id <RUN_ID>` and **skip phases already `done`**.
+- **Pass `run:<RUN_ID>`** to every sub-skill so artifacts co-locate and downstream phases read paths, not full content.
+- **PARENT-ONLY WRITES (concurrency safety):** during the Parallel Phase, swarm subagents MUST NOT write run state. Each subagent only returns its artifact path; the **parent** orchestrator records each `done <phase> --run-id <RUN_ID> --artifact <path>` after the parallel agents join. This avoids races on the state directory.
+- **Re-entry safety:** `ce-work` MUST run with `mode:orchestrated` so resume reconciles existing work instead of duplicating commits/PRs. If `.atv/runs/` is absent, infer progress from the plan, branch, and any open PR.
+
 ## Sequential Phase
 
 1. **Optional:** If the `ralph-loop` skill is available, run `/ralph-loop-ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
-2. `/ce-plan $ARGUMENTS` — **Record the plan file path** from `docs/plans/` for steps 4 and 6.
-3. `/ce-work` — **Use swarm mode**: Make a Task list and launch an army of agent swarm subagents to build the plan
+2. `/ce-plan $ARGUMENTS run:<RUN_ID>` — **Record the plan file path** from `docs/plans/` for steps 4 and 6. Then (parent) `lfg-state.js bind-plan --run-id <RUN_ID> --plan <plan-path>` and `done ce-plan --run-id <RUN_ID> --artifact <plan-path>`.
+3. `/ce-work mode:orchestrated plan:<plan-path-from-step-2> run:<RUN_ID>` — **Use swarm mode**: Make a Task list and launch an army of agent swarm subagents to build the plan. Then (parent) `done ce-work --run-id <RUN_ID>`.
 
 ## Parallel Phase
 
-After work completes, launch steps 4 and 5 as **parallel swarm agents** (both only need code to be written):
+After work completes, launch steps 4 and 5 as **parallel swarm agents** (both only need code to be written). Subagents return artifact paths only — the parent records state after they join:
 
-4. `/ce-review mode:report-only plan:<plan-path-from-step-2>` — spawn as background Task agent
-5. `/compound-engineering-test-browser` — spawn as background Task agent
+4. `/ce-review mode:report-only plan:<plan-path-from-step-2> run:<RUN_ID>` — spawn as background Task agent
+5. `/compound-engineering-test-browser run:<RUN_ID>` — spawn as background Task agent
 
-Wait for both to complete before continuing.
+Wait for both to complete before continuing. Then (parent) `done test-browser --run-id <RUN_ID> --artifact <report-path>`.
 
 ## Autofix Phase
 
-6. `/ce-review mode:autofix plan:<plan-path-from-step-2>` — run sequentially after the parallel phase so it can safely mutate the checkout, apply `safe_auto` fixes, and emit residual todos for step 7
+6. `/ce-review mode:autofix plan:<plan-path-from-step-2> run:<RUN_ID>` — run sequentially after the parallel phase so it can safely mutate the checkout, apply `safe_auto` fixes, and emit residual todos for step 7. Then (parent) `done ce-review --run-id <RUN_ID> --artifact <review-artifact-path>`.
 
 ## Finalize Phase
 
-7. `/compound-engineering-todo-resolve` — resolve findings, compound on learnings, clean up completed todos
-8. `/compound-engineering-feature-video` — record the final walkthrough and add to PR
+7. `/compound-engineering-todo-resolve` — resolve findings, compound on learnings, clean up completed todos. Then `done todo-resolve --run-id <RUN_ID>`.
+8. `/compound-engineering-feature-video` — record the final walkthrough and add to PR. Then `done feature-video --run-id <RUN_ID>`.
 9. Output `<promise>DONE</promise>` when video is in PR
 
 Start with step 1 now.

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ Thumbs.db
 # ATV observation logs (ephemeral)
 .atv/observations.jsonl
 
+# ATV LFG/SLFG run state (ephemeral, local-only resumability markers)
+.atv/runs/
+
 # Local planning and session artifacts
 PRD.md
 PROGRESS.md

--- a/docs/plans/2026-06-01-001-feat-lfg-slfg-resumability-plan.md
+++ b/docs/plans/2026-06-01-001-feat-lfg-slfg-resumability-plan.md
@@ -4,15 +4,15 @@
 - **Type:** feat
 - **Date:** 2026-06-01
 - **Owner:** ATV maintainers
-- **Origin:** Comparison of Claude Code's *Dynamic Workflows* vs. ATV's `lfg`/`slfg` skills. Two
-  workflow-runtime features were identified as borrowable into the markdown-skill system:
-  (A) phase-completion markers for **resumability**, (B) passing phase outputs **by reference**.
+- **Origin:** Two workflow-runtime features were identified as borrowable into ATV's `lfg`/`slfg`
+  markdown-skill system: (A) phase-completion markers for **resumability**, (B) passing phase
+  outputs **by reference**.
 
 ## Problem
 
 `lfg` and `slfg` are markdown skills that an LLM executes turn-by-turn, orchestrating a pipeline of
 sub-skills (`ce-plan → ce-work → ce-review → todo-resolve → test-browser → feature-video`). Unlike
-Claude Code Dynamic Workflows (JS executed by a runtime), they have:
+workflow engines that execute JS in a runtime, they have:
 
 1. **No resumability** — an interruption restarts the whole turn; completed phases re-run.
 2. **No artifact-by-reference discipline** — phase outputs flow through the agent's context.

--- a/docs/plans/2026-06-01-001-feat-lfg-slfg-resumability-plan.md
+++ b/docs/plans/2026-06-01-001-feat-lfg-slfg-resumability-plan.md
@@ -1,0 +1,103 @@
+# Plan: Resumable Phase State + Artifact-by-Reference for LFG / SLFG
+
+- **Status:** Implemented (this plan is the durable record; checkboxes reflect delivered work)
+- **Type:** feat
+- **Date:** 2026-06-01
+- **Owner:** ATV maintainers
+- **Origin:** Comparison of Claude Code's *Dynamic Workflows* vs. ATV's `lfg`/`slfg` skills. Two
+  workflow-runtime features were identified as borrowable into the markdown-skill system:
+  (A) phase-completion markers for **resumability**, (B) passing phase outputs **by reference**.
+
+## Problem
+
+`lfg` and `slfg` are markdown skills that an LLM executes turn-by-turn, orchestrating a pipeline of
+sub-skills (`ce-plan → ce-work → ce-review → todo-resolve → test-browser → feature-video`). Unlike
+Claude Code Dynamic Workflows (JS executed by a runtime), they have:
+
+1. **No resumability** — an interruption restarts the whole turn; completed phases re-run.
+2. **No artifact-by-reference discipline** — phase outputs flow through the agent's context.
+
+The fix must be **extremely lightweight** because it runs on *every* `/lfg` and `/slfg` session.
+
+## Decision: stack & architecture
+
+**Reframe:** the state consumer is an LLM measuring cost in tokens + tool round-trips, not disk
+microseconds. This settles the storage question.
+
+- **Rejected SQLite** — needs a `sqlite3` binary (dependency, often absent); a binary file is opaque
+  to the agent (a bash round-trip per peek); not git-diffable; `*.db` is already gitignored;
+  "fast CRUD" is irrelevant for ~6–9 rows whose bottleneck is the LLM.
+- **Rejected plan-checkbox reuse** — fuzzy to parse; mixes a durable artifact with ephemeral run
+  state; multiple runs of one plan collide.
+- **Chosen: small JSON files mutated by a tiny Node CLI helper**, mirroring the existing
+  `observe.js` convention. Node is already a baseline hook dependency → zero new dependencies.
+
+**Layout** (`.atv/runs/<run-id>/`, gitignored, local-only):
+
+```
+meta.json                 # written once at init; only the parent binds plan_path (single writer)
+phases/<phase>.done.json  # one atomic sentinel per completed phase (temp-write + rename)
+```
+
+Per-phase sentinels eliminate read-modify-write races (critical for SLFG's parallel phase): "is this
+phase done?" == "does the sentinel exist?". Each sentinel's `artifact` field is the by-reference
+pointer — one structure solves **both** (A) and (B).
+
+### Rubber-duck-driven refinements (folded in)
+
+1. **Two-stage run identity** — deriving the id from the plan filename can't work *during* planning
+   (chicken-and-egg). A provisional id (`slug(feature)+hash(repo|branch|feature)`) is created at
+   init; after `ce-plan` succeeds the run binds `plan_path`. On resume, the orchestrator searches
+   `docs/plans/` before re-running `ce-plan`.
+2. **`ce-work mode:orchestrated`** — `ce-work` mutates state, so it is *not* blindly restarted; the
+   orchestrated mode reconciles existing `git diff` / plan checkboxes / todos and skips PR + shipping.
+3. **`run:<run-id>` parsed before threading** — sub-skills recognize-and-strip the token so an
+   unknown token is never mis-read as a PR/branch arg.
+4. **Parent-only state writes in SLFG** — parallel swarm subagents return artifact paths only; the
+   parent records `done` after they join.
+
+## Work breakdown
+
+- [x] **Step 1 — Helper** `.github/hooks/scripts/lfg-state.js` (+ shipped copy
+  `pkg/scaffold/templates/hooks/scripts/lfg-state.js`). Commands: `init`, `bind-plan`,
+  `done <phase> [--artifact]`, `is-done`, `status`, `run-id-from-plan`. Pure functions exported for
+  tests; CLI guarded by `require.main`. Atomic writes via temp-file + rename; phase-name sanitization.
+  - Tests: `.github/hooks/scripts/tests/lfg-state.test.js` (18 cases, real temp-dir fs, no mocks).
+- [x] **Step 2 — `.gitignore`** add `.atv/runs/` (ephemeral, local resume only).
+- [x] **Step 3 — Sub-skill arg parsing**: `ce-plan`, `ce-work`, `ce-review` recognize-and-strip
+  `run:<run-id>`; `ce-work` gains `mode:orchestrated` (resume-safe, no PR/ship). Both dogfood
+  (`.github/skills/...`) and shipped (`pkg/scaffold/templates/skills/...`) copies.
+- [x] **Step 4 — Orchestrator wiring**: `lfg` and `slfg` (both copies) get a *Run State* section —
+  derive/resume run-id, skip `done` phases, mark each phase done with its artifact path, thread
+  `run:<RUN_ID>`, and (SLFG) parent-only writes.
+- [x] **Contract tests** `.github/hooks/scripts/tests/skill-contract.test.js` (22 cases) assert the
+  skills actually adopt the protocol and that dogfood/template copies cannot drift.
+- [x] **Regenerate** `plugins/` from templates (`go run ./cmd/plugingen`); parity check clean.
+
+## Test scenarios (delivered)
+
+- `lfg-state.test.js`: slugify bounds; deterministic provisional id; plan→run-id derivation;
+  idempotent `init` (resume safety); `bindPlan`; atomic `markDone`/`isDone`; artifact recorded by
+  reference; path-traversal rejection; compact `status`; missing-run returns empty (no error);
+  `parseRunToken` extraction + passthrough.
+- `skill-contract.test.js`: helper exported API present in both copies; LFG references helper,
+  documents resume, threads `run:<...>`, marks done with `--artifact`; SLFG documents parent-only
+  writes; every sub-skill recognizes `run:<run-id>`; `ce-work` exposes `mode:orchestrated`.
+- End-to-end resume simulation: interrupt after `ce-plan`+`ce-work` → `status` resumes at
+  `ce-review`; re-`init` preserves original meta.
+
+## How to run the tests
+
+```
+node --test .github/hooks/scripts/tests/lfg-state.test.js .github/hooks/scripts/tests/skill-contract.test.js
+go test ./pkg/scaffold/... ./pkg/plugingen/...
+go run ./cmd/plugingen -check
+```
+
+## Scope boundaries (non-goals)
+
+- No new runtime, daemon, or DB engine; no new dependencies.
+- Cross-machine/fresh-checkout resume is intentionally out of scope — state is local-only; recovery
+  there falls back to durable signals (plan checkboxes, branch, open PR), as the skills now state.
+- Pre-existing content drift between dogfood and template skill copies (e.g. unslop/observe/learn
+  steps) is preserved as-is; only the new resume wiring is kept in sync.

--- a/pkg/scaffold/templates/hooks/scripts/lfg-state.js
+++ b/pkg/scaffold/templates/hooks/scripts/lfg-state.js
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+// ATV LFG/SLFG run-state helper.
+//
+// Backs the resumability + artifact-by-reference features of the `lfg` and
+// `slfg` skills. State lives under `.atv/runs/<run-id>/`:
+//
+//   meta.json                 written once at init, then only the parent binds
+//                             the plan path (single writer) — two-stage identity
+//   phases/<phase>.done.json  one atomic sentinel per completed phase, written
+//                             via temp-file + rename so parallel SLFG agents
+//                             never corrupt or lose each other's updates
+//
+// Design notes:
+//   * The consumer is an LLM measuring cost in tokens + tool round-trips, not
+//     disk microseconds, so plain JSON files (readable, git-diffable, zero
+//     dependencies) beat a SQLite/binary store. Mirrors observe.js.
+//   * Per-phase sentinels avoid read-modify-write races entirely; "is this
+//     phase done?" is just "does the sentinel exist?".
+//
+// Usable two ways:
+//   * require('./lfg-state') — exported pure + fs-backed functions (tested)
+//   * node lfg-state.js <command> ...                          — CLI for skills
+
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const crypto = require("node:crypto");
+
+const MAX_SLUG = 50;
+
+// --- pure helpers ----------------------------------------------------------
+
+function slugify(text) {
+  return String(text == null ? "" : text)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_SLUG)
+    .replace(/-+$/g, "");
+}
+
+function runIdFromPlan(planPath) {
+  const base = path.basename(String(planPath || ""));
+  return base.replace(/\.md$/i, "").replace(/-plan$/i, "");
+}
+
+function provisionalRunId({ feature, repo, branch }) {
+  const hash = crypto
+    .createHash("sha1")
+    .update(`${repo}|${branch}|${feature}`)
+    .digest("hex")
+    .slice(0, 8);
+  const slug = slugify(feature) || "run";
+  return `prov-${slug}-${hash}`.slice(0, MAX_SLUG + 16);
+}
+
+function sanitizePhase(name) {
+  const safe = String(name || "");
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(safe)) {
+    throw new Error(`invalid phase name: ${JSON.stringify(name)}`);
+  }
+  return safe;
+}
+
+function parseRunToken(args) {
+  const text = String(args || "");
+  const match = text.match(/(?:^|\s)run:(\S+)/);
+  if (!match) return { runId: null, rest: text.trim() };
+  const rest = (text.slice(0, match.index) + text.slice(match.index + match[0].length))
+    .replace(/\s+/g, " ")
+    .trim();
+  return { runId: match[1], rest };
+}
+
+// --- filesystem helpers ----------------------------------------------------
+
+function runDir(runsDir, runId) {
+  return path.join(runsDir, runId);
+}
+
+function phasesDir(runsDir, runId) {
+  return path.join(runDir(runsDir, runId), "phases");
+}
+
+function atomicWriteJson(filePath, obj) {
+  const tmp = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(obj, null, 2) + "\n");
+  fs.renameSync(tmp, filePath);
+}
+
+function init(runsDir, { runId, skill, feature, plan }) {
+  fs.mkdirSync(phasesDir(runsDir, runId), { recursive: true });
+  const metaPath = path.join(runDir(runsDir, runId), "meta.json");
+  if (fs.existsSync(metaPath)) {
+    return JSON.parse(fs.readFileSync(metaPath, "utf8"));
+  }
+  const meta = {
+    run_id: runId,
+    skill: skill || null,
+    feature: feature || null,
+    plan_path: plan || null,
+    created_at: new Date().toISOString(),
+  };
+  atomicWriteJson(metaPath, meta);
+  return meta;
+}
+
+function bindPlan(runsDir, runId, planPath) {
+  const metaPath = path.join(runDir(runsDir, runId), "meta.json");
+  const meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+  meta.plan_path = planPath;
+  atomicWriteJson(metaPath, meta);
+  return meta;
+}
+
+function markDone(runsDir, runId, phase, opts) {
+  const safe = sanitizePhase(phase);
+  const options = opts || {};
+  fs.mkdirSync(phasesDir(runsDir, runId), { recursive: true });
+  const sentinel = {
+    phase: safe,
+    status: "done",
+    artifact: options.artifact == null ? null : options.artifact,
+    ended_at: new Date().toISOString(),
+  };
+  atomicWriteJson(path.join(phasesDir(runsDir, runId), `${safe}.done.json`), sentinel);
+  return sentinel;
+}
+
+function isDone(runsDir, runId, phase) {
+  const safe = sanitizePhase(phase);
+  return fs.existsSync(path.join(phasesDir(runsDir, runId), `${safe}.done.json`));
+}
+
+function status(runsDir, runId) {
+  const metaPath = path.join(runDir(runsDir, runId), "meta.json");
+  let meta = null;
+  if (fs.existsSync(metaPath)) {
+    meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+  }
+  const pdir = phasesDir(runsDir, runId);
+  let phases = [];
+  if (fs.existsSync(pdir)) {
+    phases = fs
+      .readdirSync(pdir)
+      .filter((f) => f.endsWith(".done.json"))
+      .map((f) => JSON.parse(fs.readFileSync(path.join(pdir, f), "utf8")))
+      .sort((a, b) => String(a.ended_at).localeCompare(String(b.ended_at)));
+  }
+  return { run_id: runId, meta, phases };
+}
+
+// --- CLI -------------------------------------------------------------------
+
+function defaultRunsDir() {
+  return process.env.LFG_RUNS_DIR || path.join(process.cwd(), ".atv", "runs");
+}
+
+function parseFlags(argv) {
+  const flags = {};
+  const positional = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const val = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : "true";
+      flags[key] = val;
+    } else {
+      positional.push(a);
+    }
+  }
+  return { flags, positional };
+}
+
+function main(argv) {
+  const [command, ...rest] = argv;
+  const { flags, positional } = parseFlags(rest);
+  const runsDir = flags["runs-dir"] || defaultRunsDir();
+  let out;
+  switch (command) {
+    case "init": {
+      const runId =
+        flags["run-id"] ||
+        (flags.plan
+          ? runIdFromPlan(flags.plan)
+          : provisionalRunId({
+              feature: flags.feature || "",
+              repo: flags.repo || "",
+              branch: flags.branch || "",
+            }));
+      out = init(runsDir, {
+        runId,
+        skill: flags.skill,
+        feature: flags.feature,
+        plan: flags.plan,
+      });
+      break;
+    }
+    case "bind-plan":
+      out = bindPlan(runsDir, flags["run-id"], flags.plan);
+      break;
+    case "done":
+      out = markDone(runsDir, flags["run-id"], positional[0] || flags.phase, {
+        artifact: flags.artifact,
+      });
+      break;
+    case "is-done":
+      out = { phase: positional[0], done: isDone(runsDir, flags["run-id"], positional[0]) };
+      break;
+    case "status":
+      out = status(runsDir, flags["run-id"]);
+      break;
+    case "run-id-from-plan":
+      out = { run_id: runIdFromPlan(flags.plan || positional[0]) };
+      break;
+    default:
+      process.stderr.write(
+        "usage: lfg-state.js <init|bind-plan|done|is-done|status|run-id-from-plan> [--run-id id] [--plan path] [--skill s] [--feature f] [--repo r] [--branch b] [--artifact path]\n"
+      );
+      process.exit(2);
+  }
+  process.stdout.write(JSON.stringify(out, null, 2) + "\n");
+}
+
+module.exports = {
+  slugify,
+  runIdFromPlan,
+  provisionalRunId,
+  sanitizePhase,
+  parseRunToken,
+  init,
+  bindPlan,
+  markDone,
+  isDone,
+  status,
+};
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}

--- a/pkg/scaffold/templates/skills/ce-plan/SKILL.md
+++ b/pkg/scaffold/templates/skills/ce-plan/SKILL.md
@@ -22,6 +22,8 @@ Ask one question at a time. Prefer a concise single-select choice when natural o
 
 <feature_description> #$ARGUMENTS </feature_description>
 
+**Orchestration arguments:** If `$ARGUMENTS` contains a `run:<run-id>` token (passed by `/lfg` or `/slfg`), recognize and strip it before interpreting the remainder as the feature description. It associates this plan with a shared orchestrated run; you do not need to act on it further. Ignore any other unrecognized `key:value` tokens.
+
 **If the feature description above is empty, ask the user:** "What would you like to plan? Please describe the feature, bug fix, or improvement you have in mind."
 
 Do not proceed until you have a clear planning input.

--- a/pkg/scaffold/templates/skills/ce-review/SKILL.md
+++ b/pkg/scaffold/templates/skills/ce-review/SKILL.md
@@ -27,6 +27,7 @@ Parse `$ARGUMENTS` for the following optional tokens. Strip each recognized toke
 | `mode:headless` | `mode:headless` | Select headless mode for programmatic callers (see Mode Detection below) |
 | `base:<sha-or-ref>` | `base:abc1234` or `base:origin/main` | Skip scope detection — use this as the diff base directly |
 | `plan:<path>` | `plan:docs/plans/2026-03-25-001-feat-foo-plan.md` | Load this plan for requirements verification |
+| `run:<run-id>` | `run:2026-06-01-001-feat-foo` | Associate this invocation with an orchestrated `/lfg` or `/slfg` run so artifacts co-locate under the shared run id. Recognize and strip it; it does not change review behavior. Ignore any other unrecognized `key:value` tokens |
 
 All tokens are optional. Each one present means one less thing to infer. When absent, fall back to existing behavior for that stage.
 

--- a/pkg/scaffold/templates/skills/ce-work/SKILL.md
+++ b/pkg/scaffold/templates/skills/ce-work/SKILL.md
@@ -16,6 +16,11 @@ This command takes a work document (plan, specification, or todo file) or a bare
 
 <input_document> #$ARGUMENTS </input_document>
 
+**Orchestration arguments:** `$ARGUMENTS` may include tokens passed by `/lfg` or `/slfg`. Recognize and strip these before triaging the remainder as the work input; ignore other unrecognized `key:value` tokens:
+
+- `run:<run-id>` — associates this invocation with a shared orchestrated run (for artifact co-location). No further action needed.
+- `mode:orchestrated` — **resume-safe execution for orchestrators.** Do NOT create a PR or run shipping/finalize steps; the parent workflow owns those. On entry, reconcile existing state first — inspect the current `git diff`, plan checkboxes, and open todos — and continue incomplete units instead of restarting. This makes re-entry after an interruption idempotent (no duplicated commits or branches).
+
 ## Execution Workflow
 
 ### Phase 0: Input Triage

--- a/pkg/scaffold/templates/skills/lfg/SKILL.md
+++ b/pkg/scaffold/templates/skills/lfg/SKILL.md
@@ -7,33 +7,45 @@ disable-model-invocation: true
 
 CRITICAL: You MUST execute every step below IN ORDER. Do NOT skip any required step. Do NOT jump ahead to coding or implementation. The plan phase (step 2) MUST be completed and verified BEFORE any work begins. Violating this order produces bad output.
 
+## Run State (resumability + artifact passing)
+
+This workflow is **resumable**. A tiny helper tracks which phases are `done` and where each phase's output lives, so re-invoking `/lfg` continues from the first unfinished phase instead of restarting.
+
+- **Helper:** `node .github/hooks/scripts/lfg-state.js` — commands `init`, `bind-plan`, `done <phase> --run-id <id> [--artifact <repo-relative-path>]`, `status --run-id <id>`, `run-id-from-plan --plan <path>`. It writes `.atv/runs/<run-id>/` (gitignored, local-only).
+- **On start (resume check):**
+  1. If a recent plan for this feature already exists in `docs/plans/`, derive `RUN_ID` from it: `node .github/hooks/scripts/lfg-state.js run-id-from-plan --plan <plan-path>`. Otherwise create a provisional id: run `init --skill lfg --feature "$ARGUMENTS" --repo <repo> --branch <branch>` and read `run_id`.
+  2. Run `status --run-id <RUN_ID>` and **skip every phase whose sentinel is already `done`**; resume at the first not-done phase.
+- **After each phase passes its gate:** record it with `done <phase> --run-id <RUN_ID> [--artifact <path>]` (pass the artifact path the phase produced; omit when it produced none).
+- **Pass `run:<RUN_ID>`** to every sub-skill so artifacts co-locate and downstream phases read paths, not full content.
+- **Re-entry safety:** local state is only valid in this worktree; if `.atv/runs/` is absent, infer progress from the plan, branch, and any open PR. Non-`done` phases are re-entered from the start, so `ce-work` MUST be called with `mode:orchestrated` to reconcile existing work instead of duplicating commits/PRs.
+
 1. **Optional:** If the `ralph-loop` skill is available, run `/ralph-loop-ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
 
-2. `/ce-plan $ARGUMENTS`
+2. `/ce-plan $ARGUMENTS run:<RUN_ID>`
 
-   GATE: STOP. Verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, run `/ce-plan $ARGUMENTS` again. Do NOT proceed to step 3 until a written plan exists. **Record the plan file path** — it will be passed to ce-review in step 4.
+   GATE: STOP. Verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, run `/ce-plan $ARGUMENTS run:<RUN_ID>` again. Do NOT proceed to step 3 until a written plan exists. **Record the plan file path**, then bind it and mark the phase done: `lfg-state.js bind-plan --run-id <RUN_ID> --plan <plan-path>` and `lfg-state.js done ce-plan --run-id <RUN_ID> --artifact <plan-path>`.
 
-3. `/ce-work`
+3. `/ce-work mode:orchestrated plan:<plan-path-from-step-2> run:<RUN_ID>`
 
-   GATE: STOP. Verify that implementation work was performed - files were created or modified beyond the plan. Do NOT proceed to step 4 if no code changes were made.
+   GATE: STOP. Verify that implementation work was performed - files were created or modified beyond the plan. Do NOT proceed to step 4 if no code changes were made. Then `lfg-state.js done ce-work --run-id <RUN_ID>`.
 
-4. `/ce-review mode:autofix plan:<plan-path-from-step-2>`
+4. `/ce-review mode:autofix plan:<plan-path-from-step-2> run:<RUN_ID>`
 
-   Pass the plan file path from step 2 so ce-review can verify requirements completeness.
+   Pass the plan file path from step 2 so ce-review can verify requirements completeness. Then `lfg-state.js done ce-review --run-id <RUN_ID> --artifact <review-artifact-path>`.
 
 5. `/unslop fix`
 
-   Strip AI slop after review fixes land — removes commented-out code, filler comments, stale TODOs.
+   Strip AI slop after review fixes land — removes commented-out code, filler comments, stale TODOs. Then `lfg-state.js done unslop --run-id <RUN_ID>`.
 
 6. `/observe` on the areas of code that were changed — analyze patterns in the modified files to capture what was done and how.
 
 7. `/learn` — extract reusable patterns from this session into project instincts.
 
-8. `/compound-engineering-todo-resolve`
+8. `/compound-engineering-todo-resolve` — then `lfg-state.js done todo-resolve --run-id <RUN_ID>`
 
-9. `/compound-engineering-test-browser`
+9. `/compound-engineering-test-browser` — then `lfg-state.js done test-browser --run-id <RUN_ID> --artifact <report-path>`
 
-10. `/compound-engineering-feature-video`
+10. `/compound-engineering-feature-video` — then `lfg-state.js done feature-video --run-id <RUN_ID>`
 
 11. Output `<promise>DONE</promise>` when video is in PR
 

--- a/pkg/scaffold/templates/skills/slfg/SKILL.md
+++ b/pkg/scaffold/templates/skills/slfg/SKILL.md
@@ -7,26 +7,36 @@ disable-model-invocation: true
 
 Swarm-enabled LFG. Run these steps in order, parallelizing where indicated. Do not stop between steps — complete every step through to the end.
 
+## Run State (resumability + artifact passing)
+
+This workflow is **resumable**. A tiny helper tracks which phases are `done` and where each phase's output lives, so re-invoking `/slfg` continues from the first unfinished phase instead of restarting.
+
+- **Helper:** `node .github/hooks/scripts/lfg-state.js` — commands `init`, `bind-plan`, `done <phase> --run-id <id> [--artifact <repo-relative-path>]`, `status --run-id <id>`, `run-id-from-plan --plan <path>`. It writes `.atv/runs/<run-id>/` (gitignored, local-only).
+- **On start:** derive `RUN_ID` from an existing `docs/plans/` plan via `run-id-from-plan`, else `init` a provisional id. Run `status --run-id <RUN_ID>` and **skip phases already `done`**.
+- **Pass `run:<RUN_ID>`** to every sub-skill so artifacts co-locate and downstream phases read paths, not full content.
+- **PARENT-ONLY WRITES (concurrency safety):** during the Parallel Phase, swarm subagents MUST NOT write run state. Each subagent only returns its artifact path; the **parent** orchestrator records each `done <phase> --run-id <RUN_ID> --artifact <path>` after the parallel agents join. This avoids races on the state directory.
+- **Re-entry safety:** `ce-work` MUST run with `mode:orchestrated` so resume reconciles existing work instead of duplicating commits/PRs. If `.atv/runs/` is absent, infer progress from the plan, branch, and any open PR.
+
 ## Sequential Phase
 
 1. **Optional:** If the `ralph-loop` skill is available, run `/ralph-loop-ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
-2. `/ce-plan $ARGUMENTS` — **Record the plan file path** from `docs/plans/` for steps 4 and 6.
-3. `/ce-work` — **Use swarm mode**: Make a Task list and launch an army of agent swarm subagents to build the plan
+2. `/ce-plan $ARGUMENTS run:<RUN_ID>` — **Record the plan file path** from `docs/plans/` for steps 4 and 6. Then (parent) `lfg-state.js bind-plan --run-id <RUN_ID> --plan <plan-path>` and `done ce-plan --run-id <RUN_ID> --artifact <plan-path>`.
+3. `/ce-work mode:orchestrated plan:<plan-path-from-step-2> run:<RUN_ID>` — **Use swarm mode**: Make a Task list and launch an army of agent swarm subagents to build the plan. Then (parent) `done ce-work --run-id <RUN_ID>`.
 
 ## Parallel Phase
 
-After work completes, launch steps 4, 5, and 6 as **parallel swarm agents** (all read-only, safe to run concurrently):
+After work completes, launch steps 4, 5, and 6 as **parallel swarm agents** (all read-only, safe to run concurrently). Subagents return artifact paths only — the parent records state after they join:
 
-4. `/ce-review mode:report-only plan:<plan-path-from-step-2>` — spawn as background Task agent
-5. `/compound-engineering-test-browser` — spawn as background Task agent
-6. `/unslop` — spawn as background Task agent (read-only de-slop report)
+4. `/ce-review mode:report-only plan:<plan-path-from-step-2> run:<RUN_ID>` — spawn as background Task agent
+5. `/compound-engineering-test-browser run:<RUN_ID>` — spawn as background Task agent
+6. `/unslop run:<RUN_ID>` — spawn as background Task agent (read-only de-slop report)
 
-Wait for all three to complete before continuing.
+Wait for all three to complete before continuing. Then (parent) `done test-browser --run-id <RUN_ID> --artifact <report-path>`.
 
 ## Autofix Phase
 
-7. `/ce-review mode:autofix plan:<plan-path-from-step-2>` — run sequentially after the parallel phase so it can safely mutate the checkout, apply `safe_auto` fixes, and emit residual todos for step 8
-8. `/unslop fix` — run sequentially after ce-review autofix to strip AI slop (commented-out code, filler comments, stale TODOs)
+7. `/ce-review mode:autofix plan:<plan-path-from-step-2> run:<RUN_ID>` — run sequentially after the parallel phase so it can safely mutate the checkout, apply `safe_auto` fixes, and emit residual todos for step 8. Then (parent) `done ce-review --run-id <RUN_ID> --artifact <review-artifact-path>`.
+8. `/unslop fix` — run sequentially after ce-review autofix to strip AI slop (commented-out code, filler comments, stale TODOs). Then `done unslop --run-id <RUN_ID>`.
 
 ## Learning Phase
 
@@ -35,8 +45,8 @@ Wait for all three to complete before continuing.
 
 ## Finalize Phase
 
-11. `/compound-engineering-todo-resolve` — resolve findings, compound on learnings, clean up completed todos
-12. `/compound-engineering-feature-video` — record the final walkthrough and add to PR
+11. `/compound-engineering-todo-resolve` — resolve findings, compound on learnings, clean up completed todos. Then `done todo-resolve --run-id <RUN_ID>`.
+12. `/compound-engineering-feature-video` — record the final walkthrough and add to PR. Then `done feature-video --run-id <RUN_ID>`.
 13. Output `<promise>DONE</promise>` when video is in PR
 
 Start with step 1 now.

--- a/plugins/atv-everything/skills/ce-plan/SKILL.md
+++ b/plugins/atv-everything/skills/ce-plan/SKILL.md
@@ -22,6 +22,8 @@ Ask one question at a time. Prefer a concise single-select choice when natural o
 
 <feature_description> #$ARGUMENTS </feature_description>
 
+**Orchestration arguments:** If `$ARGUMENTS` contains a `run:<run-id>` token (passed by `/lfg` or `/slfg`), recognize and strip it before interpreting the remainder as the feature description. It associates this plan with a shared orchestrated run; you do not need to act on it further. Ignore any other unrecognized `key:value` tokens.
+
 **If the feature description above is empty, ask the user:** "What would you like to plan? Please describe the feature, bug fix, or improvement you have in mind."
 
 Do not proceed until you have a clear planning input.

--- a/plugins/atv-everything/skills/ce-review/SKILL.md
+++ b/plugins/atv-everything/skills/ce-review/SKILL.md
@@ -27,6 +27,7 @@ Parse `$ARGUMENTS` for the following optional tokens. Strip each recognized toke
 | `mode:headless` | `mode:headless` | Select headless mode for programmatic callers (see Mode Detection below) |
 | `base:<sha-or-ref>` | `base:abc1234` or `base:origin/main` | Skip scope detection — use this as the diff base directly |
 | `plan:<path>` | `plan:docs/plans/2026-03-25-001-feat-foo-plan.md` | Load this plan for requirements verification |
+| `run:<run-id>` | `run:2026-06-01-001-feat-foo` | Associate this invocation with an orchestrated `/lfg` or `/slfg` run so artifacts co-locate under the shared run id. Recognize and strip it; it does not change review behavior. Ignore any other unrecognized `key:value` tokens |
 
 All tokens are optional. Each one present means one less thing to infer. When absent, fall back to existing behavior for that stage.
 

--- a/plugins/atv-everything/skills/ce-work/SKILL.md
+++ b/plugins/atv-everything/skills/ce-work/SKILL.md
@@ -16,6 +16,11 @@ This command takes a work document (plan, specification, or todo file) or a bare
 
 <input_document> #$ARGUMENTS </input_document>
 
+**Orchestration arguments:** `$ARGUMENTS` may include tokens passed by `/lfg` or `/slfg`. Recognize and strip these before triaging the remainder as the work input; ignore other unrecognized `key:value` tokens:
+
+- `run:<run-id>` — associates this invocation with a shared orchestrated run (for artifact co-location). No further action needed.
+- `mode:orchestrated` — **resume-safe execution for orchestrators.** Do NOT create a PR or run shipping/finalize steps; the parent workflow owns those. On entry, reconcile existing state first — inspect the current `git diff`, plan checkboxes, and open todos — and continue incomplete units instead of restarting. This makes re-entry after an interruption idempotent (no duplicated commits or branches).
+
 ## Execution Workflow
 
 ### Phase 0: Input Triage

--- a/plugins/atv-everything/skills/lfg/SKILL.md
+++ b/plugins/atv-everything/skills/lfg/SKILL.md
@@ -7,33 +7,45 @@ disable-model-invocation: true
 
 CRITICAL: You MUST execute every step below IN ORDER. Do NOT skip any required step. Do NOT jump ahead to coding or implementation. The plan phase (step 2) MUST be completed and verified BEFORE any work begins. Violating this order produces bad output.
 
+## Run State (resumability + artifact passing)
+
+This workflow is **resumable**. A tiny helper tracks which phases are `done` and where each phase's output lives, so re-invoking `/lfg` continues from the first unfinished phase instead of restarting.
+
+- **Helper:** `node .github/hooks/scripts/lfg-state.js` — commands `init`, `bind-plan`, `done <phase> --run-id <id> [--artifact <repo-relative-path>]`, `status --run-id <id>`, `run-id-from-plan --plan <path>`. It writes `.atv/runs/<run-id>/` (gitignored, local-only).
+- **On start (resume check):**
+  1. If a recent plan for this feature already exists in `docs/plans/`, derive `RUN_ID` from it: `node .github/hooks/scripts/lfg-state.js run-id-from-plan --plan <plan-path>`. Otherwise create a provisional id: run `init --skill lfg --feature "$ARGUMENTS" --repo <repo> --branch <branch>` and read `run_id`.
+  2. Run `status --run-id <RUN_ID>` and **skip every phase whose sentinel is already `done`**; resume at the first not-done phase.
+- **After each phase passes its gate:** record it with `done <phase> --run-id <RUN_ID> [--artifact <path>]` (pass the artifact path the phase produced; omit when it produced none).
+- **Pass `run:<RUN_ID>`** to every sub-skill so artifacts co-locate and downstream phases read paths, not full content.
+- **Re-entry safety:** local state is only valid in this worktree; if `.atv/runs/` is absent, infer progress from the plan, branch, and any open PR. Non-`done` phases are re-entered from the start, so `ce-work` MUST be called with `mode:orchestrated` to reconcile existing work instead of duplicating commits/PRs.
+
 1. **Optional:** If the `ralph-loop` skill is available, run `/ralph-loop-ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
 
-2. `/ce-plan $ARGUMENTS`
+2. `/ce-plan $ARGUMENTS run:<RUN_ID>`
 
-   GATE: STOP. Verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, run `/ce-plan $ARGUMENTS` again. Do NOT proceed to step 3 until a written plan exists. **Record the plan file path** — it will be passed to ce-review in step 4.
+   GATE: STOP. Verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, run `/ce-plan $ARGUMENTS run:<RUN_ID>` again. Do NOT proceed to step 3 until a written plan exists. **Record the plan file path**, then bind it and mark the phase done: `lfg-state.js bind-plan --run-id <RUN_ID> --plan <plan-path>` and `lfg-state.js done ce-plan --run-id <RUN_ID> --artifact <plan-path>`.
 
-3. `/ce-work`
+3. `/ce-work mode:orchestrated plan:<plan-path-from-step-2> run:<RUN_ID>`
 
-   GATE: STOP. Verify that implementation work was performed - files were created or modified beyond the plan. Do NOT proceed to step 4 if no code changes were made.
+   GATE: STOP. Verify that implementation work was performed - files were created or modified beyond the plan. Do NOT proceed to step 4 if no code changes were made. Then `lfg-state.js done ce-work --run-id <RUN_ID>`.
 
-4. `/ce-review mode:autofix plan:<plan-path-from-step-2>`
+4. `/ce-review mode:autofix plan:<plan-path-from-step-2> run:<RUN_ID>`
 
-   Pass the plan file path from step 2 so ce-review can verify requirements completeness.
+   Pass the plan file path from step 2 so ce-review can verify requirements completeness. Then `lfg-state.js done ce-review --run-id <RUN_ID> --artifact <review-artifact-path>`.
 
 5. `/unslop fix`
 
-   Strip AI slop after review fixes land — removes commented-out code, filler comments, stale TODOs.
+   Strip AI slop after review fixes land — removes commented-out code, filler comments, stale TODOs. Then `lfg-state.js done unslop --run-id <RUN_ID>`.
 
 6. `/observe` on the areas of code that were changed — analyze patterns in the modified files to capture what was done and how.
 
 7. `/learn` — extract reusable patterns from this session into project instincts.
 
-8. `/compound-engineering-todo-resolve`
+8. `/compound-engineering-todo-resolve` — then `lfg-state.js done todo-resolve --run-id <RUN_ID>`
 
-9. `/compound-engineering-test-browser`
+9. `/compound-engineering-test-browser` — then `lfg-state.js done test-browser --run-id <RUN_ID> --artifact <report-path>`
 
-10. `/compound-engineering-feature-video`
+10. `/compound-engineering-feature-video` — then `lfg-state.js done feature-video --run-id <RUN_ID>`
 
 11. Output `<promise>DONE</promise>` when video is in PR
 

--- a/plugins/atv-everything/skills/slfg/SKILL.md
+++ b/plugins/atv-everything/skills/slfg/SKILL.md
@@ -7,26 +7,36 @@ disable-model-invocation: true
 
 Swarm-enabled LFG. Run these steps in order, parallelizing where indicated. Do not stop between steps — complete every step through to the end.
 
+## Run State (resumability + artifact passing)
+
+This workflow is **resumable**. A tiny helper tracks which phases are `done` and where each phase's output lives, so re-invoking `/slfg` continues from the first unfinished phase instead of restarting.
+
+- **Helper:** `node .github/hooks/scripts/lfg-state.js` — commands `init`, `bind-plan`, `done <phase> --run-id <id> [--artifact <repo-relative-path>]`, `status --run-id <id>`, `run-id-from-plan --plan <path>`. It writes `.atv/runs/<run-id>/` (gitignored, local-only).
+- **On start:** derive `RUN_ID` from an existing `docs/plans/` plan via `run-id-from-plan`, else `init` a provisional id. Run `status --run-id <RUN_ID>` and **skip phases already `done`**.
+- **Pass `run:<RUN_ID>`** to every sub-skill so artifacts co-locate and downstream phases read paths, not full content.
+- **PARENT-ONLY WRITES (concurrency safety):** during the Parallel Phase, swarm subagents MUST NOT write run state. Each subagent only returns its artifact path; the **parent** orchestrator records each `done <phase> --run-id <RUN_ID> --artifact <path>` after the parallel agents join. This avoids races on the state directory.
+- **Re-entry safety:** `ce-work` MUST run with `mode:orchestrated` so resume reconciles existing work instead of duplicating commits/PRs. If `.atv/runs/` is absent, infer progress from the plan, branch, and any open PR.
+
 ## Sequential Phase
 
 1. **Optional:** If the `ralph-loop` skill is available, run `/ralph-loop-ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
-2. `/ce-plan $ARGUMENTS` — **Record the plan file path** from `docs/plans/` for steps 4 and 6.
-3. `/ce-work` — **Use swarm mode**: Make a Task list and launch an army of agent swarm subagents to build the plan
+2. `/ce-plan $ARGUMENTS run:<RUN_ID>` — **Record the plan file path** from `docs/plans/` for steps 4 and 6. Then (parent) `lfg-state.js bind-plan --run-id <RUN_ID> --plan <plan-path>` and `done ce-plan --run-id <RUN_ID> --artifact <plan-path>`.
+3. `/ce-work mode:orchestrated plan:<plan-path-from-step-2> run:<RUN_ID>` — **Use swarm mode**: Make a Task list and launch an army of agent swarm subagents to build the plan. Then (parent) `done ce-work --run-id <RUN_ID>`.
 
 ## Parallel Phase
 
-After work completes, launch steps 4, 5, and 6 as **parallel swarm agents** (all read-only, safe to run concurrently):
+After work completes, launch steps 4, 5, and 6 as **parallel swarm agents** (all read-only, safe to run concurrently). Subagents return artifact paths only — the parent records state after they join:
 
-4. `/ce-review mode:report-only plan:<plan-path-from-step-2>` — spawn as background Task agent
-5. `/compound-engineering-test-browser` — spawn as background Task agent
-6. `/unslop` — spawn as background Task agent (read-only de-slop report)
+4. `/ce-review mode:report-only plan:<plan-path-from-step-2> run:<RUN_ID>` — spawn as background Task agent
+5. `/compound-engineering-test-browser run:<RUN_ID>` — spawn as background Task agent
+6. `/unslop run:<RUN_ID>` — spawn as background Task agent (read-only de-slop report)
 
-Wait for all three to complete before continuing.
+Wait for all three to complete before continuing. Then (parent) `done test-browser --run-id <RUN_ID> --artifact <report-path>`.
 
 ## Autofix Phase
 
-7. `/ce-review mode:autofix plan:<plan-path-from-step-2>` — run sequentially after the parallel phase so it can safely mutate the checkout, apply `safe_auto` fixes, and emit residual todos for step 8
-8. `/unslop fix` — run sequentially after ce-review autofix to strip AI slop (commented-out code, filler comments, stale TODOs)
+7. `/ce-review mode:autofix plan:<plan-path-from-step-2> run:<RUN_ID>` — run sequentially after the parallel phase so it can safely mutate the checkout, apply `safe_auto` fixes, and emit residual todos for step 8. Then (parent) `done ce-review --run-id <RUN_ID> --artifact <review-artifact-path>`.
+8. `/unslop fix` — run sequentially after ce-review autofix to strip AI slop (commented-out code, filler comments, stale TODOs). Then `done unslop --run-id <RUN_ID>`.
 
 ## Learning Phase
 
@@ -35,8 +45,8 @@ Wait for all three to complete before continuing.
 
 ## Finalize Phase
 
-11. `/compound-engineering-todo-resolve` — resolve findings, compound on learnings, clean up completed todos
-12. `/compound-engineering-feature-video` — record the final walkthrough and add to PR
+11. `/compound-engineering-todo-resolve` — resolve findings, compound on learnings, clean up completed todos. Then `done todo-resolve --run-id <RUN_ID>`.
+12. `/compound-engineering-feature-video` — record the final walkthrough and add to PR. Then `done feature-video --run-id <RUN_ID>`.
 13. Output `<promise>DONE</promise>` when video is in PR
 
 Start with step 1 now.

--- a/plugins/atv-pack-planning/skills/ce-plan/SKILL.md
+++ b/plugins/atv-pack-planning/skills/ce-plan/SKILL.md
@@ -22,6 +22,8 @@ Ask one question at a time. Prefer a concise single-select choice when natural o
 
 <feature_description> #$ARGUMENTS </feature_description>
 
+**Orchestration arguments:** If `$ARGUMENTS` contains a `run:<run-id>` token (passed by `/lfg` or `/slfg`), recognize and strip it before interpreting the remainder as the feature description. It associates this plan with a shared orchestrated run; you do not need to act on it further. Ignore any other unrecognized `key:value` tokens.
+
 **If the feature description above is empty, ask the user:** "What would you like to plan? Please describe the feature, bug fix, or improvement you have in mind."
 
 Do not proceed until you have a clear planning input.

--- a/plugins/atv-pack-review/skills/ce-review/SKILL.md
+++ b/plugins/atv-pack-review/skills/ce-review/SKILL.md
@@ -27,6 +27,7 @@ Parse `$ARGUMENTS` for the following optional tokens. Strip each recognized toke
 | `mode:headless` | `mode:headless` | Select headless mode for programmatic callers (see Mode Detection below) |
 | `base:<sha-or-ref>` | `base:abc1234` or `base:origin/main` | Skip scope detection — use this as the diff base directly |
 | `plan:<path>` | `plan:docs/plans/2026-03-25-001-feat-foo-plan.md` | Load this plan for requirements verification |
+| `run:<run-id>` | `run:2026-06-01-001-feat-foo` | Associate this invocation with an orchestrated `/lfg` or `/slfg` run so artifacts co-locate under the shared run id. Recognize and strip it; it does not change review behavior. Ignore any other unrecognized `key:value` tokens |
 
 All tokens are optional. Each one present means one less thing to infer. When absent, fall back to existing behavior for that stage.
 

--- a/plugins/atv-pack-shipping/skills/ce-work/SKILL.md
+++ b/plugins/atv-pack-shipping/skills/ce-work/SKILL.md
@@ -16,6 +16,11 @@ This command takes a work document (plan, specification, or todo file) or a bare
 
 <input_document> #$ARGUMENTS </input_document>
 
+**Orchestration arguments:** `$ARGUMENTS` may include tokens passed by `/lfg` or `/slfg`. Recognize and strip these before triaging the remainder as the work input; ignore other unrecognized `key:value` tokens:
+
+- `run:<run-id>` — associates this invocation with a shared orchestrated run (for artifact co-location). No further action needed.
+- `mode:orchestrated` — **resume-safe execution for orchestrators.** Do NOT create a PR or run shipping/finalize steps; the parent workflow owns those. On entry, reconcile existing state first — inspect the current `git diff`, plan checkboxes, and open todos — and continue incomplete units instead of restarting. This makes re-entry after an interruption idempotent (no duplicated commits or branches).
+
 ## Execution Workflow
 
 ### Phase 0: Input Triage

--- a/plugins/atv-pack-shipping/skills/lfg/SKILL.md
+++ b/plugins/atv-pack-shipping/skills/lfg/SKILL.md
@@ -7,33 +7,45 @@ disable-model-invocation: true
 
 CRITICAL: You MUST execute every step below IN ORDER. Do NOT skip any required step. Do NOT jump ahead to coding or implementation. The plan phase (step 2) MUST be completed and verified BEFORE any work begins. Violating this order produces bad output.
 
+## Run State (resumability + artifact passing)
+
+This workflow is **resumable**. A tiny helper tracks which phases are `done` and where each phase's output lives, so re-invoking `/lfg` continues from the first unfinished phase instead of restarting.
+
+- **Helper:** `node .github/hooks/scripts/lfg-state.js` — commands `init`, `bind-plan`, `done <phase> --run-id <id> [--artifact <repo-relative-path>]`, `status --run-id <id>`, `run-id-from-plan --plan <path>`. It writes `.atv/runs/<run-id>/` (gitignored, local-only).
+- **On start (resume check):**
+  1. If a recent plan for this feature already exists in `docs/plans/`, derive `RUN_ID` from it: `node .github/hooks/scripts/lfg-state.js run-id-from-plan --plan <plan-path>`. Otherwise create a provisional id: run `init --skill lfg --feature "$ARGUMENTS" --repo <repo> --branch <branch>` and read `run_id`.
+  2. Run `status --run-id <RUN_ID>` and **skip every phase whose sentinel is already `done`**; resume at the first not-done phase.
+- **After each phase passes its gate:** record it with `done <phase> --run-id <RUN_ID> [--artifact <path>]` (pass the artifact path the phase produced; omit when it produced none).
+- **Pass `run:<RUN_ID>`** to every sub-skill so artifacts co-locate and downstream phases read paths, not full content.
+- **Re-entry safety:** local state is only valid in this worktree; if `.atv/runs/` is absent, infer progress from the plan, branch, and any open PR. Non-`done` phases are re-entered from the start, so `ce-work` MUST be called with `mode:orchestrated` to reconcile existing work instead of duplicating commits/PRs.
+
 1. **Optional:** If the `ralph-loop` skill is available, run `/ralph-loop-ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
 
-2. `/ce-plan $ARGUMENTS`
+2. `/ce-plan $ARGUMENTS run:<RUN_ID>`
 
-   GATE: STOP. Verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, run `/ce-plan $ARGUMENTS` again. Do NOT proceed to step 3 until a written plan exists. **Record the plan file path** — it will be passed to ce-review in step 4.
+   GATE: STOP. Verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, run `/ce-plan $ARGUMENTS run:<RUN_ID>` again. Do NOT proceed to step 3 until a written plan exists. **Record the plan file path**, then bind it and mark the phase done: `lfg-state.js bind-plan --run-id <RUN_ID> --plan <plan-path>` and `lfg-state.js done ce-plan --run-id <RUN_ID> --artifact <plan-path>`.
 
-3. `/ce-work`
+3. `/ce-work mode:orchestrated plan:<plan-path-from-step-2> run:<RUN_ID>`
 
-   GATE: STOP. Verify that implementation work was performed - files were created or modified beyond the plan. Do NOT proceed to step 4 if no code changes were made.
+   GATE: STOP. Verify that implementation work was performed - files were created or modified beyond the plan. Do NOT proceed to step 4 if no code changes were made. Then `lfg-state.js done ce-work --run-id <RUN_ID>`.
 
-4. `/ce-review mode:autofix plan:<plan-path-from-step-2>`
+4. `/ce-review mode:autofix plan:<plan-path-from-step-2> run:<RUN_ID>`
 
-   Pass the plan file path from step 2 so ce-review can verify requirements completeness.
+   Pass the plan file path from step 2 so ce-review can verify requirements completeness. Then `lfg-state.js done ce-review --run-id <RUN_ID> --artifact <review-artifact-path>`.
 
 5. `/unslop fix`
 
-   Strip AI slop after review fixes land — removes commented-out code, filler comments, stale TODOs.
+   Strip AI slop after review fixes land — removes commented-out code, filler comments, stale TODOs. Then `lfg-state.js done unslop --run-id <RUN_ID>`.
 
 6. `/observe` on the areas of code that were changed — analyze patterns in the modified files to capture what was done and how.
 
 7. `/learn` — extract reusable patterns from this session into project instincts.
 
-8. `/compound-engineering-todo-resolve`
+8. `/compound-engineering-todo-resolve` — then `lfg-state.js done todo-resolve --run-id <RUN_ID>`
 
-9. `/compound-engineering-test-browser`
+9. `/compound-engineering-test-browser` — then `lfg-state.js done test-browser --run-id <RUN_ID> --artifact <report-path>`
 
-10. `/compound-engineering-feature-video`
+10. `/compound-engineering-feature-video` — then `lfg-state.js done feature-video --run-id <RUN_ID>`
 
 11. Output `<promise>DONE</promise>` when video is in PR
 

--- a/plugins/atv-pack-shipping/skills/slfg/SKILL.md
+++ b/plugins/atv-pack-shipping/skills/slfg/SKILL.md
@@ -7,26 +7,36 @@ disable-model-invocation: true
 
 Swarm-enabled LFG. Run these steps in order, parallelizing where indicated. Do not stop between steps — complete every step through to the end.
 
+## Run State (resumability + artifact passing)
+
+This workflow is **resumable**. A tiny helper tracks which phases are `done` and where each phase's output lives, so re-invoking `/slfg` continues from the first unfinished phase instead of restarting.
+
+- **Helper:** `node .github/hooks/scripts/lfg-state.js` — commands `init`, `bind-plan`, `done <phase> --run-id <id> [--artifact <repo-relative-path>]`, `status --run-id <id>`, `run-id-from-plan --plan <path>`. It writes `.atv/runs/<run-id>/` (gitignored, local-only).
+- **On start:** derive `RUN_ID` from an existing `docs/plans/` plan via `run-id-from-plan`, else `init` a provisional id. Run `status --run-id <RUN_ID>` and **skip phases already `done`**.
+- **Pass `run:<RUN_ID>`** to every sub-skill so artifacts co-locate and downstream phases read paths, not full content.
+- **PARENT-ONLY WRITES (concurrency safety):** during the Parallel Phase, swarm subagents MUST NOT write run state. Each subagent only returns its artifact path; the **parent** orchestrator records each `done <phase> --run-id <RUN_ID> --artifact <path>` after the parallel agents join. This avoids races on the state directory.
+- **Re-entry safety:** `ce-work` MUST run with `mode:orchestrated` so resume reconciles existing work instead of duplicating commits/PRs. If `.atv/runs/` is absent, infer progress from the plan, branch, and any open PR.
+
 ## Sequential Phase
 
 1. **Optional:** If the `ralph-loop` skill is available, run `/ralph-loop-ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
-2. `/ce-plan $ARGUMENTS` — **Record the plan file path** from `docs/plans/` for steps 4 and 6.
-3. `/ce-work` — **Use swarm mode**: Make a Task list and launch an army of agent swarm subagents to build the plan
+2. `/ce-plan $ARGUMENTS run:<RUN_ID>` — **Record the plan file path** from `docs/plans/` for steps 4 and 6. Then (parent) `lfg-state.js bind-plan --run-id <RUN_ID> --plan <plan-path>` and `done ce-plan --run-id <RUN_ID> --artifact <plan-path>`.
+3. `/ce-work mode:orchestrated plan:<plan-path-from-step-2> run:<RUN_ID>` — **Use swarm mode**: Make a Task list and launch an army of agent swarm subagents to build the plan. Then (parent) `done ce-work --run-id <RUN_ID>`.
 
 ## Parallel Phase
 
-After work completes, launch steps 4, 5, and 6 as **parallel swarm agents** (all read-only, safe to run concurrently):
+After work completes, launch steps 4, 5, and 6 as **parallel swarm agents** (all read-only, safe to run concurrently). Subagents return artifact paths only — the parent records state after they join:
 
-4. `/ce-review mode:report-only plan:<plan-path-from-step-2>` — spawn as background Task agent
-5. `/compound-engineering-test-browser` — spawn as background Task agent
-6. `/unslop` — spawn as background Task agent (read-only de-slop report)
+4. `/ce-review mode:report-only plan:<plan-path-from-step-2> run:<RUN_ID>` — spawn as background Task agent
+5. `/compound-engineering-test-browser run:<RUN_ID>` — spawn as background Task agent
+6. `/unslop run:<RUN_ID>` — spawn as background Task agent (read-only de-slop report)
 
-Wait for all three to complete before continuing.
+Wait for all three to complete before continuing. Then (parent) `done test-browser --run-id <RUN_ID> --artifact <report-path>`.
 
 ## Autofix Phase
 
-7. `/ce-review mode:autofix plan:<plan-path-from-step-2>` — run sequentially after the parallel phase so it can safely mutate the checkout, apply `safe_auto` fixes, and emit residual todos for step 8
-8. `/unslop fix` — run sequentially after ce-review autofix to strip AI slop (commented-out code, filler comments, stale TODOs)
+7. `/ce-review mode:autofix plan:<plan-path-from-step-2> run:<RUN_ID>` — run sequentially after the parallel phase so it can safely mutate the checkout, apply `safe_auto` fixes, and emit residual todos for step 8. Then (parent) `done ce-review --run-id <RUN_ID> --artifact <review-artifact-path>`.
+8. `/unslop fix` — run sequentially after ce-review autofix to strip AI slop (commented-out code, filler comments, stale TODOs). Then `done unslop --run-id <RUN_ID>`.
 
 ## Learning Phase
 
@@ -35,8 +45,8 @@ Wait for all three to complete before continuing.
 
 ## Finalize Phase
 
-11. `/compound-engineering-todo-resolve` — resolve findings, compound on learnings, clean up completed todos
-12. `/compound-engineering-feature-video` — record the final walkthrough and add to PR
+11. `/compound-engineering-todo-resolve` — resolve findings, compound on learnings, clean up completed todos. Then `done todo-resolve --run-id <RUN_ID>`.
+12. `/compound-engineering-feature-video` — record the final walkthrough and add to PR. Then `done feature-video --run-id <RUN_ID>`.
 13. Output `<promise>DONE</promise>` when video is in PR
 
 Start with step 1 now.

--- a/plugins/atv-skill-ce-plan/skills/ce-plan/SKILL.md
+++ b/plugins/atv-skill-ce-plan/skills/ce-plan/SKILL.md
@@ -22,6 +22,8 @@ Ask one question at a time. Prefer a concise single-select choice when natural o
 
 <feature_description> #$ARGUMENTS </feature_description>
 
+**Orchestration arguments:** If `$ARGUMENTS` contains a `run:<run-id>` token (passed by `/lfg` or `/slfg`), recognize and strip it before interpreting the remainder as the feature description. It associates this plan with a shared orchestrated run; you do not need to act on it further. Ignore any other unrecognized `key:value` tokens.
+
 **If the feature description above is empty, ask the user:** "What would you like to plan? Please describe the feature, bug fix, or improvement you have in mind."
 
 Do not proceed until you have a clear planning input.

--- a/plugins/atv-skill-ce-review/skills/ce-review/SKILL.md
+++ b/plugins/atv-skill-ce-review/skills/ce-review/SKILL.md
@@ -27,6 +27,7 @@ Parse `$ARGUMENTS` for the following optional tokens. Strip each recognized toke
 | `mode:headless` | `mode:headless` | Select headless mode for programmatic callers (see Mode Detection below) |
 | `base:<sha-or-ref>` | `base:abc1234` or `base:origin/main` | Skip scope detection — use this as the diff base directly |
 | `plan:<path>` | `plan:docs/plans/2026-03-25-001-feat-foo-plan.md` | Load this plan for requirements verification |
+| `run:<run-id>` | `run:2026-06-01-001-feat-foo` | Associate this invocation with an orchestrated `/lfg` or `/slfg` run so artifacts co-locate under the shared run id. Recognize and strip it; it does not change review behavior. Ignore any other unrecognized `key:value` tokens |
 
 All tokens are optional. Each one present means one less thing to infer. When absent, fall back to existing behavior for that stage.
 

--- a/plugins/atv-skill-ce-work/skills/ce-work/SKILL.md
+++ b/plugins/atv-skill-ce-work/skills/ce-work/SKILL.md
@@ -16,6 +16,11 @@ This command takes a work document (plan, specification, or todo file) or a bare
 
 <input_document> #$ARGUMENTS </input_document>
 
+**Orchestration arguments:** `$ARGUMENTS` may include tokens passed by `/lfg` or `/slfg`. Recognize and strip these before triaging the remainder as the work input; ignore other unrecognized `key:value` tokens:
+
+- `run:<run-id>` — associates this invocation with a shared orchestrated run (for artifact co-location). No further action needed.
+- `mode:orchestrated` — **resume-safe execution for orchestrators.** Do NOT create a PR or run shipping/finalize steps; the parent workflow owns those. On entry, reconcile existing state first — inspect the current `git diff`, plan checkboxes, and open todos — and continue incomplete units instead of restarting. This makes re-entry after an interruption idempotent (no duplicated commits or branches).
+
 ## Execution Workflow
 
 ### Phase 0: Input Triage

--- a/plugins/atv-skill-lfg/skills/lfg/SKILL.md
+++ b/plugins/atv-skill-lfg/skills/lfg/SKILL.md
@@ -7,33 +7,45 @@ disable-model-invocation: true
 
 CRITICAL: You MUST execute every step below IN ORDER. Do NOT skip any required step. Do NOT jump ahead to coding or implementation. The plan phase (step 2) MUST be completed and verified BEFORE any work begins. Violating this order produces bad output.
 
+## Run State (resumability + artifact passing)
+
+This workflow is **resumable**. A tiny helper tracks which phases are `done` and where each phase's output lives, so re-invoking `/lfg` continues from the first unfinished phase instead of restarting.
+
+- **Helper:** `node .github/hooks/scripts/lfg-state.js` — commands `init`, `bind-plan`, `done <phase> --run-id <id> [--artifact <repo-relative-path>]`, `status --run-id <id>`, `run-id-from-plan --plan <path>`. It writes `.atv/runs/<run-id>/` (gitignored, local-only).
+- **On start (resume check):**
+  1. If a recent plan for this feature already exists in `docs/plans/`, derive `RUN_ID` from it: `node .github/hooks/scripts/lfg-state.js run-id-from-plan --plan <plan-path>`. Otherwise create a provisional id: run `init --skill lfg --feature "$ARGUMENTS" --repo <repo> --branch <branch>` and read `run_id`.
+  2. Run `status --run-id <RUN_ID>` and **skip every phase whose sentinel is already `done`**; resume at the first not-done phase.
+- **After each phase passes its gate:** record it with `done <phase> --run-id <RUN_ID> [--artifact <path>]` (pass the artifact path the phase produced; omit when it produced none).
+- **Pass `run:<RUN_ID>`** to every sub-skill so artifacts co-locate and downstream phases read paths, not full content.
+- **Re-entry safety:** local state is only valid in this worktree; if `.atv/runs/` is absent, infer progress from the plan, branch, and any open PR. Non-`done` phases are re-entered from the start, so `ce-work` MUST be called with `mode:orchestrated` to reconcile existing work instead of duplicating commits/PRs.
+
 1. **Optional:** If the `ralph-loop` skill is available, run `/ralph-loop-ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
 
-2. `/ce-plan $ARGUMENTS`
+2. `/ce-plan $ARGUMENTS run:<RUN_ID>`
 
-   GATE: STOP. Verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, run `/ce-plan $ARGUMENTS` again. Do NOT proceed to step 3 until a written plan exists. **Record the plan file path** — it will be passed to ce-review in step 4.
+   GATE: STOP. Verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, run `/ce-plan $ARGUMENTS run:<RUN_ID>` again. Do NOT proceed to step 3 until a written plan exists. **Record the plan file path**, then bind it and mark the phase done: `lfg-state.js bind-plan --run-id <RUN_ID> --plan <plan-path>` and `lfg-state.js done ce-plan --run-id <RUN_ID> --artifact <plan-path>`.
 
-3. `/ce-work`
+3. `/ce-work mode:orchestrated plan:<plan-path-from-step-2> run:<RUN_ID>`
 
-   GATE: STOP. Verify that implementation work was performed - files were created or modified beyond the plan. Do NOT proceed to step 4 if no code changes were made.
+   GATE: STOP. Verify that implementation work was performed - files were created or modified beyond the plan. Do NOT proceed to step 4 if no code changes were made. Then `lfg-state.js done ce-work --run-id <RUN_ID>`.
 
-4. `/ce-review mode:autofix plan:<plan-path-from-step-2>`
+4. `/ce-review mode:autofix plan:<plan-path-from-step-2> run:<RUN_ID>`
 
-   Pass the plan file path from step 2 so ce-review can verify requirements completeness.
+   Pass the plan file path from step 2 so ce-review can verify requirements completeness. Then `lfg-state.js done ce-review --run-id <RUN_ID> --artifact <review-artifact-path>`.
 
 5. `/unslop fix`
 
-   Strip AI slop after review fixes land — removes commented-out code, filler comments, stale TODOs.
+   Strip AI slop after review fixes land — removes commented-out code, filler comments, stale TODOs. Then `lfg-state.js done unslop --run-id <RUN_ID>`.
 
 6. `/observe` on the areas of code that were changed — analyze patterns in the modified files to capture what was done and how.
 
 7. `/learn` — extract reusable patterns from this session into project instincts.
 
-8. `/compound-engineering-todo-resolve`
+8. `/compound-engineering-todo-resolve` — then `lfg-state.js done todo-resolve --run-id <RUN_ID>`
 
-9. `/compound-engineering-test-browser`
+9. `/compound-engineering-test-browser` — then `lfg-state.js done test-browser --run-id <RUN_ID> --artifact <report-path>`
 
-10. `/compound-engineering-feature-video`
+10. `/compound-engineering-feature-video` — then `lfg-state.js done feature-video --run-id <RUN_ID>`
 
 11. Output `<promise>DONE</promise>` when video is in PR
 

--- a/plugins/atv-skill-slfg/skills/slfg/SKILL.md
+++ b/plugins/atv-skill-slfg/skills/slfg/SKILL.md
@@ -7,26 +7,36 @@ disable-model-invocation: true
 
 Swarm-enabled LFG. Run these steps in order, parallelizing where indicated. Do not stop between steps — complete every step through to the end.
 
+## Run State (resumability + artifact passing)
+
+This workflow is **resumable**. A tiny helper tracks which phases are `done` and where each phase's output lives, so re-invoking `/slfg` continues from the first unfinished phase instead of restarting.
+
+- **Helper:** `node .github/hooks/scripts/lfg-state.js` — commands `init`, `bind-plan`, `done <phase> --run-id <id> [--artifact <repo-relative-path>]`, `status --run-id <id>`, `run-id-from-plan --plan <path>`. It writes `.atv/runs/<run-id>/` (gitignored, local-only).
+- **On start:** derive `RUN_ID` from an existing `docs/plans/` plan via `run-id-from-plan`, else `init` a provisional id. Run `status --run-id <RUN_ID>` and **skip phases already `done`**.
+- **Pass `run:<RUN_ID>`** to every sub-skill so artifacts co-locate and downstream phases read paths, not full content.
+- **PARENT-ONLY WRITES (concurrency safety):** during the Parallel Phase, swarm subagents MUST NOT write run state. Each subagent only returns its artifact path; the **parent** orchestrator records each `done <phase> --run-id <RUN_ID> --artifact <path>` after the parallel agents join. This avoids races on the state directory.
+- **Re-entry safety:** `ce-work` MUST run with `mode:orchestrated` so resume reconciles existing work instead of duplicating commits/PRs. If `.atv/runs/` is absent, infer progress from the plan, branch, and any open PR.
+
 ## Sequential Phase
 
 1. **Optional:** If the `ralph-loop` skill is available, run `/ralph-loop-ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
-2. `/ce-plan $ARGUMENTS` — **Record the plan file path** from `docs/plans/` for steps 4 and 6.
-3. `/ce-work` — **Use swarm mode**: Make a Task list and launch an army of agent swarm subagents to build the plan
+2. `/ce-plan $ARGUMENTS run:<RUN_ID>` — **Record the plan file path** from `docs/plans/` for steps 4 and 6. Then (parent) `lfg-state.js bind-plan --run-id <RUN_ID> --plan <plan-path>` and `done ce-plan --run-id <RUN_ID> --artifact <plan-path>`.
+3. `/ce-work mode:orchestrated plan:<plan-path-from-step-2> run:<RUN_ID>` — **Use swarm mode**: Make a Task list and launch an army of agent swarm subagents to build the plan. Then (parent) `done ce-work --run-id <RUN_ID>`.
 
 ## Parallel Phase
 
-After work completes, launch steps 4, 5, and 6 as **parallel swarm agents** (all read-only, safe to run concurrently):
+After work completes, launch steps 4, 5, and 6 as **parallel swarm agents** (all read-only, safe to run concurrently). Subagents return artifact paths only — the parent records state after they join:
 
-4. `/ce-review mode:report-only plan:<plan-path-from-step-2>` — spawn as background Task agent
-5. `/compound-engineering-test-browser` — spawn as background Task agent
-6. `/unslop` — spawn as background Task agent (read-only de-slop report)
+4. `/ce-review mode:report-only plan:<plan-path-from-step-2> run:<RUN_ID>` — spawn as background Task agent
+5. `/compound-engineering-test-browser run:<RUN_ID>` — spawn as background Task agent
+6. `/unslop run:<RUN_ID>` — spawn as background Task agent (read-only de-slop report)
 
-Wait for all three to complete before continuing.
+Wait for all three to complete before continuing. Then (parent) `done test-browser --run-id <RUN_ID> --artifact <report-path>`.
 
 ## Autofix Phase
 
-7. `/ce-review mode:autofix plan:<plan-path-from-step-2>` — run sequentially after the parallel phase so it can safely mutate the checkout, apply `safe_auto` fixes, and emit residual todos for step 8
-8. `/unslop fix` — run sequentially after ce-review autofix to strip AI slop (commented-out code, filler comments, stale TODOs)
+7. `/ce-review mode:autofix plan:<plan-path-from-step-2> run:<RUN_ID>` — run sequentially after the parallel phase so it can safely mutate the checkout, apply `safe_auto` fixes, and emit residual todos for step 8. Then (parent) `done ce-review --run-id <RUN_ID> --artifact <review-artifact-path>`.
+8. `/unslop fix` — run sequentially after ce-review autofix to strip AI slop (commented-out code, filler comments, stale TODOs). Then `done unslop --run-id <RUN_ID>`.
 
 ## Learning Phase
 
@@ -35,8 +45,8 @@ Wait for all three to complete before continuing.
 
 ## Finalize Phase
 
-11. `/compound-engineering-todo-resolve` — resolve findings, compound on learnings, clean up completed todos
-12. `/compound-engineering-feature-video` — record the final walkthrough and add to PR
+11. `/compound-engineering-todo-resolve` — resolve findings, compound on learnings, clean up completed todos. Then `done todo-resolve --run-id <RUN_ID>`.
+12. `/compound-engineering-feature-video` — record the final walkthrough and add to PR. Then `done feature-video --run-id <RUN_ID>`.
 13. Output `<promise>DONE</promise>` when video is in PR
 
 Start with step 1 now.


### PR DESCRIPTION
## Summary

Adds **resumable phase state** and **artifact-by-reference** to the `/lfg` and `/slfg` markdown-skill orchestration pipelines (`ce-plan → ce-work → ce-review → todo-resolve → test-browser → feature-video`).

Previously these skills had no resumability (an interruption restarted the whole turn, re-running completed phases) and no artifact-by-reference discipline (phase outputs flowed through the agent's context). This runs on every `/lfg` and `/slfg` session, so the design is deliberately lightweight: a tiny Node CLI + gitignored JSON sentinels, zero new dependencies.

Plan of record: `docs/plans/2026-06-01-001-feat-lfg-slfg-resumability-plan.md`.

## Skill register — what each skill now does

Every skill is edited in **8 synced copies**: the dogfood copy (`.github/skills/`), the shipped template (`pkg/scaffold/templates/skills/`), and 6 plugin bundles (`atv-everything`, `atv-pack-planning`, `atv-pack-review`, `atv-pack-shipping`, and the per-skill `atv-skill-*` packs). `plugins/` is regenerated from templates by `plugingen`, so dogfood ↔ template ↔ plugin cannot drift (enforced by contract tests).

| Skill | Role | Change |
|-------|------|--------|
| **`/lfg`** | Orchestrator | New **Run State** section. On start: derive `RUN_ID` from an existing plan (`run-id-from-plan`) or `init` a provisional id; run `status` and **skip every phase already `done`**, resuming at the first unfinished one. After each phase gate passes, records `done <phase> --run-id <id> [--artifact <path>]`. Threads `run:<RUN_ID>` into every sub-skill. Calls `ce-work` with `mode:orchestrated` on re-entry. |
| **`/slfg`** | Parallel orchestrator | Same Run State section, plus **parent-only writes**: during the parallel swarm phase, subagents return artifact paths only and never touch state; the parent records `done` after agents join. Avoids races on the state dir. |
| **`/ce-plan`** | Sub-skill | Recognizes and strips a `run:<run-id>` token before reading the remainder as the feature description. Associates the plan with the shared run; no other behavior change. |
| **`/ce-work`** | Sub-skill | Strips `run:<run-id>`, and adds **`mode:orchestrated`**: resume-safe execution — does NOT create a PR or run shipping/finalize (the parent owns those), and on entry reconciles existing `git diff` / plan checkboxes / open todos, continuing incomplete units instead of restarting. Makes re-entry idempotent (no duplicate commits/branches). |
| **`/ce-review`** | Sub-skill | Recognizes and strips `run:<run-id>` so review artifacts co-locate under the shared run id. No change to review behavior. |

**Token convention:** sub-skills recognize-and-strip `run:<run-id>` (and `mode:orchestrated` for `ce-work`) so an unknown token is never mis-read as a PR/branch arg.

## Helper CLI — `.github/hooks/scripts/lfg-state.js`

Mirrors the existing `observe.js` convention. Node is already a baseline hook dependency, so no new deps.

| Command | Purpose |
|---------|---------|
| `init --skill <s> --feature <f> --repo <r> --branch <b>` | Create a run; returns provisional `run_id` = `slug(feature)+hash(repo\|branch\|feature)`. Idempotent (resume-safe). |
| `bind-plan --run-id <id> --plan <path>` | Bind `plan_path` after `ce-plan` succeeds (two-stage identity resolves the planning chicken-and-egg). |
| `done <phase> --run-id <id> [--artifact <path>]` | Write an atomic per-phase sentinel; `--artifact` is the by-reference pointer. |
| `is-done <phase> --run-id <id>` | JSON `{done: bool}` (exit 0 always; read the field). |
| `status --run-id <id>` | Compact run state — meta + all done phases with artifacts. |
| `run-id-from-plan --plan <path>` | Deterministic run id from a plan filename (for resume). |

**State layout** (`.atv/runs/<run-id>/`, gitignored via new `.gitignore` entry, local-only):
- `meta.json` — written once at init; only the parent binds `plan_path` (single writer).
- `phases/<phase>.done.json` — one atomic sentinel per completed phase (temp-write + rename).

Per-phase sentinels eliminate read-modify-write races (critical for SLFG's parallel phase): "is this phase done?" == "does the sentinel exist?". Each sentinel's `artifact` field is the by-reference pointer — one structure solves both resumability and artifact passing. Phase names are sanitized (path-traversal rejected).

## Test plan

Verified locally on Node v24 / Go 1.26:

- [x] `node --test .github/hooks/scripts/tests/lfg-state.test.js .github/hooks/scripts/tests/skill-contract.test.js` → **40/40 pass** (18 helper unit + 22 skill-contract)
- [x] `go test -count=1 ./pkg/scaffold/... ./pkg/plugingen/...` → **ok**
- [x] `go run ./cmd/plugingen -check` → **plugin tree in sync (kit 2.6.3)**
- [x] Live CLI resume simulation: init → bind-plan → mark `ce-plan`+`ce-work` done with artifacts → interrupt → `status` correctly resumes at `ce-review`; `is-done` JSON contract correct; `parseRunToken` extracts id + preserves rest; path-traversal phase name rejected (exit 1)

**Test files (both committed & tracked):**
- `.github/hooks/scripts/tests/lfg-state.test.js` — 18 cases (real temp-dir fs, no mocks): slugify bounds, deterministic provisional id, plan→run-id derivation, idempotent `init`, `bindPlan`, atomic `markDone`/`isDone`, artifact-by-reference, path-traversal rejection, compact `status`, missing-run returns empty, `parseRunToken` extraction + passthrough.
- `.github/hooks/scripts/tests/skill-contract.test.js` — 22 cases: helper API present in both copies; LFG references helper / documents resume / threads `run:<...>` / marks done with `--artifact`; SLFG documents parent-only writes; every sub-skill recognizes `run:<run-id>`; `ce-work` exposes `mode:orchestrated`. Asserts dogfood/template copies cannot drift.

The **contract tests are the register enforcement** — they fail if any skill copy drops the protocol or drifts from its siblings.

No browser surface exists for this feature (Node CLI + markdown-skill wiring), so verification is via the test suites and live CLI resume run — the path the plan defines.

## Docs note

This change intentionally touches **no README/DOCS/CHANGELOG** — the resume protocol is documented inline in each skill's own SKILL.md (the Run State section and orchestration-argument tables above), which is where a user or agent reading the skill will find it. The plan file is the durable design record. If you'd prefer a top-level CHANGELOG entry or a mention in DOCS.md, say so and I'll add it.

## Scope boundaries

- No new runtime, daemon, or DB engine; no new dependencies.
- Cross-machine / fresh-checkout resume is intentionally out of scope — state is local-only; recovery there falls back to durable signals (plan checkboxes, branch, open PR), as the skills now state.