### PR TITLE
fix: pin prompt-shim files to LF so parity test passes on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 README.md whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
+
+# Dogfood prompt shims are compared byte-for-byte against BuildPromptShim
+# output (LF) by TestDogfoodPromptParity. Pin them to LF so Windows checkouts
+# with core.autocrlf=true don't rewrite them to CRLF and fail the parity test.
+*.prompt.md text eol=lf


### PR DESCRIPTION
## Problem

`TestDogfoodPromptParity` (`pkg/scaffold`) fails for Windows contributors even on a clean checkout of `main`:

```
--- FAIL: TestDogfoodPromptParity
    parity_test.go:366: dogfood prompt shim .github\prompts\lfg.prompt.md drifted from BuildPromptShim output.
    ... (one line per shim)
```

## Root cause

The test compares every `.github/prompts/*.prompt.md` **byte-for-byte** against `BuildPromptShim(name)`, which emits **LF** line endings. On Windows, git's default `core.autocrlf=true` rewrites the checked-out shims to **CRLF**, so the on-disk bytes no longer match the LF output:

```
$ git ls-files --eol .github/prompts/lfg.prompt.md
i/lf    w/crlf  attr/    .github/prompts/lfg.prompt.md
```

The files are correct in the index (`i/lf`); only the working-tree checkout drifts. This is why the test reads green on Linux/mac (LF) but red on Windows — and why it's shown up as a recurring "flaky parity" failure.

## Fix

Add one rule to `.gitattributes`:

```
*.prompt.md text eol=lf
```

Git now always checks the shims out as LF regardless of `core.autocrlf`, keeping the parity check green cross-platform. No code or shim content changes.

## Verification (Windows/amd64, Go 1.26.5, default `core.autocrlf=true`)

Fresh clone of this branch:

```
$ git config --get core.autocrlf
true
$ git ls-files --eol .github/prompts/lfg.prompt.md
i/lf    w/lf    attr/text eol=lf    .github/prompts/lfg.prompt.md
$ go test ./pkg/scaffold/... -run TestDogfoodPromptParity
--- PASS: TestDogfoodPromptParity (0.10s)
ok   github.com/All-The-Vibes/ATV-StarterKit/pkg/scaffold
```

## Context

Split out from the review of #58 (Windows UAC binary rename), where this Windows-only parity failure was diagnosed. Kept as its own focused PR since it's independent of that change.
